### PR TITLE
Introduce legacy-compat feature for rbx_types

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased Changes
 * `Ref` can now represent null explicitly via `Ref::none` and `Ref::is_none`.
 * Added `Region3` and `Region3int16` to `Variant` and `VariantType`.
+* Added `legacy-compat` feature to enable conversions with rbx_dom_weak 1.x.
 
 ## 0.1.0 (2020-02-05)
 * Initial release of types crate, should have rough feature parity with rbx_dom_weak.

--- a/rbx_types/Cargo.toml
+++ b/rbx_types/Cargo.toml
@@ -17,6 +17,7 @@ bitflags = "1.2.1"
 lazy_static = "1.4.0"
 rand = "0.7.3"
 serde = { version = "1.0.104", features = ["derive"], optional = true }
+rbx_dom_weak = { version = "1.10.1", optional = true }
 
 [dev-dependencies]
 bincode = "1.2.1"
@@ -24,3 +25,7 @@ serde_json = "1.0.45"
 
 [features]
 default = []
+
+# Enables compatibility conversions between this crate and rbx_dom_weak v1
+# types.
+legacy-compat = ["rbx_dom_weak"]

--- a/rbx_types/Cargo.toml
+++ b/rbx_types/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "1.2.1"
 lazy_static = "1.4.0"
 rand = "0.7.3"
 serde = { version = "1.0.104", features = ["derive"], optional = true }
-rbx_dom_weak = { version = "1.10.1", optional = true }
+rbx_dom_weak = { version = "1.10.1", path = "../rbx_dom_weak", optional = true }
 
 [dev-dependencies]
 bincode = "1.2.1"

--- a/rbx_types/src/legacy_compat.rs
+++ b/rbx_types/src/legacy_compat.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use rbx_dom_weak::{BrickColor as LegacyBrickColor, RbxValue, RbxValueType};
 
