### PR TITLE
Fix rbx_binary's relationship to canonical and logical properties

### DIFF
--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -365,33 +365,29 @@ pub fn find_property_descriptors(
                 PropertyKind::Alias { alias_for } => {
                     let canonical = class_descriptor.properties.get(alias_for.as_ref()).unwrap();
 
-                    match &canonical.kind {
-                        PropertyKind::Canonical { serialization } => {
-                            let serialized = find_serialized_from_canonical(
-                                class_descriptor,
-                                canonical,
-                                serialization,
-                            );
+                    if let PropertyKind::Canonical { serialization } = &canonical.kind {
+                        let serialized = find_serialized_from_canonical(
+                            class_descriptor,
+                            canonical,
+                            serialization,
+                        );
 
-                            return Some(PropertyDescriptors {
-                                canonical,
-                                serialized,
-                            });
-                        }
-
+                        return Some(PropertyDescriptors {
+                            canonical,
+                            serialized,
+                        });
+                    } else {
                         // If one property in the database calls itself an alias
                         // of another property, that property must be canonical.
-                        _ => {
-                            log::error!(
-                                "Property {}.{} is marked as an alias for {}.{}, but the latter is not canonical.",
-                                class_descriptor.name,
-                                property_descriptor.name,
-                                class_descriptor.name,
-                                alias_for
-                            );
+                        log::error!(
+                            "Property {}.{} is marked as an alias for {}.{}, but the latter is not canonical.",
+                            class_descriptor.name,
+                            property_descriptor.name,
+                            class_descriptor.name,
+                            alias_for
+                        );
 
-                            return None;
-                        }
+                        return None;
                     }
                 }
 

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -444,12 +444,8 @@ fn find_serialized_from_canonical(
             Some(serialized_descriptor)
         }
 
-        // If this property does not serialize, it's possible that it isn't
-        // relevant for rbx_binary. As-is we cannot distinguish between unknown
-        // properties and properties that do not serialize.
-        //
-        // FIXME: Should we change PropertyDescriptors.serialized to
-        // be optional and return a None serialized descriptor here?
+        // If this property does not serialize, there is no serialized
+        // descriptor to use.
         PropertySerialization::DoesNotSerialize => None,
 
         // This case will be hit if a new form of property serialization is

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -328,9 +328,7 @@ pub fn find_property_descriptors(
     class_name: &str,
     property_name: &str,
 ) -> Option<PropertyDescriptors> {
-    let class_descriptor = rbx_reflection_database::get().classes.get(class_name)?;
-
-    let mut current_class_descriptor = class_descriptor;
+    let mut class_descriptor = rbx_reflection_database::get().classes.get(class_name)?;
 
     // We need to find the canonical property descriptor associated with
     // the property we're working with.
@@ -342,7 +340,7 @@ pub fn find_property_descriptors(
     loop {
         // If this class descriptor knows about this property name, we're pretty
         // much done!
-        if let Some(property_descriptor) = current_class_descriptor.properties.get(property_name) {
+        if let Some(property_descriptor) = class_descriptor.properties.get(property_name) {
             match &property_descriptor.kind {
                 // This property descriptor is the canonical form of this
                 // logical property. That means we've found one of the two
@@ -365,10 +363,7 @@ pub fn find_property_descriptors(
                 // return, it's possible that both the canonical and serialized
                 // forms are different.
                 PropertyKind::Alias { alias_for } => {
-                    let canonical = current_class_descriptor
-                        .properties
-                        .get(alias_for.as_ref())
-                        .unwrap();
+                    let canonical = class_descriptor.properties.get(alias_for.as_ref()).unwrap();
 
                     match &canonical.kind {
                         PropertyKind::Canonical { serialization } => {
@@ -389,9 +384,9 @@ pub fn find_property_descriptors(
                         _ => {
                             log::error!(
                                 "Property {}.{} is marked as an alias for {}.{}, but the latter is not canonical.",
-                                current_class_descriptor.name,
+                                class_descriptor.name,
                                 property_descriptor.name,
-                                current_class_descriptor.name,
+                                class_descriptor.name,
                                 alias_for
                             );
 
@@ -406,11 +401,11 @@ pub fn find_property_descriptors(
             }
         }
 
-        if let Some(superclass_name) = &current_class_descriptor.superclass {
+        if let Some(superclass_name) = &class_descriptor.superclass {
             // If a property descriptor isn't found in our class, check our
             // superclass.
 
-            current_class_descriptor = rbx_reflection_database::get()
+            class_descriptor = rbx_reflection_database::get()
                 .classes
                 .get(superclass_name)
                 .expect("Superclass in reflection database didn't exist");

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -319,7 +319,7 @@ pub fn find_canonical_property_descriptor(
 
 pub struct PropertyDescriptors {
     pub canonical: &'static PropertyDescriptor<'static>,
-    pub serialized: &'static PropertyDescriptor<'static>,
+    pub serialized: Option<&'static PropertyDescriptor<'static>>,
 }
 
 /// Find both the canonical and serialized property descriptors for a given
@@ -352,7 +352,7 @@ pub fn find_property_descriptors(
                         class_descriptor,
                         property_descriptor,
                         serialization,
-                    )?;
+                    );
 
                     return Some(PropertyDescriptors {
                         canonical: property_descriptor,
@@ -376,7 +376,7 @@ pub fn find_property_descriptors(
                                 class_descriptor,
                                 canonical,
                                 serialization,
-                            )?;
+                            );
 
                             return Some(PropertyDescriptors {
                                 canonical,

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -499,7 +499,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                 let mut chunk = ChunkBuilder::new(b"PROP", ChunkCompression::Compressed);
 
                 chunk.write_le_u32(type_info.type_id)?;
-                chunk.write_string(&prop_name)?;
+                chunk.write_string(&prop_info.serialized_name)?;
                 chunk.write_u8(prop_info.prop_type as u8)?;
 
                 let dom = &self.dom;

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -243,10 +243,17 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
 
             match find_property_descriptors(&instance.class, prop_name) {
                 Some(descriptors) => {
-                    canonical_name = descriptors.canonical.name.clone();
-                    serialized_name = descriptors.serialized.name.clone();
+                    // For any properties that do not serialize, we can skip
+                    // adding them to the set of type_infos.
+                    let serialized = match descriptors.serialized {
+                        Some(descriptor) => descriptor,
+                        None => continue,
+                    };
 
-                    serialized_ty = match &descriptors.serialized.data_type {
+                    canonical_name = descriptors.canonical.name.clone();
+                    serialized_name = serialized.name.clone();
+
+                    serialized_ty = match &serialized.data_type {
                         DataType::Value(ty) => *ty,
                         DataType::Enum(_) => VariantType::EnumValue,
 

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__logical_properties_basepart_size.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__logical_properties_basepart_size.snap
@@ -1,0 +1,47 @@
+---
+source: rbx_binary/src/tests/serializer.rs
+expression: decoded
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: Part
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Part
+        - Part
+        - Part
+  - Prop:
+      type_id: 0
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 1.0
+          - 2.0
+          - 3.0
+        - - 4.0
+          - 5.0
+          - 6.0
+        - - 4.0
+          - 1.2000000476837159
+          - 2.0
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End


### PR DESCRIPTION
This is a pretty involved change; I hope I've added enough documentation inline in the code to help guide people through the new design decisions here.

## Logical Properties
This is a concept that has existed in rbx-dom informally for awhile now, but I think I've finally found a good name: logical properties.

A logical property describes an attribute of an instance, and may have multiple property names. We already have special terms to describe two kinds of property names: canonical names and serialized names. The idea is that all names for a logical property have storage that aliases. One of them must be canonical and zero or one of them must be marked for serialization.

Examples of groups of property names that describe logical properties:
* `BasePart.Size` (canonical), `BasePart.size` (serialized)
* `BasePart.Color` (canonical), `BasePart.Color3uint8` (serialized), `BasePart.BrickColor` (other), `BasePart.brickColor` (other)
* `SpawnLocation.AllowTeamChangeOnTouch` (canonical, serialized)

## PropInfo's New Semantics
Previously, rbx_binary's serializer would create a new `PropInfo` struct for each unique property name found for each class. This meant that the same logical property could be represented multiple times, and for properties whose canonical and serialized names are different, resulted in issues. The need for this fix was brought up by #133.

In this PR, exactly one `PropInfo` is created for each logical property. `TypeInfo` now explicitly contains a map from _canonical_ property names to `PropInfo` structs, and the serialized name is stored inline in `PropInfo`.

Additionally, I've added a set of aliases for each `PropInfo`. This set will be empty for most instances, but helps consolidate and deduplicate values with different names that form the same logical property. This would come up when mixing an older model with parts that have `BrickColor` alongside a newer model with parts that have `Color3uint8`. The `BrickColor` parts will be automatically upgraded to have `Color3uint8` instead, which should match the behavior of Roblox Studio.

One nice side effect of this change is that we're now able to borrow property name data in a few more places, as most names will come from static data located in the reflection database.