### PR TITLE
Stop using built-in plugins for reflection generation

### DIFF
--- a/generate_reflection/src/run_in_roblox.rs
+++ b/generate_reflection/src/run_in_roblox.rs
@@ -121,9 +121,7 @@ pub fn run_in_roblox(plugin: &RbxTree) -> Vec<Vec<u8>> {
     let work_dir = tempdir().expect("Could not create temporary directory");
 
     let place_file_path = work_dir.path().join("place.rbxlx");
-    let plugin_file_path = studio_install
-        .built_in_plugins_path()
-        .join("run_in_roblox.rbxmx");
+    let plugin_file_path = studio_install.plugins_path().join("run_in_roblox.rbxmx");
 
     {
         let place = create_place();

--- a/rbx_dom_lua/src/ReflectionDatabase/classes.lua
+++ b/rbx_dom_lua/src/ReflectionDatabase/classes.lua
@@ -6,7 +6,6 @@ return {
 		properties = {
 		},
 		defaults = {
-			Name = "ABTestService",
 		},
 	},
 	Accessory = {
@@ -3004,7 +3003,6 @@ return {
 		},
 		defaults = {
 			Name = "CoreGui",
-			SelectionImageObject = nil,
 		},
 	},
 	CorePackages = {
@@ -3013,7 +3011,6 @@ return {
 		properties = {
 		},
 		defaults = {
-			Name = "CorePackages",
 		},
 	},
 	CoreScript = {
@@ -5333,7 +5330,6 @@ return {
 			IgnoreGuiInset = false,
 			Localize = true,
 			Name = "GuiMain",
-			OnTopOfCoreBlur = false,
 			ResetOnSpawn = true,
 			RootLocalizationTable = nil,
 			ZIndexBehavior = 0,
@@ -5669,12 +5665,9 @@ return {
 		},
 		defaults = {
 			AutoSelectGuiEnabled = true,
-			CoreEffectFolder = nil,
-			CoreGuiFolder = nil,
 			CoreGuiNavigationEnabled = true,
 			GuiNavigationEnabled = true,
 			Name = "GuiService",
-			SelectedCoreObject = nil,
 			SelectedObject = nil,
 		},
 	},
@@ -6758,7 +6751,6 @@ return {
 			LeftLegColor = Color3.new(0, 0, 0),
 			Name = "HumanoidDescription",
 			NeckAccessory = "",
-			NumberEmotesLoaded = -1,
 			Pants = 0,
 			ProportionScale = 1,
 			RightArm = 0,
@@ -8008,10 +8000,7 @@ return {
 			},
 		},
 		defaults = {
-			IsTextScraperRunning = false,
 			Name = "LocalizationService",
-			RobloxForcePlayModeGameLocaleId = "",
-			RobloxForcePlayModeRobloxLocaleId = "en-us",
 		},
 	},
 	LocalizationTable = {
@@ -9173,7 +9162,6 @@ return {
 		},
 		defaults = {
 			Name = "NotificationService",
-			SelectedTheme = "",
 		},
 	},
 	NumberValue = {
@@ -9388,17 +9376,6 @@ return {
 			},
 		},
 		defaults = {
-			A = 1,
-			Adornee = nil,
-			B = 0,
-			C = 0,
-			Color = BrickColor.new(1),
-			Color3 = Color3.new(0.9490197, 0.95294124, 0.95294124),
-			Name = "ParabolaAdornment",
-			Range = 1,
-			Thickness = 1,
-			Transparency = 0,
-			Visible = true,
 		},
 	},
 	Part = {
@@ -10762,9 +10739,6 @@ return {
 			},
 		},
 		defaults = {
-			Checked = true,
-			DefaultShortcut = "",
-			Enabled = true,
 			Name = "Instance",
 		},
 	},
@@ -11098,7 +11072,6 @@ return {
 		properties = {
 		},
 		defaults = {
-			Name = "RbxAnalyticsService",
 		},
 	},
 	ReflectionMetadata = {
@@ -11764,7 +11737,6 @@ return {
 		properties = {
 		},
 		defaults = {
-			Name = "RobloxPluginGuiService",
 		},
 	},
 	RobloxReplicatedStorage = {
@@ -11773,7 +11745,6 @@ return {
 		properties = {
 		},
 		defaults = {
-			Name = "RobloxReplicatedStorage",
 		},
 	},
 	RocketPropulsion = {
@@ -12116,7 +12087,6 @@ return {
 			IgnoreGuiInset = false,
 			Localize = true,
 			Name = "ScreenGui",
-			OnTopOfCoreBlur = false,
 			ResetOnSpawn = true,
 			RootLocalizationTable = nil,
 			ZIndexBehavior = 0,
@@ -14043,7 +14013,7 @@ return {
 				isCanonical = true,
 				canonicalName = nil,
 				serializedName = nil,
-				scriptability = "ReadWrite",
+				scriptability = "Read",
 				serializes = true,
 			},
 			AutoJumpEnabled = {
@@ -14388,23 +14358,6 @@ return {
 			DevTouchCameraMovementMode = 0,
 			DevTouchMovementMode = 0,
 			EnableMouseLockOption = true,
-			GameSettingsAssetIDFace = 0,
-			GameSettingsAssetIDHead = 0,
-			GameSettingsAssetIDLeftArm = 0,
-			GameSettingsAssetIDLeftLeg = 0,
-			GameSettingsAssetIDPants = 0,
-			GameSettingsAssetIDRightArm = 0,
-			GameSettingsAssetIDRightLeg = 0,
-			GameSettingsAssetIDShirt = 0,
-			GameSettingsAssetIDTeeShirt = 0,
-			GameSettingsAssetIDTorso = 0,
-			GameSettingsAvatar = 1,
-			GameSettingsR15Collision = 0,
-			GameSettingsScaleRangeBodyType = NumberRange.new(0, 1),
-			GameSettingsScaleRangeHead = NumberRange.new(0.95, 1),
-			GameSettingsScaleRangeHeight = NumberRange.new(0.9, 1.05),
-			GameSettingsScaleRangeProportion = NumberRange.new(0, 1),
-			GameSettingsScaleRangeWidth = NumberRange.new(0.7, 1),
 			HealthDisplayDistance = 100,
 			LoadCharacterAppearance = true,
 			Name = "StarterPlayer",
@@ -15669,24 +15622,20 @@ return {
 			ClipsDescendants = false,
 			CursorPosition = 1,
 			Draggable = false,
-			EnableRealtimeFilteringHints = false,
 			Font = 0,
 			FontSize = 0,
 			LayoutOrder = 0,
 			LineHeight = 1,
 			Localize = true,
-			ManualFocusRelease = false,
 			MultiLine = false,
 			Name = "TextBox",
 			NextSelectionDown = nil,
 			NextSelectionLeft = nil,
 			NextSelectionRight = nil,
 			NextSelectionUp = nil,
-			OverlayNativeInput = false,
 			PlaceholderColor3 = Color3.new(0.7, 0.7, 0.7),
 			PlaceholderText = "",
 			Position = UDim2.new(0, 0, 0, 0),
-			ReturnKeyType = 0,
 			RootLocalizationTable = nil,
 			Rotation = 0,
 			Selectable = true,
@@ -15699,7 +15648,6 @@ return {
 			TextColor = BrickColor.new(26),
 			TextColor3 = Color3.new(0.10588236, 0.16470589, 0.20784315),
 			TextEditable = true,
-			TextInputType = 0,
 			TextScaled = false,
 			TextSize = 8,
 			TextStrokeColor3 = Color3.new(0, 0, 0),
@@ -17932,14 +17880,11 @@ return {
 			},
 		},
 		defaults = {
-			GazeSelectionEnabled = true,
-			LegacyInputEventsEnabled = true,
 			ModalEnabled = false,
 			MouseBehavior = 0,
 			MouseDeltaSensitivity = 1,
 			MouseIconEnabled = true,
 			Name = "Instance",
-			OverrideMouseIconBehavior = 0,
 		},
 	},
 	UserSettings = {
@@ -18412,7 +18357,6 @@ return {
 			},
 		},
 		defaults = {
-			AdditionalLuaState = "",
 			Name = "VirtualInputManager",
 		},
 	},

--- a/rbx_reflection/src/reflection_database/classes.rs
+++ b/rbx_reflection/src/reflection_database/classes.rs
@@ -14,16 +14,7 @@ fn generate_ab_test_service() -> RbxClassDescriptor {
             | RbxInstanceTags::NOT_REPLICATED
             | RbxInstanceTags::SERVICE,
         properties: HashMap::new(),
-        default_properties: {
-            let mut map = HashMap::with_capacity(1);
-            map.insert(
-                Cow::Borrowed("Name"),
-                RbxValue::String {
-                    value: String::from("ABTestService"),
-                },
-            );
-            map
-        },
+        default_properties: HashMap::new(),
     };
 }
 fn generate_accessory() -> RbxClassDescriptor {
@@ -5215,16 +5206,12 @@ fn generate_core_gui() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(2);
+            let mut map = HashMap::with_capacity(1);
             map.insert(
                 Cow::Borrowed("Name"),
                 RbxValue::String {
                     value: String::from("CoreGui"),
                 },
-            );
-            map.insert(
-                Cow::Borrowed("SelectionImageObject"),
-                RbxValue::Ref { value: None },
             );
             map
         },
@@ -5238,16 +5225,7 @@ fn generate_core_packages() -> RbxClassDescriptor {
             | RbxInstanceTags::NOT_REPLICATED
             | RbxInstanceTags::SERVICE,
         properties: HashMap::new(),
-        default_properties: {
-            let mut map = HashMap::with_capacity(1);
-            map.insert(
-                Cow::Borrowed("Name"),
-                RbxValue::String {
-                    value: String::from("CorePackages"),
-                },
-            );
-            map
-        },
+        default_properties: HashMap::new(),
     };
 }
 fn generate_core_script() -> RbxClassDescriptor {
@@ -9350,7 +9328,7 @@ fn generate_gui_main() -> RbxClassDescriptor {
         tags: RbxInstanceTags::DEPRECATED,
         properties: HashMap::new(),
         default_properties: {
-            let mut map = HashMap::with_capacity(10);
+            let mut map = HashMap::with_capacity(9);
             map.insert(
                 Cow::Borrowed("AutoLocalize"),
                 RbxValue::Bool { value: true },
@@ -9367,10 +9345,6 @@ fn generate_gui_main() -> RbxClassDescriptor {
                 RbxValue::String {
                     value: String::from("GuiMain"),
                 },
-            );
-            map.insert(
-                Cow::Borrowed("OnTopOfCoreBlur"),
-                RbxValue::Bool { value: false },
             );
             map.insert(
                 Cow::Borrowed("ResetOnSpawn"),
@@ -9872,18 +9846,10 @@ fn generate_gui_service() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(8);
+            let mut map = HashMap::with_capacity(5);
             map.insert(
                 Cow::Borrowed("AutoSelectGuiEnabled"),
                 RbxValue::Bool { value: true },
-            );
-            map.insert(
-                Cow::Borrowed("CoreEffectFolder"),
-                RbxValue::Ref { value: None },
-            );
-            map.insert(
-                Cow::Borrowed("CoreGuiFolder"),
-                RbxValue::Ref { value: None },
             );
             map.insert(
                 Cow::Borrowed("CoreGuiNavigationEnabled"),
@@ -9898,10 +9864,6 @@ fn generate_gui_service() -> RbxClassDescriptor {
                 RbxValue::String {
                     value: String::from("GuiService"),
                 },
-            );
-            map.insert(
-                Cow::Borrowed("SelectedCoreObject"),
-                RbxValue::Ref { value: None },
             );
             map.insert(
                 Cow::Borrowed("SelectedObject"),
@@ -11633,7 +11595,7 @@ fn generate_humanoid_description() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(39);
+            let mut map = HashMap::with_capacity(38);
             map.insert(
                 Cow::Borrowed("BackAccessory"),
                 RbxValue::String {
@@ -11718,10 +11680,6 @@ fn generate_humanoid_description() -> RbxClassDescriptor {
                 RbxValue::String {
                     value: String::from(""),
                 },
-            );
-            map.insert(
-                Cow::Borrowed("NumberEmotesLoaded"),
-                RbxValue::Int32 { value: -1 },
             );
             map.insert(Cow::Borrowed("Pants"), RbxValue::Int32 { value: 0 });
             map.insert(
@@ -14004,27 +13962,11 @@ fn generate_localization_service() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(4);
-            map.insert(
-                Cow::Borrowed("IsTextScraperRunning"),
-                RbxValue::Bool { value: false },
-            );
+            let mut map = HashMap::with_capacity(1);
             map.insert(
                 Cow::Borrowed("Name"),
                 RbxValue::String {
                     value: String::from("LocalizationService"),
-                },
-            );
-            map.insert(
-                Cow::Borrowed("RobloxForcePlayModeGameLocaleId"),
-                RbxValue::String {
-                    value: String::from(""),
-                },
-            );
-            map.insert(
-                Cow::Borrowed("RobloxForcePlayModeRobloxLocaleId"),
-                RbxValue::String {
-                    value: String::from("en-us"),
                 },
             );
             map
@@ -16095,17 +16037,11 @@ fn generate_notification_service() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(2);
+            let mut map = HashMap::with_capacity(1);
             map.insert(
                 Cow::Borrowed("Name"),
                 RbxValue::String {
                     value: String::from("NotificationService"),
-                },
-            );
-            map.insert(
-                Cow::Borrowed("SelectedTheme"),
-                RbxValue::String {
-                    value: String::from(""),
                 },
             );
             map
@@ -16454,39 +16390,7 @@ fn generate_parabola_adornment() -> RbxClassDescriptor {
             );
             map
         },
-        default_properties: {
-            let mut map = HashMap::with_capacity(11);
-            map.insert(Cow::Borrowed("A"), RbxValue::Float32 { value: 1.0 });
-            map.insert(Cow::Borrowed("Adornee"), RbxValue::Ref { value: None });
-            map.insert(Cow::Borrowed("B"), RbxValue::Float32 { value: 0.0 });
-            map.insert(Cow::Borrowed("C"), RbxValue::Float32 { value: 0.0 });
-            map.insert(
-                Cow::Borrowed("Color"),
-                RbxValue::BrickColor {
-                    value: BrickColor::from_number(1).unwrap(),
-                },
-            );
-            map.insert(
-                Cow::Borrowed("Color3"),
-                RbxValue::Color3 {
-                    value: [0.9490197, 0.95294124, 0.95294124],
-                },
-            );
-            map.insert(
-                Cow::Borrowed("Name"),
-                RbxValue::String {
-                    value: String::from("ParabolaAdornment"),
-                },
-            );
-            map.insert(Cow::Borrowed("Range"), RbxValue::Float32 { value: 1.0 });
-            map.insert(Cow::Borrowed("Thickness"), RbxValue::Float32 { value: 1.0 });
-            map.insert(
-                Cow::Borrowed("Transparency"),
-                RbxValue::Float32 { value: 0.0 },
-            );
-            map.insert(Cow::Borrowed("Visible"), RbxValue::Bool { value: true });
-            map
-        },
+        default_properties: HashMap::new(),
     };
 }
 fn generate_part() -> RbxClassDescriptor {
@@ -18816,15 +18720,7 @@ fn generate_plugin_action() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(4);
-            map.insert(Cow::Borrowed("Checked"), RbxValue::Bool { value: true });
-            map.insert(
-                Cow::Borrowed("DefaultShortcut"),
-                RbxValue::String {
-                    value: String::from(""),
-                },
-            );
-            map.insert(Cow::Borrowed("Enabled"), RbxValue::Bool { value: true });
+            let mut map = HashMap::with_capacity(1);
             map.insert(
                 Cow::Borrowed("Name"),
                 RbxValue::String {
@@ -19391,16 +19287,7 @@ fn generate_rbx_analytics_service() -> RbxClassDescriptor {
         superclass: Some(Cow::Borrowed("Instance")),
         tags: RbxInstanceTags::NOT_CREATABLE | RbxInstanceTags::SERVICE,
         properties: HashMap::new(),
-        default_properties: {
-            let mut map = HashMap::with_capacity(1);
-            map.insert(
-                Cow::Borrowed("Name"),
-                RbxValue::String {
-                    value: String::from("RbxAnalyticsService"),
-                },
-            );
-            map
-        },
+        default_properties: HashMap::new(),
     };
 }
 fn generate_reflection_metadata() -> RbxClassDescriptor {
@@ -20583,16 +20470,7 @@ fn generate_roblox_plugin_gui_service() -> RbxClassDescriptor {
             | RbxInstanceTags::NOT_REPLICATED
             | RbxInstanceTags::SERVICE,
         properties: HashMap::new(),
-        default_properties: {
-            let mut map = HashMap::with_capacity(1);
-            map.insert(
-                Cow::Borrowed("Name"),
-                RbxValue::String {
-                    value: String::from("RobloxPluginGuiService"),
-                },
-            );
-            map
-        },
+        default_properties: HashMap::new(),
     };
 }
 fn generate_roblox_replicated_storage() -> RbxClassDescriptor {
@@ -20603,16 +20481,7 @@ fn generate_roblox_replicated_storage() -> RbxClassDescriptor {
             | RbxInstanceTags::NOT_CREATABLE
             | RbxInstanceTags::SERVICE,
         properties: HashMap::new(),
-        default_properties: {
-            let mut map = HashMap::with_capacity(1);
-            map.insert(
-                Cow::Borrowed("Name"),
-                RbxValue::String {
-                    value: String::from("RobloxReplicatedStorage"),
-                },
-            );
-            map
-        },
+        default_properties: HashMap::new(),
     };
 }
 fn generate_rocket_propulsion() -> RbxClassDescriptor {
@@ -21187,7 +21056,7 @@ fn generate_screen_gui() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(10);
+            let mut map = HashMap::with_capacity(9);
             map.insert(
                 Cow::Borrowed("AutoLocalize"),
                 RbxValue::Bool { value: true },
@@ -21204,10 +21073,6 @@ fn generate_screen_gui() -> RbxClassDescriptor {
                 RbxValue::String {
                     value: String::from("ScreenGui"),
                 },
-            );
-            map.insert(
-                Cow::Borrowed("OnTopOfCoreBlur"),
-                RbxValue::Bool { value: false },
             );
             map.insert(
                 Cow::Borrowed("ResetOnSpawn"),
@@ -24895,7 +24760,7 @@ fn generate_starter_player() -> RbxClassDescriptor {
                     is_canonical: true,
                     canonical_name: None,
                     serialized_name: None,
-                    scriptability: RbxPropertyScriptability::ReadWrite,
+                    scriptability: RbxPropertyScriptability::Read,
                     serializes: true,
                 },
             );
@@ -25380,7 +25245,7 @@ fn generate_starter_player() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(38);
+            let mut map = HashMap::with_capacity(21);
             map.insert(
                 Cow::Borrowed("AllowCustomAnimations"),
                 RbxValue::Bool { value: true },
@@ -25441,74 +25306,6 @@ fn generate_starter_player() -> RbxClassDescriptor {
             map.insert(
                 Cow::Borrowed("EnableMouseLockOption"),
                 RbxValue::Bool { value: true },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDFace"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDHead"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDLeftArm"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDLeftLeg"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDPants"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDRightArm"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDRightLeg"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDShirt"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDTeeShirt"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAssetIDTorso"),
-                RbxValue::Int32 { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsAvatar"),
-                RbxValue::Enum { value: 1 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsR15Collision"),
-                RbxValue::Enum { value: 0 },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsScaleRangeBodyType"),
-                RbxValue::NumberRange { value: (0.0, 1.0) },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsScaleRangeHead"),
-                RbxValue::NumberRange { value: (0.95, 1.0) },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsScaleRangeHeight"),
-                RbxValue::NumberRange { value: (0.9, 1.05) },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsScaleRangeProportion"),
-                RbxValue::NumberRange { value: (0.0, 1.0) },
-            );
-            map.insert(
-                Cow::Borrowed("GameSettingsScaleRangeWidth"),
-                RbxValue::NumberRange { value: (0.7, 1.0) },
             );
             map.insert(
                 Cow::Borrowed("HealthDisplayDistance"),
@@ -28301,7 +28098,7 @@ fn generate_text_box() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(58);
+            let mut map = HashMap::with_capacity(53);
             map.insert(Cow::Borrowed("Active"), RbxValue::Bool { value: true });
             map.insert(
                 Cow::Borrowed("AnchorPoint"),
@@ -28357,10 +28154,6 @@ fn generate_text_box() -> RbxClassDescriptor {
                 RbxValue::Int32 { value: 1 },
             );
             map.insert(Cow::Borrowed("Draggable"), RbxValue::Bool { value: false });
-            map.insert(
-                Cow::Borrowed("EnableRealtimeFilteringHints"),
-                RbxValue::Bool { value: false },
-            );
             map.insert(Cow::Borrowed("Font"), RbxValue::Enum { value: 0 });
             map.insert(Cow::Borrowed("FontSize"), RbxValue::Enum { value: 0 });
             map.insert(Cow::Borrowed("LayoutOrder"), RbxValue::Int32 { value: 0 });
@@ -28369,10 +28162,6 @@ fn generate_text_box() -> RbxClassDescriptor {
                 RbxValue::Float32 { value: 1.0 },
             );
             map.insert(Cow::Borrowed("Localize"), RbxValue::Bool { value: true });
-            map.insert(
-                Cow::Borrowed("ManualFocusRelease"),
-                RbxValue::Bool { value: false },
-            );
             map.insert(Cow::Borrowed("MultiLine"), RbxValue::Bool { value: false });
             map.insert(
                 Cow::Borrowed("Name"),
@@ -28397,10 +28186,6 @@ fn generate_text_box() -> RbxClassDescriptor {
                 RbxValue::Ref { value: None },
             );
             map.insert(
-                Cow::Borrowed("OverlayNativeInput"),
-                RbxValue::Bool { value: false },
-            );
-            map.insert(
                 Cow::Borrowed("PlaceholderColor3"),
                 RbxValue::Color3 {
                     value: [0.7, 0.7, 0.7],
@@ -28418,7 +28203,6 @@ fn generate_text_box() -> RbxClassDescriptor {
                     value: (0.0, 0, 0.0, 0),
                 },
             );
-            map.insert(Cow::Borrowed("ReturnKeyType"), RbxValue::Enum { value: 0 });
             map.insert(
                 Cow::Borrowed("RootLocalizationTable"),
                 RbxValue::Ref { value: None },
@@ -28466,7 +28250,6 @@ fn generate_text_box() -> RbxClassDescriptor {
                 Cow::Borrowed("TextEditable"),
                 RbxValue::Bool { value: true },
             );
-            map.insert(Cow::Borrowed("TextInputType"), RbxValue::Enum { value: 0 });
             map.insert(Cow::Borrowed("TextScaled"), RbxValue::Bool { value: false });
             map.insert(Cow::Borrowed("TextSize"), RbxValue::Float32 { value: 8.0 });
             map.insert(
@@ -32450,15 +32233,7 @@ fn generate_user_input_service() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(8);
-            map.insert(
-                Cow::Borrowed("GazeSelectionEnabled"),
-                RbxValue::Bool { value: true },
-            );
-            map.insert(
-                Cow::Borrowed("LegacyInputEventsEnabled"),
-                RbxValue::Bool { value: true },
-            );
+            let mut map = HashMap::with_capacity(5);
             map.insert(
                 Cow::Borrowed("ModalEnabled"),
                 RbxValue::Bool { value: false },
@@ -32477,10 +32252,6 @@ fn generate_user_input_service() -> RbxClassDescriptor {
                 RbxValue::String {
                     value: String::from("Instance"),
                 },
-            );
-            map.insert(
-                Cow::Borrowed("OverrideMouseIconBehavior"),
-                RbxValue::Enum { value: 0 },
             );
             map
         },
@@ -33415,13 +33186,7 @@ fn generate_virtual_input_manager() -> RbxClassDescriptor {
             map
         },
         default_properties: {
-            let mut map = HashMap::with_capacity(2);
-            map.insert(
-                Cow::Borrowed("AdditionalLuaState"),
-                RbxValue::String {
-                    value: String::from(""),
-                },
-            );
+            let mut map = HashMap::with_capacity(1);
             map.insert(
                 Cow::Borrowed("Name"),
                 RbxValue::String {


### PR DESCRIPTION
Closes #68.

Roblox recently started requiring that all built-in plugins have a signature associated with them that's verified by Studio.

This project doesn't have access to any signing tools to bypass that verification, so I'm downgrading the required permissions.

This has two effects:
1. Bad: the reflection database contains less information, since there is some serializable information that isn't available at core script security. `ParabolaAdornment` is probably a bad example since it's only meant for core scripts, but is something we lose information about with this change.
2. Good: the reflection database contains more accurate information for most consumers. Plugins like Rojo will no longer know about plugins that they couldn't read or write anyways.