-use crate::{BrickColor, Variant, VariantType};
+use crate::{BrickColor, CFrame, Color3, Color3uint8, Matrix3, Variant, VariantType, Vector3};
 
 impl TryFrom<RbxValue> for Variant {
     type Error = String;
@@ -23,9 +23,22 @@ impl TryFrom<RbxValue> for Variant {
                 Variant::BrickColor(BrickColor::from_number(value as u16).unwrap())
             }
 
-            // RbxValue::CFrame { value } => Variant::CFrame(value),
-            // RbxValue::Color3 { value } => Variant::Color3(value),
-            // RbxValue::Color3uint8 { value } => Variant::Color3uint8(value),
+            RbxValue::CFrame { value } => Variant::CFrame(CFrame::new(
+                Vector3::new(value[0], value[1], value[2]),
+                Matrix3 {
+                    x: Vector3::new(value[3], value[4], value[5]),
+                    y: Vector3::new(value[6], value[7], value[8]),
+                    z: Vector3::new(value[9], value[10], value[11]),
+                },
+            )),
+
+            RbxValue::Color3 { value } => {
+                Variant::Color3(Color3::new(value[0], value[1], value[2]))
+            }
+            RbxValue::Color3uint8 { value } => {
+                Variant::Color3uint8(Color3uint8::new(value[0], value[1], value[2]))
+            }
+
             // RbxValue::ColorSequence { value } => Variant::ColorSequence(value),
             // RbxValue::Content { value } => Variant::Content(value),
             // RbxValue::Enum { value } => Variant::EnumValue(value),
@@ -67,25 +80,46 @@ impl TryFrom<Variant> for RbxValue {
                 value: LegacyBrickColor::from_number(value as u16).unwrap(),
             },
 
-            // RbxValue::CFrame { value } => Variant::CFrame(value),
-            // RbxValue::Color3 { value } => Variant::Color3(value),
-            // RbxValue::Color3uint8 { value } => Variant::Color3uint8(value),
-            // RbxValue::ColorSequence { value } => Variant::ColorSequence(value),
-            // RbxValue::Content { value } => Variant::Content(value),
-            // RbxValue::Enum { value } => Variant::EnumValue(value),
-            // RbxValue::NumberRange { value } => Variant::NumberRange(value),
-            // RbxValue::NumberSequence { value } => Variant::NumberSequence(value),
-            // RbxValue::PhysicalProperties { value } => Variant::PhysicalProperties(value),
-            // RbxValue::Ray { value } => Variant::Ray(value),
-            // RbxValue::Rect { value } => Variant::Rect(value),
-            // RbxValue::Ref { value } => Variant::Ref(value),
-            // RbxValue::SharedString { value } => Variant::SharedString(value),
-            // RbxValue::UDim { value } => Variant::UDim(value),
-            // RbxValue::UDim2 { value } => Variant::UDim2(value),
-            // RbxValue::Vector2 { value } => Variant::Vector2(value),
-            // RbxValue::Vector2int16 { value } => Variant::Vector2int16(value),
-            // RbxValue::Vector3 { value } => Variant::Vector3(value),
-            // RbxValue::Vector3int16 { value } => Variant::Vector3int16(value),
+            Variant::CFrame(value) => RbxValue::CFrame {
+                value: [
+                    value.position.x,
+                    value.position.y,
+                    value.position.z,
+                    value.orientation.x.x,
+                    value.orientation.x.y,
+                    value.orientation.x.z,
+                    value.orientation.y.x,
+                    value.orientation.y.y,
+                    value.orientation.y.z,
+                    value.orientation.z.x,
+                    value.orientation.z.y,
+                    value.orientation.z.z,
+                ],
+            },
+
+            Variant::Color3(value) => RbxValue::Color3 {
+                value: [value.r, value.g, value.b],
+            },
+            Variant::Color3uint8(value) => RbxValue::Color3uint8 {
+                value: [value.r, value.g, value.b],
+            },
+
+            // Variant::ColorSequence(value) => RbxValue::ColorSequence { value },
+            // Variant::Content(value) => RbxValue::Content { value },
+            // Variant::Enum(value) => RbxValue::EnumValue { value },
+            // Variant::NumberRange(value) => RbxValue::NumberRange { value },
+            // Variant::NumberSequence(value) => RbxValue::NumberSequence { value },
+            // Variant::PhysicalProperties(value) => RbxValue::PhysicalProperties { value },
+            // Variant::Ray(value) => RbxValue::Ray { value },
+            // Variant::Rect(value) => RbxValue::Rect { value },
+            // Variant::Ref(value) => RbxValue::Ref { value },
+            // Variant::SharedString(value) => RbxValue::SharedString { value },
+            // Variant::UDim(value) => RbxValue::UDim { value },
+            // Variant::UDim2(value) => RbxValue::UDim2 { value },
+            // Variant::Vector2(value) => RbxValue::Vector2 { value },
+            // Variant::Vector2int16(value) => RbxValue::Vector2int16 { value },
+            // Variant::Vector3(value) => RbxValue::Vector3 { value },
+            // Variant::Vector3int16(value) => RbxValue::Vector3int16 { value },
             _ => return Err(format!("Cannot convert Variant {:?} to RbxValue", value)),
         })
     }

--- a/rbx_types/src/legacy_compat.rs
+++ b/rbx_types/src/legacy_compat.rs
@@ -6,13 +6,14 @@ use rbx_dom_weak::{
     BrickColor as LegacyBrickColor, ColorSequence as LegacyColorSequence,
     ColorSequenceKeypoint as LegacyColorSequenceKeypoint, NumberSequence as LegacyNumberSequence,
     NumberSequenceKeypoint as LegacyNumberSequenceKeypoint,
-    PhysicalProperties as LegacyPhysicalProperties, RbxValue,
+    PhysicalProperties as LegacyPhysicalProperties, Ray as LegacyRay, RbxValue,
+    SharedString as LegacySharedString,
 };
 
 use crate::{
     BrickColor, CFrame, Color3, Color3uint8, ColorSequence, ColorSequenceKeypoint,
     CustomPhysicalProperties, EnumValue, Matrix3, NumberRange, NumberSequence,
-    NumberSequenceKeypoint, PhysicalProperties, Variant, Vector3,
+    NumberSequenceKeypoint, PhysicalProperties, Ray, SharedString, Variant, Vector3,
 };
 
 impl TryFrom<RbxValue> for Variant {
@@ -101,9 +102,19 @@ impl TryFrom<RbxValue> for Variant {
                 }
             }
 
-            // RbxValue::Ray { value } => Variant::Ray(value),
+            RbxValue::Ray { value } => {
+                let origin = Vector3::new(value.origin[0], value.origin[1], value.origin[2]);
+                let direction =
+                    Vector3::new(value.direction[0], value.direction[1], value.direction[2]);
+
+                Variant::Ray(Ray { origin, direction })
+            }
+
             // RbxValue::Rect { value } => Variant::Rect(value),
