### PR TITLE
Implement BrickColor in rbx_binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | Axes               | `ArcHandles.Axes`               | ✔ | ❌ | ✔ | ✔ |
 | BinaryString       | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
 | Bool               | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |
-| BrickColor         | `Part.BrickColor`               | ✔ | ✔ | ✔ | ❌ |
+| BrickColor         | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
 | CFrame             | `Camera.CFrame`                 | ✔ | ✔ | ✔ | ➖ |
 | Color3             | `Lighting.Ambient`              | ✔ | ✔ | ✔ | ✔ |
 | Color3uint8        | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |

--- a/format/binary.md
+++ b/format/binary.md
@@ -322,6 +322,10 @@ Three encoded `Axes` with values `X`, `X Y`, and `X Z` would look like this: `01
 ### BrickColor
 **Type ID 0x0B**
 
+The `BrickColor` type is a single untransformed big-endian `u32` that represents the `Number` of a BrickColor. When an array of BrickColors is present, the Numbers are [byte interleaved](#byte-interleaving) but otherwise are unchanged.
+
+As an example, three encoded BrickColors with values `Really red (1004)`, `Bright green (37)`, and `Really blue (1010)` look like this: `00 00 00 00 00 00 03 00 03 EC 25 F2`.
+
 ### Color3
 **Type ID 0x0C**
 

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -684,13 +684,11 @@ impl<R: Read> BinaryDeserializer<R> {
                         let color = value
                             .try_into()
                             .map(|value| BrickColor::from_number(value).unwrap())
-                            .map_err(|_| {
-                                InnerError::InvalidPropData {
-                                    type_name: type_info.type_name.clone(),
-                                    prop_name: prop_name.clone(),
-                                    valid_value: "a valid BrickColor",
-                                    actual_value: value.to_string(),
-                                }
+                            .map_err(|_| InnerError::InvalidPropData {
+                                type_name: type_info.type_name.clone(),
+                                prop_name: prop_name.clone(),
+                                valid_value: "a valid BrickColor",
+                                actual_value: value.to_string(),
                             })?;
                         instance
                             .properties

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -681,15 +681,17 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     for (value, referent) in values.into_iter().zip(&type_info.referents) {
                         let instance = self.instances_by_ref.get_mut(referent).unwrap();
-                        let color = BrickColor::from_number(value as u16).ok_or_else(|| {
-                            InnerError::InvalidPropData {
-                                type_name: type_info.type_name.clone(),
-                                prop_name: prop_name.clone(),
-                                valid_value: "a valid BrickColor",
-                                actual_value: value.to_string(),
-                            }
-                        })?;
-
+                        let color = value
+                            .try_into()
+                            .map(|value| BrickColor::from_number(value).unwrap())
+                            .map_err(|_| {
+                                InnerError::InvalidPropData {
+                                    type_name: type_info.type_name.clone(),
+                                    prop_name: prop_name.clone(),
+                                    valid_value: "a valid BrickColor",
+                                    actual_value: value.to_string(),
+                                }
+                            })?;
                         instance
                             .properties
                             .push((canonical_name.clone(), Variant::BrickColor(color)));

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -675,14 +675,16 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     for (value, referent) in values.into_iter().zip(&type_info.referents) {
                         let instance = self.instances_by_ref.get_mut(referent).unwrap();
-                        let rbx_value = Variant::BrickColor(
-                            BrickColor::from_number(value as u16)
-                                // We should perhaps return an error here but this matches Roblox Studio's behavior
-                                .unwrap_or_else(|| BrickColor::MediumStoneGrey),
-                        );
+                        let color = BrickColor::from_number(value as u16).ok_or_else(|| InnerError::InvalidPropData {
+                            type_name: type_info.type_name.clone(),
+                            prop_name: prop_name.clone(),
+                            valid_value: "a valid BrickColor",
+                            actual_value: value.to_string(),
+                        })?;
+
                         instance
                             .properties
-                            .push((canonical_name.clone(), rbx_value));
+                            .push((canonical_name.clone(), Variant::BrickColor(color)));
                     }
                 }
                 invalid_type => {

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -675,11 +675,13 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     for (value, referent) in values.into_iter().zip(&type_info.referents) {
                         let instance = self.instances_by_ref.get_mut(referent).unwrap();
-                        let color = BrickColor::from_number(value as u16).ok_or_else(|| InnerError::InvalidPropData {
-                            type_name: type_info.type_name.clone(),
-                            prop_name: prop_name.clone(),
-                            valid_value: "a valid BrickColor",
-                            actual_value: value.to_string(),
+                        let color = BrickColor::from_number(value as u16).ok_or_else(|| {
+                            InnerError::InvalidPropData {
+                                type_name: type_info.type_name.clone(),
+                                prop_name: prop_name.clone(),
+                                valid_value: "a valid BrickColor",
+                                actual_value: value.to_string(),
+                            }
                         })?;
 
                         instance

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -684,7 +684,7 @@ impl<R: Read> BinaryDeserializer<R> {
                         let color = value
                             .try_into()
                             .ok()
-                            .and_then(|color| BrickColor::from_number(color))
+                            .and_then(BrickColor::from_number)
                             .ok_or_else(|| InnerError::InvalidPropData {
                                 type_name: type_info.type_name.clone(),
                                 prop_name: prop_name.clone(),

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -683,8 +683,9 @@ impl<R: Read> BinaryDeserializer<R> {
                         let instance = self.instances_by_ref.get_mut(referent).unwrap();
                         let color = value
                             .try_into()
-                            .map(|value| BrickColor::from_number(value).unwrap())
-                            .map_err(|_| InnerError::InvalidPropData {
+                            .ok()
+                            .and_then(|color| BrickColor::from_number(color))
+                            .ok_or_else(|| InnerError::InvalidPropData {
                                 type_name: type_info.type_name.clone(),
                                 prop_name: prop_name.clone(),
                                 valid_value: "a valid BrickColor",

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -8,8 +8,8 @@ use std::{
 
 use rbx_dom_weak::{
     types::{
-        Axes, BinaryString, CFrame, Color3, Color3uint8, Faces, Matrix3, Ref, UDim, UDim2, Variant,
-        VariantType, Vector2, Vector3,
+        Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, Faces, Matrix3, Ref, UDim,
+        UDim2, Variant, VariantType, Vector2, Vector3,
     },
     WeakDom,
 };
@@ -680,6 +680,19 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                             }
                         }
                     }
+                    Type::BrickColor => {
+                        let mut numbers = Vec::with_capacity(values.len());
+
+                        for (i, rbx_value) in values {
+                            if let Variant::BrickColor(value) = rbx_value.as_ref() {
+                                numbers.push(*value as u32)
+                            } else {
+                                return type_mismatch(i, &rbx_value, "BrickColor");
+                            }
+                        }
+
+                        chunk.write_interleaved_u32_array(&numbers)?;
+                    }
                     Type::Color3 => {
                         let mut r = Vec::with_capacity(values.len());
                         let mut g = Vec::with_capacity(values.len());
@@ -926,6 +939,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
             VariantType::UDim2 => Variant::UDim2(UDim2::new(UDim::new(0.0, 0), UDim::new(0.0, 0))),
             VariantType::Faces => Variant::Faces(Faces::from_bits(0)?),
             VariantType::Axes => Variant::Axes(Axes::from_bits(0)?),
+            VariantType::BrickColor => Variant::BrickColor(BrickColor::MediumStoneGrey),
             VariantType::CFrame => Variant::CFrame(CFrame::new(
                 Vector3::new(0.0, 0.0, 0.0),
                 Matrix3::identity(),

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -42,4 +42,5 @@ binary_tests! {
     cframe_special_cases,
     cframe_case_mixture,
     three_unique_parts,
+    three_brickcolorvalues,
 }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-brickcolorvalues__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-brickcolorvalues__decoded.snap
@@ -1,0 +1,46 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Value
+  class: BrickColorValue
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    Tags:
+      Type: BinaryString
+      Value: ""
+    Value:
+      Type: BrickColor
+      Value: 1004
+  children: []
+- referent: referent-1
+  name: Value
+  class: BrickColorValue
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    Tags:
+      Type: BinaryString
+      Value: ""
+    Value:
+      Type: BrickColor
+      Value: 37
+  children: []
+- referent: referent-2
+  name: Value
+  class: BrickColorValue
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    Tags:
+      Type: BinaryString
+      Value: ""
+    Value:
+      Type: BrickColor
+      Value: 1010
+  children: []

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-brickcolorvalues__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-brickcolorvalues__encoded.snap
@@ -1,0 +1,57 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: BrickColorValue
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Value
+        - Value
+        - Value
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Value
+      prop_type: BrickColor
+      values:
+        - 1004
+        - 37
+        - 1010
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-brickcolorvalues__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-brickcolorvalues__input.snap
@@ -1,0 +1,61 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Inst:
+      type_id: 0
+      type_name: BrickColorValue
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Value
+        - Value
+        - Value
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Value
+      prop_type: BrickColor
+      values:
+        - 1004
+        - 37
+        - 1010
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -302,10 +302,7 @@ impl DecodedValues {
 
                 let values = values
                     .into_iter()
-                    .map(|value| {
-                        BrickColor::from_number(value as u16)
-                            .unwrap_or_else(|| BrickColor::MediumStoneGrey)
-                    })
+                    .map(|value| BrickColor::from_number(value as u16).unwrap())
                     .collect();
 
                 Some(DecodedValues::BrickColor(values))

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -303,7 +303,7 @@ impl DecodedValues {
 
                 let values = values
                     .into_iter()
-                    .map(|value| BrickColor::from_number(value as u16).unwrap())
+                    .map(|value| BrickColor::from_number(value.try_into().unwrap()).unwrap())
                     .collect();
 
                 Some(DecodedValues::BrickColor(values))

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -7,7 +7,8 @@
 use std::{collections::HashMap, convert::TryInto, io::Read};
 
 use rbx_dom_weak::types::{
-    Axes, CFrame, Color3, Color3uint8, EnumValue, Faces, Matrix3, UDim, UDim2, Vector2, Vector3,
+    Axes, BrickColor, CFrame, Color3, Color3uint8, EnumValue, Faces, Matrix3, UDim, UDim2, Vector2,
+    Vector3,
 };
 use serde::Serialize;
 
@@ -181,6 +182,7 @@ pub enum DecodedValues {
     UDim2(Vec<UDim2>),
     Faces(Vec<Faces>),
     Axes(Vec<Axes>),
+    BrickColor(Vec<BrickColor>),
     Color3(Vec<Color3>),
     Vector2(Vec<Vector2>),
     Vector3(Vec<Vector3>),
@@ -293,6 +295,20 @@ impl DecodedValues {
                 }
 
                 Some(DecodedValues::Axes(values))
+            }
+            Type::BrickColor => {
+                let mut values = vec![0; prop_count];
+                reader.read_interleaved_u32_array(&mut values).unwrap();
+
+                let values = values
+                    .into_iter()
+                    .map(|value| {
+                        BrickColor::from_number(value as u16)
+                            .unwrap_or_else(|| BrickColor::MediumStoneGrey)
+                    })
+                    .collect();
+
+                Some(DecodedValues::BrickColor(values))
             }
             Type::CFrame => {
                 let mut rotations = vec![Matrix3::identity(); prop_count];


### PR DESCRIPTION
Nothing unusual in here. This implementation returns an Err (in deserializer) or panics (in text_deserializer) when it encounters any unknown BrickColor codes, which matches the behavior of other types when they encounter a bad piece of data.