### PR TITLE
Add EncodeOutput type to rbx_xml

### DIFF
--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -140,7 +140,7 @@ use crate::{deserializer::decode_internal, serializer::encode_internal};
 pub use crate::{
     deserializer::{DecodeOptions, DecodePropertyBehavior},
     error::{DecodeError, EncodeError},
-    serializer::{EncodeOptions, EncodePropertyBehavior},
+    serializer::{EncodeOptions, EncodeOutput, EncodePropertyBehavior},
 };
 
 /// Decodes an XML-format model or place from something that implements the
@@ -173,7 +173,7 @@ pub fn to_writer<W: Write>(
     tree: &RbxTree,
     ids: &[RbxId],
     options: EncodeOptions,
-) -> Result<(), EncodeError> {
+) -> Result<EncodeOutput, EncodeError> {
     encode_internal(writer, tree, ids, options)
 }
 
@@ -184,6 +184,6 @@ pub fn to_writer_default<W: Write>(
     writer: W,
     tree: &RbxTree,
     ids: &[RbxId],
-) -> Result<(), EncodeError> {
+) -> Result<EncodeOutput, EncodeError> {
     encode_internal(writer, tree, ids, EncodeOptions::default())
 }


### PR DESCRIPTION
Experimental PR that introduces a new type, `EncodeOutput`, and changes the public rbx_xml serialization functions to return it.

Currently, it contains the referent map that's built up during serialization. This is part of an experiment to implement sourcemaps for Roblox. Rojo will consume the result of this struct and write a JSON file whose keys are referents and whose values are file paths!