-            // RbxValue::SharedString { value } => Variant::SharedString(value),
+            RbxValue::SharedString { value } => {
+                Variant::SharedString(SharedString::new(value.data().to_vec()))
+            }
+
             // RbxValue::UDim { value } => Variant::UDim(value),
             // RbxValue::UDim2 { value } => Variant::UDim2(value),
             // RbxValue::Vector2 { value } => Variant::Vector2(value),
@@ -214,9 +225,18 @@ impl TryFrom<Variant> for RbxValue {
                 RbxValue::PhysicalProperties { value: new_value }
             }
 
-            // Variant::Ray(value) => RbxValue::Ray { value },
+            Variant::Ray(value) => RbxValue::Ray {
+                value: LegacyRay {
+                    origin: [value.origin.x, value.origin.y, value.origin.z],
+                    direction: [value.direction.x, value.direction.y, value.direction.z],
+                },
+            },
+
             // Variant::Rect(value) => RbxValue::Rect { value },
-            // Variant::SharedString(value) => RbxValue::SharedString { value },
+            Variant::SharedString(value) => RbxValue::SharedString {
+                value: LegacySharedString::new(value.data().to_vec()),
+            },
+
             // Variant::UDim(value) => RbxValue::UDim { value },
             // Variant::UDim2(value) => RbxValue::UDim2 { value },
             // Variant::Vector2(value) => RbxValue::Vector2 { value },

--- a/rbx_types/src/legacy_compat.rs
+++ b/rbx_types/src/legacy_compat.rs
@@ -2,9 +2,9 @@
 
 use std::convert::TryFrom;
 
-use rbx_dom_weak::{RbxValue, RbxValueType};
+use rbx_dom_weak::{BrickColor as LegacyBrickColor, RbxValue, RbxValueType};
 
