### PR TITLE
Remove byte_order as a dependency of rbx_binary

### DIFF
--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 unstable_text_format = ["base64", "serde"]
 
 [dependencies]
-byteorder = "1.2.7"
 log = "0.4.6"
 lz4 = "1.23.1"
 rbx_dom_weak = { path = "../rbx_dom_weak" }

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -158,7 +158,19 @@ pub trait RbxWriteExt: Write {
         Ok(())
     }
 
+    fn write_le_u16(&mut self, value: u16) -> io::Result<()> {
+        self.write_all(&value.to_le_bytes())?;
+
+        Ok(())
+    }
+
     fn write_le_f32(&mut self, value: f32) -> io::Result<()> {
+        self.write_all(&value.to_le_bytes())?;
+
+        Ok(())
+    }
+
+    fn write_le_f64(&mut self, value: f64) -> io::Result<()> {
         self.write_all(&value.to_le_bytes())?;
 
         Ok(())

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -17,11 +17,25 @@ pub trait RbxReadExt: Read {
         Ok(u32::from_le_bytes(buffer))
     }
 
+    fn read_le_u16(&mut self) -> io::Result<u16> {
+        let mut bytes = [0; 2];
+        self.read_exact(&mut bytes)?;
+
+        Ok(u16::from_le_bytes(bytes))
+    }
+
     fn read_le_f32(&mut self) -> io::Result<f32> {
         let mut buffer = [0u8; 4];
         self.read_exact(&mut buffer)?;
 
         Ok(f32::from_le_bytes(buffer))
+    }
+
+    fn read_le_f64(&mut self) -> io::Result<f64> {
+        let mut bytes = [0; 8];
+        self.read_exact(&mut bytes)?;
+
+        Ok(f64::from_le_bytes(bytes))
     }
 
     fn read_u8(&mut self) -> io::Result<u8> {

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -550,11 +550,7 @@ impl<R: Read> BinaryDeserializer<R> {
                 VariantType::Float64 => {
                     for referent in &type_info.referents {
                         let instance = self.instances_by_ref.get_mut(referent).unwrap();
-                        let value = {
-                            let mut bytes = [0; 8];
-                            chunk.read_exact(&mut bytes)?;
-                            f64::from_le_bytes(bytes)
-                        };
+                        let value = chunk.read_le_f64()?;
                         let rbx_value = Variant::Float64(value);
                         instance
                             .properties
@@ -985,11 +981,7 @@ impl FileHeader {
             return Err(InnerError::BadHeader);
         }
 
-        let version = {
-            let mut bytes = [0; 2];
-            source.read_exact(&mut bytes)?;
-            u16::from_le_bytes(bytes)
-        };
+        let version = source.read_le_u16()?;
 
         if version != FILE_VERSION {
             return Err(InnerError::UnknownFileVersion { version });

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -334,7 +334,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
 
         self.output.write_all(FILE_MAGIC_HEADER)?;
         self.output.write_all(FILE_SIGNATURE)?;
-        self.output.write_all(&FILE_VERSION.to_le_bytes())?;
+        self.output.write_le_u16(FILE_VERSION)?;
 
         self.output.write_le_u32(self.type_infos.len() as u32)?;
         self.output
@@ -527,7 +527,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                     Type::Float64 => {
                         for (i, rbx_value) in values {
                             if let Variant::Float64(value) = rbx_value.as_ref() {
-                                chunk.write_all(&value.to_le_bytes())?;
+                                chunk.write_le_f64(*value)?;
                             } else {
                                 return type_mismatch(i, &rbx_value, "Float64");
                             }

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -225,11 +225,7 @@ impl DecodedValues {
                 let mut values = Vec::with_capacity(prop_count);
 
                 for _ in 0..prop_count {
-                    values.push({
-                        let mut bytes = [0; 8];
-                        reader.read_exact(&mut bytes).unwrap();
-                        f64::from_le_bytes(bytes)
-                    });
+                    values.push(reader.read_le_f64().unwrap());
                 }
 
                 Some(DecodedValues::Float64(values))


### PR DESCRIPTION
Removes byte_order as a dependency of rbx_binary.

Doesn't implement new methods for niche data types like f64 and u16; these aren't used in many places, so it seems unnecessary.

Instead, those functions are replaced with inlines such as:
```rust
{
    let mut bytes = [0; 8];
    chunk.read_exact(&mut bytes)?;
    f64::from_le_bytes(bytes)
}
```

I also resisted the urge to clean up any of the other functions since I wanted this to be a pure commit, but expect something like that in the future. Notably, I would like to (eventually) figure out a way to swap the `read_interleaved_TYPE_array` functions to also using `to_le_bytes` and `from_le_bytes`.