### PR TITLE
Fix SharedString buffers with CRLF failing to decode

### DIFF
--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -387,9 +387,7 @@ fn deserialize_shared_string<R: Read>(
     let md5_hash =
         md5_hash.ok_or_else(|| reader.error(DecodeErrorKind::MissingAttribute("md5")))?;
 
-    let encoded_buffer = reader.read_characters()?.replace("\n", "");
-
-    let buffer = base64::decode(&encoded_buffer).map_err(|e| reader.error(e))?;
+    let buffer = reader.read_base64_characters()?;
 
     let value = SharedString::new(buffer);
 

--- a/rbx_xml/src/deserializer_core.rs
+++ b/rbx_xml/src/deserializer_core.rs
@@ -221,6 +221,21 @@ impl<R: Read> XmlEventReader<R> {
         Ok(buffer)
     }
 
+    /// Reads characters from the head of the deserializer and attempts to parse
+    /// them as base64 and turn them into a buffer of bytes.
+    ///
+    /// In Roblox XML model files, binary data is base64 encoded and
+    /// line-wrapped, meaning we have to be careful to ignore whitespace.
+    pub fn read_base64_characters(&mut self) -> Result<Vec<u8>, NewDecodeError> {
+        let contents: String = self
+            .read_characters()?
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        base64::decode(&contents).map_err(|e| self.error(e))
+    }
+
     /// Reads a tag completely and returns its text content. This is intended
     /// for parsing simple tags where we don't care about the attributes or
     /// children, only the text value, for Vector3s and such, which are encoded

--- a/rbx_xml/src/types/binary_string.rs
+++ b/rbx_xml/src/types/binary_string.rs
@@ -29,13 +29,9 @@ impl XmlType<[u8]> for BinaryStringType {
     }
 
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<RbxValue, DecodeError> {
-        let contents = reader.read_tag_contents(Self::XML_TAG_NAME)?;
-
-        // Roblox wraps base64 BinaryString data at the 72 byte mark. The base64
-        // crate doesn't accept whitespace.
-        let contents: String = contents.chars().filter(|c| !c.is_whitespace()).collect();
-
-        let value = base64::decode(&contents).map_err(|e| reader.error(e))?;
+        reader.expect_start_with_name(Self::XML_TAG_NAME)?;
+        let value = reader.read_base64_characters()?;
+        reader.expect_end_with_name(Self::XML_TAG_NAME)?;
 
         Ok(RbxValue::BinaryString { value })
     }


### PR DESCRIPTION
Some XML model files from Roblox Studio have CRLF line endings. We fixed
handling these in BinaryString values, but didn't port the fix to work
with SharedString.

This change pulls that logic out into a new method and uses it for both
BinaryString and SharedString values.