-use crate::{Variant, VariantType};
+use crate::{BrickColor, Variant, VariantType};
 
 impl TryFrom<RbxValue> for Variant {
     type Error = String;
@@ -19,8 +19,10 @@ impl TryFrom<RbxValue> for Variant {
             RbxValue::Float64 { value } => value.into(),
 
             RbxValue::BinaryString { value } => Variant::BinaryString(value.into()),
+            RbxValue::BrickColor { value } => {
+                Variant::BrickColor(BrickColor::from_number(value as u16).unwrap())
+            }
 
-            // RbxValue::BrickColor { value } => Variant::BrickColor(value),
             // RbxValue::CFrame { value } => Variant::CFrame(value),
             // RbxValue::Color3 { value } => Variant::Color3(value),
             // RbxValue::Color3uint8 { value } => Variant::Color3uint8(value),
@@ -57,7 +59,14 @@ impl TryFrom<Variant> for RbxValue {
             Variant::Float32(value) => RbxValue::Float32 { value },
             Variant::Float64(value) => RbxValue::Float64 { value },
 
-            // RbxValue::BrickColor { value } => Variant::BrickColor(value),
+            Variant::BinaryString(value) => RbxValue::BinaryString {
+                value: value.into(),
+            },
+
+            Variant::BrickColor(value) => RbxValue::BrickColor {
+                value: LegacyBrickColor::from_number(value as u16).unwrap(),
+            },
+
             // RbxValue::CFrame { value } => Variant::CFrame(value),
             // RbxValue::Color3 { value } => Variant::Color3(value),
             // RbxValue::Color3uint8 { value } => Variant::Color3uint8(value),

--- a/rbx_types/src/legacy_compat.rs
+++ b/rbx_types/src/legacy_compat.rs
@@ -1,0 +1,83 @@
+//! Compatibility conversions for rbx_dom_weak v1 and this crate.
+
+use std::convert::TryFrom;
+
+use rbx_dom_weak::{RbxValue, RbxValueType};
+
+use crate::{Variant, VariantType};
+
+impl TryFrom<RbxValue> for Variant {
+    type Error = String;
+
+    fn try_from(value: RbxValue) -> Result<Self, Self::Error> {
+        Ok(match value {
+            RbxValue::String { value } => value.into(),
+            RbxValue::Bool { value } => value.into(),
+            RbxValue::Int32 { value } => value.into(),
+            RbxValue::Int64 { value } => value.into(),
+            RbxValue::Float32 { value } => value.into(),
+            RbxValue::Float64 { value } => value.into(),
+
+            RbxValue::BinaryString { value } => Variant::BinaryString(value.into()),
+
+            // RbxValue::BrickColor { value } => Variant::BrickColor(value),
+            // RbxValue::CFrame { value } => Variant::CFrame(value),
+            // RbxValue::Color3 { value } => Variant::Color3(value),
+            // RbxValue::Color3uint8 { value } => Variant::Color3uint8(value),
+            // RbxValue::ColorSequence { value } => Variant::ColorSequence(value),
+            // RbxValue::Content { value } => Variant::Content(value),
+            // RbxValue::Enum { value } => Variant::EnumValue(value),
+            // RbxValue::NumberRange { value } => Variant::NumberRange(value),
+            // RbxValue::NumberSequence { value } => Variant::NumberSequence(value),
+            // RbxValue::PhysicalProperties { value } => Variant::PhysicalProperties(value),
+            // RbxValue::Ray { value } => Variant::Ray(value),
+            // RbxValue::Rect { value } => Variant::Rect(value),
+            // RbxValue::Ref { value } => Variant::Ref(value),
+            // RbxValue::SharedString { value } => Variant::SharedString(value),
+            // RbxValue::UDim { value } => Variant::UDim(value),
+            // RbxValue::UDim2 { value } => Variant::UDim2(value),
+            // RbxValue::Vector2 { value } => Variant::Vector2(value),
+            // RbxValue::Vector2int16 { value } => Variant::Vector2int16(value),
+            // RbxValue::Vector3 { value } => Variant::Vector3(value),
+            // RbxValue::Vector3int16 { value } => Variant::Vector3int16(value),
+            _ => return Err(format!("Cannot convert RbxValue {:?} to Variant", value)),
+        })
+    }
+}
+
+impl TryFrom<Variant> for RbxValue {
+    type Error = String;
+
+    fn try_from(value: Variant) -> Result<Self, Self::Error> {
+        Ok(match value {
+            Variant::String(value) => RbxValue::String { value },
+            Variant::Bool(value) => RbxValue::Bool { value },
+            Variant::Int32(value) => RbxValue::Int32 { value },
+            Variant::Int64(value) => RbxValue::Int64 { value },
+            Variant::Float32(value) => RbxValue::Float32 { value },
+            Variant::Float64(value) => RbxValue::Float64 { value },
+
+            // RbxValue::BrickColor { value } => Variant::BrickColor(value),
+            // RbxValue::CFrame { value } => Variant::CFrame(value),
+            // RbxValue::Color3 { value } => Variant::Color3(value),
+            // RbxValue::Color3uint8 { value } => Variant::Color3uint8(value),
+            // RbxValue::ColorSequence { value } => Variant::ColorSequence(value),
+            // RbxValue::Content { value } => Variant::Content(value),
+            // RbxValue::Enum { value } => Variant::EnumValue(value),
+            // RbxValue::NumberRange { value } => Variant::NumberRange(value),
+            // RbxValue::NumberSequence { value } => Variant::NumberSequence(value),
+            // RbxValue::PhysicalProperties { value } => Variant::PhysicalProperties(value),
+            // RbxValue::Ray { value } => Variant::Ray(value),
+            // RbxValue::Rect { value } => Variant::Rect(value),
+            // RbxValue::Ref { value } => Variant::Ref(value),
+            // RbxValue::SharedString { value } => Variant::SharedString(value),
+            // RbxValue::UDim { value } => Variant::UDim(value),
+            // RbxValue::UDim2 { value } => Variant::UDim2(value),
+            // RbxValue::Vector2 { value } => Variant::Vector2(value),
+            // RbxValue::Vector2int16 { value } => Variant::Vector2int16(value),
+            // RbxValue::Vector3 { value } => Variant::Vector3(value),
+            // RbxValue::Vector3int16 { value } => Variant::Vector3int16(value),
+            _ => return Err(format!("Cannot convert Variant {:?} to RbxValue", value)),
+        })
+    }
+}

--- a/rbx_types/src/lib.rs
+++ b/rbx_types/src/lib.rs
@@ -2,6 +2,9 @@
 #[macro_use]
 mod serde_util;
 
+#[cfg(feature = "legacy-compat")]
+mod legacy_compat;
+
 mod axes;
 mod basic_types;
 mod binary_string;


### PR DESCRIPTION
This will help smooth the transition to rbx_types/rbx_dom_weak 2.0 by implementing optional conversions between `Variant` and `RbxValue`.