### PR TITLE
rbx_binary implement Color3uint8

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | BrickColor         | `Part.BrickColor`               | ✔ | ✔ | ✔ | ❌ |
 | CFrame             | `Camera.CFrame`                 | ✔ | ✔ | ✔ | ➖ |
 | Color3             | `Lighting.Ambient`              | ✔ | ✔ | ✔ | ✔ |
-| Color3uint8        | `N/A`                           | ✔ | ✔ | ✔ | ❌ |
+| Color3uint8        | `N/A`                           | ✔ | ✔ | ✔ | ✔ |
 | ColorSequence      | `Beam.Color`                    | ✔ | ✔ | ✔ | ❌ |
 | Content            | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
 | Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ❌ |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | Color3uint8        | `N/A`                           | ✔ | ✔ | ✔ | ✔ |
 | ColorSequence      | `Beam.Color`                    | ✔ | ✔ | ✔ | ❌ |
 | Content            | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
-| Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ❌ |
+| Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ✔ |
 | Faces              | `Handles.Faces`                 | ✔ | ❌ | ✔ | ✔ |
 | Float32            | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
 | Float64            | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | Color3uint8        | `N/A`                           | ✔ | ✔ | ✔ | ✔ |
 | ColorSequence      | `Beam.Color`                    | ✔ | ✔ | ✔ | ❌ |
 | Content            | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
-| Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ✔ |
+| Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ❌ |
 | Faces              | `Handles.Faces`                 | ✔ | ❌ | ✔ | ✔ |
 | Float32            | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
 | Float64            | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |

--- a/format/binary.md
+++ b/format/binary.md
@@ -451,6 +451,18 @@ The **correct** interpretation of this data, with accumulation, is:
 ### Color3uint8
 **Type ID 0x1A**
 
+The `Color3uint8` type is a struct made up of three bytes, one for each component:
+
+| Field Name  | Format | Value                                |
+|:------------|:-------|:-------------------------------------|
+| R           | u8     | The `R` component of the Color3uint8 |
+| G           | u8     | The `G` component of the Color3uint8 |
+| B           | u8     | The `B` component of the Color3uint8 |
+
+`Color3uint8` is stored as three consecutive arrays of components in the order `R`, `G`, `B`. It is not subject to any transformation or byte interleaving.
+
+Two Color3uint8s with the values `0, 255, 255` and `63, 0, 127`, respectively, look like this: `00 3f ff 00 ff 7f`.
+
 ### Int64
 **Type ID 0x1B**
 

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -859,21 +859,13 @@ impl<R: Read> BinaryDeserializer<R> {
             Type::Color3uint8 => match canonical_type {
                 VariantType::Color3 => {
                     let len = type_info.referents.len();
-                    let mut r = Vec::with_capacity(len);
-                    let mut g = Vec::with_capacity(len);
-                    let mut b = Vec::with_capacity(len);
+                    let mut r = vec![0; len];
+                    let mut g = vec![0; len];
+                    let mut b = vec![0; len];
 
-                    for _ in 0..len {
-                        r.push(chunk.read_u8().unwrap());
-                    }
-
-                    for _ in 0..len {
-                        g.push(chunk.read_u8().unwrap());
-                    }
-
-                    for _ in 0..len {
-                        b.push(chunk.read_u8().unwrap());
-                    }
+                    chunk.read_exact(r.as_mut_slice())?;
+                    chunk.read_exact(g.as_mut_slice())?;
+                    chunk.read_exact(b.as_mut_slice())?;
 
                     let colors = r
                         .into_iter()

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -7,8 +7,8 @@ use std::{
 
 use rbx_dom_weak::{
     types::{
-        Axes, CFrame, Color3, EnumValue, Faces, Matrix3, Ref, UDim, UDim2, Variant, VariantType,
-        Vector2, Vector3,
+        Axes, CFrame, Color3, Color3uint8, EnumValue, Faces, Matrix3, Ref, UDim, UDim2, Variant,
+        VariantType, Vector2, Vector3,
     },
     InstanceBuilder, WeakDom,
 };
@@ -856,7 +856,45 @@ impl<R: Read> BinaryDeserializer<R> {
             Type::NumberRange => {}
             Type::Rect => {}
             Type::PhysicalProperties => {}
-            Type::Color3uint8 => {}
+            Type::Color3uint8 => match canonical_type {
+                VariantType::Color3 => {
+                    let len = type_info.referents.len();
+                    let mut r = Vec::with_capacity(len);
+                    let mut g = Vec::with_capacity(len);
+                    let mut b = Vec::with_capacity(len);
+
+                    for _ in 0..len {
+                        r.push(chunk.read_u8().unwrap());
+                    }
+
+                    for _ in 0..len {
+                        g.push(chunk.read_u8().unwrap());
+                    }
+
+                    for _ in 0..len {
+                        b.push(chunk.read_u8().unwrap());
+                    }
+
+                    let colors = r
+                        .into_iter()
+                        .zip(g)
+                        .zip(b)
+                        .map(|((r, g), b)| Variant::Color3uint8(Color3uint8::new(r, g, b)));
+
+                    for (color, referent) in colors.into_iter().zip(&type_info.referents) {
+                        let instance = self.instances_by_ref.get_mut(referent).unwrap();
+                        instance.properties.push((canonical_name.clone(), color));
+                    }
+                }
+                invalid_type => {
+                    return Err(InnerError::PropTypeMismatch {
+                        type_name: type_info.type_name.clone(),
+                        prop_name,
+                        valid_type_names: "Color3",
+                        actual_type_name: format!("{:?}", invalid_type),
+                    });
+                }
+            },
             Type::Int64 => match canonical_type {
                 VariantType::Int64 => {
                     let mut values = vec![0; type_info.referents.len()];

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -710,26 +710,24 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                         let mut b = Vec::with_capacity(values.len());
 
                         for (i, rbx_value) in values {
-                            if let Variant::Color3uint8(value) = rbx_value.as_ref() {
-                                r.push(value.r);
-                                g.push(value.g);
-                                b.push(value.b);
-                            } else {
-                                return type_mismatch(i, &rbx_value, "Color3uint8");
+                            match rbx_value.as_ref() {
+                                Variant::Color3uint8(value) => {
+                                    r.push(value.r);
+                                    g.push(value.g);
+                                    b.push(value.b);
+                                }
+                                Variant::Color3(value) => {
+                                    r.push((value.r.max(0.0).min(1.0) * 255.0).round() as u8);
+                                    g.push((value.g.max(0.0).min(1.0) * 255.0).round() as u8);
+                                    b.push((value.b.max(0.0).min(1.0) * 255.0).round() as u8);
+                                }
+                                _ => return type_mismatch(i, &rbx_value, "Color3uint8 or Color3"),
                             }
                         }
 
-                        for component in r {
-                            chunk.write_u8(component)?;
-                        }
-
-                        for component in g {
-                            chunk.write_u8(component)?;
-                        }
-
-                        for component in b {
-                            chunk.write_u8(component)?;
-                        }
+                        chunk.write_all(r.as_slice())?;
+                        chunk.write_all(g.as_slice())?;
+                        chunk.write_all(b.as_slice())?;
                     }
                     Type::Int64 => {
                         let mut buf = Vec::with_capacity(values.len());

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -41,4 +41,5 @@ binary_tests! {
     two_cframevalues,
     cframe_special_cases,
     cframe_case_mixture,
+    three_unique_parts,
 }

--- a/rbx_binary/src/tests/serializer.rs
+++ b/rbx_binary/src/tests/serializer.rs
@@ -1,5 +1,5 @@
 use rbx_dom_weak::{
-    types::{Ref, Region3, Vector3},
+    types::{Color3, Ref, Region3, Vector3},
     InstanceBuilder, WeakDom,
 };
 
@@ -122,5 +122,32 @@ fn logical_properties_basepart_size() {
     let result = encode(&tree, tree.root().children(), &mut buffer);
 
     let decoded = DecodedModel::from_reader(buffer.as_slice());
+    insta::assert_yaml_snapshot!(decoded);
+}
+
+/// Ensure that Color3 can be serialized as Color3uint8. We use both the
+/// canonical property name Part.Color as well as the serialized name
+/// Part.Color3uint8.
+#[test]
+fn color3_to_color3uint8() {
+    let tree = WeakDom::new(
+        InstanceBuilder::new("Folder")
+            .with_child(
+                InstanceBuilder::new("Part")
+                    .with_property("Color3uint8", Color3::new(-0.25, 0.5, 1.2)),
+            )
+            .with_child(
+                InstanceBuilder::new("Part")
+                    .with_property("Color", Color3::new(0.1111, 0.3333, 0.9999)),
+            )
+            .with_child(
+                InstanceBuilder::new("Part").with_property("Color", Color3::new(0.0, 0.5, 1.0)),
+            ),
+    );
+
+    let mut buf = Vec::new();
+    let _ = encode(&tree, tree.root().children(), &mut buf);
+
+    let decoded = DecodedModel::from_reader(buf.as_slice());
     insta::assert_yaml_snapshot!(decoded);
 }

--- a/rbx_binary/src/tests/serializer.rs
+++ b/rbx_binary/src/tests/serializer.rs
@@ -1,5 +1,5 @@
 use rbx_dom_weak::{
-    types::{Color3, Ref, Region3, Vector3},
+    types::{Color3, Color3uint8, Ref, Region3, Vector3},
     InstanceBuilder, WeakDom,
 };
 
@@ -125,11 +125,10 @@ fn logical_properties_basepart_size() {
     insta::assert_yaml_snapshot!(decoded);
 }
 
-/// Ensures that Color3 can be serialized as Color3uint8. We use both the
-/// canonical property name Part.Color as well as the serialized name
-/// Part.Color3uint8.
+/// Ensures that all valid combinations of color property names and
+/// value types are properly handled.
 #[test]
-fn color3_to_color3uint8() {
+fn part_color() {
     let tree = WeakDom::new(
         InstanceBuilder::new("Folder")
             .with_child(
@@ -138,10 +137,13 @@ fn color3_to_color3uint8() {
             )
             .with_child(
                 InstanceBuilder::new("Part")
-                    .with_property("Color", Color3::new(0.1111, 0.3333, 0.9999)),
+                    .with_property("Color3uint8", Color3uint8::new(25, 86, 254)),
             )
             .with_child(
                 InstanceBuilder::new("Part").with_property("Color", Color3::new(0.0, 0.5, 1.0)),
+            )
+            .with_child(
+                InstanceBuilder::new("Part").with_property("Color", Color3uint8::new(1, 30, 100)),
             ),
     );
 

--- a/rbx_binary/src/tests/serializer.rs
+++ b/rbx_binary/src/tests/serializer.rs
@@ -125,7 +125,7 @@ fn logical_properties_basepart_size() {
     insta::assert_yaml_snapshot!(decoded);
 }
 
-/// Ensure that Color3 can be serialized as Color3uint8. We use both the
+/// Ensures that Color3 can be serialized as Color3uint8. We use both the
 /// canonical property name Part.Color as well as the serialized name
 /// Part.Color3uint8.
 #[test]

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__color3_to_color3uint8.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__color3_to_color3uint8.snap
@@ -1,0 +1,47 @@
+---
+source: rbx_binary/src/tests/serializer.rs
+expression: decoded
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: Part
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 0
+          - 128
+          - 255
+        - - 28
+          - 85
+          - 255
+        - - 0
+          - 128
+          - 255
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Part
+        - Part
+        - Part
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__part_color.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__part_color.snap
@@ -3,7 +3,7 @@ source: rbx_binary/src/tests/serializer.rs
 expression: decoded
 ---
 num_types: 1
-num_instances: 3
+num_instances: 4
 chunks:
   - Inst:
       type_id: 0
@@ -13,6 +13,7 @@ chunks:
         - 0
         - 1
         - 2
+        - 3
   - Prop:
       type_id: 0
       prop_name: Color3uint8
@@ -21,17 +22,21 @@ chunks:
         - - 0
           - 128
           - 255
-        - - 28
-          - 85
-          - 255
+        - - 25
+          - 86
+          - 254
         - - 0
           - 128
           - 255
+        - - 1
+          - 30
+          - 100
   - Prop:
       type_id: 0
       prop_name: Name
       prop_type: String
       values:
+        - Part
         - Part
         - Part
         - Part
@@ -43,5 +48,7 @@ chunks:
         - - 1
           - -1
         - - 2
+          - -1
+        - - 3
           - -1
   - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__decoded.snap
@@ -1,0 +1,484 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Brush your teeth
+  class: Part
+  properties:
+    Anchored:
+      Type: Bool
+      Value: false
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    BackParamA:
+      Type: Float32
+      Value: -0.5
+    BackParamB:
+      Type: Float32
+      Value: 0.5
+    BackSurface:
+      Type: EnumValue
+      Value: 0
+    BackSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    BottomParamA:
+      Type: Float32
+      Value: -0.5
+    BottomParamB:
+      Type: Float32
+      Value: 0.5
+    BottomSurface:
+      Type: EnumValue
+      Value: 0
+    BottomSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    CFrame:
+      Type: CFrame
+      Value:
+        Position:
+          - -5.5
+          - 4.0
+          - -12.5
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    CanCollide:
+      Type: Bool
+      Value: true
+    CastShadow:
+      Type: Bool
+      Value: true
+    CollisionGroupId:
+      Type: Int32
+      Value: 0
+    Color:
+      Type: Color3uint8
+      Value:
+        - 0
+        - 255
+        - 255
+    FormFactor:
+      Type: EnumValue
+      Value: 1
+    FrontParamA:
+      Type: Float32
+      Value: -0.5
+    FrontParamB:
+      Type: Float32
+      Value: 0.5
+    FrontSurface:
+      Type: EnumValue
+      Value: 0
+    FrontSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    LeftParamA:
+      Type: Float32
+      Value: -0.5
+    LeftParamB:
+      Type: Float32
+      Value: 0.5
+    LeftSurface:
+      Type: EnumValue
+      Value: 0
+    LeftSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    Locked:
+      Type: Bool
+      Value: false
+    Massless:
+      Type: Bool
+      Value: false
+    Material:
+      Type: EnumValue
+      Value: 256
+    Reflectance:
+      Type: Float32
+      Value: 0.0
+    RightParamA:
+      Type: Float32
+      Value: -0.5
+    RightParamB:
+      Type: Float32
+      Value: 0.5
+    RightSurface:
+      Type: EnumValue
+      Value: 0
+    RightSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    RootPriority:
+      Type: Int32
+      Value: 0
+    RotVelocity:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+    Shape:
+      Type: EnumValue
+      Value: 1
+    Size:
+      Type: Vector3
+      Value:
+        - 1.0
+        - 2.0
+        - 3.0
+    Tags:
+      Type: BinaryString
+      Value: ""
+    TopParamA:
+      Type: Float32
+      Value: -0.5
+    TopParamB:
+      Type: Float32
+      Value: 0.5
+    TopSurface:
+      Type: EnumValue
+      Value: 0
+    TopSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    Transparency:
+      Type: Float32
+      Value: 0.0
+    Velocity:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+  children: []
+- referent: referent-1
+  name: Eat your greens
+  class: Part
+  properties:
+    Anchored:
+      Type: Bool
+      Value: false
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    BackParamA:
+      Type: Float32
+      Value: -0.5
+    BackParamB:
+      Type: Float32
+      Value: 0.5
+    BackSurface:
+      Type: EnumValue
+      Value: 0
+    BackSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    BottomParamA:
+      Type: Float32
+      Value: -0.5
+    BottomParamB:
+      Type: Float32
+      Value: 0.5
+    BottomSurface:
+      Type: EnumValue
+      Value: 0
+    BottomSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    CFrame:
+      Type: CFrame
+      Value:
+        Position:
+          - -11.5
+          - -0.4999929964542389
+          - -17.5
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    CanCollide:
+      Type: Bool
+      Value: true
+    CastShadow:
+      Type: Bool
+      Value: true
+    CollisionGroupId:
+      Type: Int32
+      Value: 0
+    Color:
+      Type: Color3uint8
+      Value:
+        - 44
+        - 101
+        - 29
+    FormFactor:
+      Type: EnumValue
+      Value: 1
+    FrontParamA:
+      Type: Float32
+      Value: -0.5
+    FrontParamB:
+      Type: Float32
+      Value: 0.5
+    FrontSurface:
+      Type: EnumValue
+      Value: 0
+    FrontSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    LeftParamA:
+      Type: Float32
+      Value: -0.5
+    LeftParamB:
+      Type: Float32
+      Value: 0.5
+    LeftSurface:
+      Type: EnumValue
+      Value: 0
+    LeftSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    Locked:
+      Type: Bool
+      Value: false
+    Massless:
+      Type: Bool
+      Value: false
+    Material:
+      Type: EnumValue
+      Value: 256
+    Reflectance:
+      Type: Float32
+      Value: 0.0
+    RightParamA:
+      Type: Float32
+      Value: -0.5
+    RightParamB:
+      Type: Float32
+      Value: 0.5
+    RightSurface:
+      Type: EnumValue
+      Value: 0
+    RightSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    RootPriority:
+      Type: Int32
+      Value: 0
+    RotVelocity:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+    Shape:
+      Type: EnumValue
+      Value: 1
+    Size:
+      Type: Vector3
+      Value:
+        - 4.0
+        - 5.0
+        - 6.0
+    Tags:
+      Type: BinaryString
+      Value: ""
+    TopParamA:
+      Type: Float32
+      Value: -0.5
+    TopParamB:
+      Type: Float32
+      Value: 0.5
+    TopSurface:
+      Type: EnumValue
+      Value: 0
+    TopSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    Transparency:
+      Type: Float32
+      Value: 0.0
+    Velocity:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+  children: []
+- referent: referent-2
+  name: Live wildly
+  class: Part
+  properties:
+    Anchored:
+      Type: Bool
+      Value: false
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    BackParamA:
+      Type: Float32
+      Value: -0.5
+    BackParamB:
+      Type: Float32
+      Value: 0.5
+    BackSurface:
+      Type: EnumValue
+      Value: 0
+    BackSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    BottomParamA:
+      Type: Float32
+      Value: -0.5
+    BottomParamB:
+      Type: Float32
+      Value: 0.5
+    BottomSurface:
+      Type: EnumValue
+      Value: 0
+    BottomSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    CFrame:
+      Type: CFrame
+      Value:
+        Position:
+          - 5.5
+          - 8.5
+          - -25.5
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    CanCollide:
+      Type: Bool
+      Value: true
+    CastShadow:
+      Type: Bool
+      Value: true
+    CollisionGroupId:
+      Type: Int32
+      Value: 0
+    Color:
+      Type: Color3uint8
+      Value:
+        - 255
+        - 0
+        - 191
+    FormFactor:
+      Type: EnumValue
+      Value: 1
+    FrontParamA:
+      Type: Float32
+      Value: -0.5
+    FrontParamB:
+      Type: Float32
+      Value: 0.5
+    FrontSurface:
+      Type: EnumValue
+      Value: 0
+    FrontSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    LeftParamA:
+      Type: Float32
+      Value: -0.5
+    LeftParamB:
+      Type: Float32
+      Value: 0.5
+    LeftSurface:
+      Type: EnumValue
+      Value: 0
+    LeftSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    Locked:
+      Type: Bool
+      Value: false
+    Massless:
+      Type: Bool
+      Value: false
+    Material:
+      Type: EnumValue
+      Value: 256
+    Reflectance:
+      Type: Float32
+      Value: 0.0
+    RightParamA:
+      Type: Float32
+      Value: -0.5
+    RightParamB:
+      Type: Float32
+      Value: 0.5
+    RightSurface:
+      Type: EnumValue
+      Value: 0
+    RightSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    RootPriority:
+      Type: Int32
+      Value: 0
+    RotVelocity:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+    Shape:
+      Type: EnumValue
+      Value: 1
+    Size:
+      Type: Vector3
+      Value:
+        - 7.0
+        - 8.0
+        - 9.0
+    Tags:
+      Type: BinaryString
+      Value: ""
+    TopParamA:
+      Type: Float32
+      Value: -0.5
+    TopParamB:
+      Type: Float32
+      Value: 0.5
+    TopSurface:
+      Type: EnumValue
+      Value: 0
+    TopSurfaceInput:
+      Type: EnumValue
+      Value: 0
+    Transparency:
+      Type: Float32
+      Value: 0.0
+    Velocity:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+  children: []

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__encoded.snap
@@ -1,0 +1,440 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: Part
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - Position:
+            - -5.5
+            - 4.0
+            - -12.5
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - -11.5
+            - -0.4999929964542389
+            - -17.5
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 5.5
+            - 8.5
+            - -25.5
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 0
+          - 255
+          - 255
+        - - 44
+          - 101
+          - 29
+        - - 255
+          - 0
+          - 191
+  - Prop:
+      type_id: 0
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+        - 256
+        - 256
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Brush your teeth
+        - Eat your greens
+        - Live wildly
+  - Prop:
+      type_id: 0
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0.0
+        - 0.0
+        - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0.0
+        - 0.0
+        - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: formFactorRaw
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: shape
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 1.0
+          - 2.0
+          - 3.0
+        - - 4.0
+          - 5.0
+          - 6.0
+        - - 7.0
+          - 8.0
+          - 9.0
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__input.snap
@@ -1,0 +1,449 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Inst:
+      type_id: 0
+      type_name: Part
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - Position:
+            - -5.5
+            - 4.0
+            - -12.5
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - -11.5
+            - -0.4999929964542389
+            - -17.5
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 5.5
+            - 8.5
+            - -25.5
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 0
+          - 255
+          - 255
+        - - 44
+          - 101
+          - 29
+        - - 255
+          - 0
+          - 191
+  - Prop:
+      type_id: 0
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      remaining: 00 00 00
+  - Prop:
+      type_id: 0
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+        - 256
+        - 256
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Brush your teeth
+        - Eat your greens
+        - Live wildly
+  - Prop:
+      type_id: 0
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0.0
+        - 0.0
+        - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 0
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 0
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0.0
+        - 0.0
+        - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: formFactorRaw
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: shape
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 1.0
+          - 2.0
+          - 3.0
+        - - 4.0
+          - 5.0
+          - 6.0
+        - - 7.0
+          - 8.0
+          - 9.0
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -7,7 +7,7 @@
 use std::{collections::HashMap, convert::TryInto, io::Read};
 
 use rbx_dom_weak::types::{
-    Axes, CFrame, Color3, EnumValue, Faces, Matrix3, UDim, UDim2, Vector2, Vector3,
+    Axes, CFrame, Color3, Color3uint8, EnumValue, Faces, Matrix3, UDim, UDim2, Vector2, Vector3,
 };
 use serde::Serialize;
 
@@ -186,6 +186,7 @@ pub enum DecodedValues {
     Vector3(Vec<Vector3>),
     CFrame(Vec<CFrame>),
     Enum(Vec<EnumValue>),
+    Color3uint8(Vec<Color3uint8>),
     Int64(Vec<i64>),
 }
 
@@ -400,6 +401,32 @@ impl DecodedValues {
                     .collect();
 
                 Some(DecodedValues::Vector3(values))
+            }
+            Type::Color3uint8 => {
+                let mut r = Vec::with_capacity(prop_count);
+                let mut g = Vec::with_capacity(prop_count);
+                let mut b = Vec::with_capacity(prop_count);
+
+                for _ in 0..prop_count {
+                    r.push(reader.read_u8().unwrap());
+                }
+
+                for _ in 0..prop_count {
+                    g.push(reader.read_u8().unwrap());
+                }
+
+                for _ in 0..prop_count {
+                    b.push(reader.read_u8().unwrap());
+                }
+
+                let values = r
+                    .into_iter()
+                    .zip(g)
+                    .zip(b)
+                    .map(|((r, g), b)| Color3uint8::new(r, g, b))
+                    .collect();
+
+                Some(DecodedValues::Color3uint8(values))
             }
             Type::Int64 => {
                 let mut values = vec![0; prop_count];

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -403,21 +403,13 @@ impl DecodedValues {
                 Some(DecodedValues::Vector3(values))
             }
             Type::Color3uint8 => {
-                let mut r = Vec::with_capacity(prop_count);
-                let mut g = Vec::with_capacity(prop_count);
-                let mut b = Vec::with_capacity(prop_count);
+                let mut r = vec![0; prop_count];
+                let mut g = vec![0; prop_count];
+                let mut b = vec![0; prop_count];
 
-                for _ in 0..prop_count {
-                    r.push(reader.read_u8().unwrap());
-                }
-
-                for _ in 0..prop_count {
-                    g.push(reader.read_u8().unwrap());
-                }
-
-                for _ in 0..prop_count {
-                    b.push(reader.read_u8().unwrap());
-                }
+			 reader.read_exact(r.as_mut_slice()).unwrap();
+			 reader.read_exact(g.as_mut_slice()).unwrap();
+			 reader.read_exact(b.as_mut_slice()).unwrap();
 
                 let values = r
                     .into_iter()

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -407,9 +407,9 @@ impl DecodedValues {
                 let mut g = vec![0; prop_count];
                 let mut b = vec![0; prop_count];
 
-			 reader.read_exact(r.as_mut_slice()).unwrap();
-			 reader.read_exact(g.as_mut_slice()).unwrap();
-			 reader.read_exact(b.as_mut_slice()).unwrap();
+                reader.read_exact(r.as_mut_slice()).unwrap();
+                reader.read_exact(g.as_mut_slice()).unwrap();
+                reader.read_exact(b.as_mut_slice()).unwrap();
 
                 let values = r
                     .into_iter()


### PR DESCRIPTION
As part of this PR I have made `serializer.rs` [use canonical property names when fetching property values to write, rather than the serialized names](https://github.com/rojo-rbx/rbx-dom/blob/1b2cfa7efef6556504fc9a732f13cbcad3615523/rbx_binary/src/serializer.rs#L446). This became an issue because `deserializer.rs` uses canonical names as keys for property maps. This caused the serializer to erroneously write default prop values since `instance.properties.get("Color3uint8")` results in a `None`. I alternatively could have made `deserializer.rs` use `"Color3uint8"` as the key, but that seems smelly to me.

I have also updated the test files submodule.