### PR TITLE
Welcome Clippy into the codebase propertly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
     - name: Run tests (all features)
       run: cargo test --all-features --verbose
 
-    - name: Rustfmt and Clippy
-      run: |
-        cargo fmt -- --check
-        cargo clippy --all-features
+    - name: Check Formatting (stable only)
+      run: cargo fmt -- --check
       if: matrix.rust_version == 'stable'

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,30 @@
+name: Clippy
+
+on:
+  push:
+    branches:
+    - master
+
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust_version: ["1.47.0"]
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Setup Rust toolchain
+      run: rustup default ${{ matrix.rust_version }}
+
+    - name: Run Clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -24,7 +24,9 @@ jobs:
         submodules: true
 
     - name: Setup Rust toolchain
-      run: rustup default ${{ matrix.rust_version }}
+      run: |
+        rustup default ${{ matrix.rust_version }}
+        rustup component add clippy
 
     - name: Run Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings

--- a/generate_reflection/src/defaults_place.rs
+++ b/generate_reflection/src/defaults_place.rs
@@ -227,9 +227,8 @@ fn roundtrip_place_through_studio(place_contents: &str) -> anyhow::Result<Studio
     // like enigo or maybe raw input calls to do this for them.
 
     loop {
-        match rx.recv()? {
-            DebouncedEvent::Write(_) => break,
-            _ => {}
+        if let DebouncedEvent::Write(_) = rx.recv()? {
+            break;
         }
     }
 

--- a/generate_reflection/src/defaults_place.rs
+++ b/generate_reflection/src/defaults_place.rs
@@ -144,7 +144,10 @@ fn apply_defaults_from_fixture_place(database: &mut ReflectionDatabase, tree: &W
 }
 
 struct Descriptors<'a> {
+    // This descriptor might be useful in the future, but is currently unused.
+    #[allow(unused)]
     input: &'a PropertyDescriptor<'a>,
+
     canonical: &'a PropertyDescriptor<'a>,
 }
 

--- a/rbx_binary/benches/deserializer.rs
+++ b/rbx_binary/benches/deserializer.rs
@@ -32,7 +32,7 @@ pub fn de_modulescripts_100_lines_100(c: &mut Criterion) {
 
 #[inline(always)]
 fn deserialize_bench(buffer: &[u8]) {
-    rbx_binary::decode(buffer).unwrap();
+    rbx_binary::from_reader_default(buffer).unwrap();
 }
 
 criterion_group!(

--- a/rbx_binary/benches/serializer.rs
+++ b/rbx_binary/benches/serializer.rs
@@ -16,12 +16,12 @@ pub fn ser_folders_100(c: &mut Criterion) {
     let mut buffer = Vec::new();
 
     // Encode once into the buffer to pre-size it.
-    rbx_binary::encode(&tree, &[root_ref], &mut buffer).unwrap();
+    rbx_binary::to_writer_default(&mut buffer, &tree, &[root_ref]).unwrap();
     buffer.clear();
 
     c.bench_function("Serialize 100 Folders", |b| {
         b.iter(|| {
-            rbx_binary::encode(&tree, &[root_ref], &mut buffer).unwrap();
+            rbx_binary::to_writer_default(&mut buffer, &tree, &[root_ref]).unwrap();
             buffer.clear();
         });
     });

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -788,16 +788,15 @@ impl<R: Read> BinaryDeserializer<R> {
                                 ),
                             ));
                         } else {
-                            let special_case = special_case_to_rotation(id);
-                            if special_case.is_some() {
-                                rotations.push(special_case.unwrap());
-                            } else {
-                                return Err(InnerError::BadCFrameOrientationId {
+                            let special_case = special_case_to_rotation(id).ok_or_else(|| {
+                                InnerError::BadCFrameOrientationId {
                                     type_name: type_info.type_name.clone(),
-                                    prop_name,
+                                    prop_name: prop_name.clone(),
                                     id,
-                                });
-                            }
+                                }
+                            })?;
+
+                            rotations.push(special_case);
                         }
                     }
 

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -227,6 +227,9 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
 
     /// Collect information about all the different types of instance and their
     /// properties.
+    // Using the entry API here, as Clippy suggests, would require us to
+    // clone canonical_name in a cold branch. We don't want to do that.
+    #[allow(clippy::map_entry)]
     fn collect_type_info(&mut self, referent: Ref) -> Result<(), InnerError> {
         let instance = self
             .dom
@@ -285,9 +288,6 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                 None
             };
 
-            // Using the entry API here, as Clippy suggests, would require us to
-            // clone canonical_name in a cold branch. We don't want to do that.
-            #[allow(clippy::map_entry)]
             if !type_info.properties.contains_key(&canonical_name) {
                 let default_value = type_info
                     .class_descriptor

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -285,6 +285,9 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                 None
             };
 
+            // Using the entry API here, as Clippy suggests, would require us to
+            // clone canonical_name in a cold branch. We don't want to do that.
+            #[allow(clippy::map_entry)]
             if !type_info.properties.contains_key(&canonical_name) {
                 let default_value = type_info
                     .class_descriptor

--- a/rbx_binary/src/tests/serializer.rs
+++ b/rbx_binary/src/tests/serializer.rs
@@ -119,7 +119,7 @@ fn logical_properties_basepart_size() {
     );
 
     let mut buffer = Vec::new();
-    let result = encode(&tree, tree.root().children(), &mut buffer);
+    encode(&tree, tree.root().children(), &mut buffer).expect("failed to encode model");
 
     let decoded = DecodedModel::from_reader(buffer.as_slice());
     insta::assert_yaml_snapshot!(decoded);

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -299,10 +299,10 @@ impl DecodedValues {
             Type::CFrame => {
                 let mut rotations = vec![Matrix3::identity(); prop_count];
 
-                for i in 0..prop_count {
+                for rotation in rotations.iter_mut() {
                     let id = reader.read_u8().unwrap();
                     if id == 0 {
-                        rotations[i] = Matrix3::new(
+                        *rotation = Matrix3::new(
                             Vector3::new(
                                 reader.read_le_f32().unwrap(),
                                 reader.read_le_f32().unwrap(),
@@ -320,7 +320,7 @@ impl DecodedValues {
                             ),
                         );
                     } else {
-                        rotations[i] = special_case_to_rotation(id).unwrap();
+                        *rotation = special_case_to_rotation(id).unwrap();
                     }
                 }
 
@@ -346,10 +346,7 @@ impl DecodedValues {
                 let mut ints = vec![0; prop_count];
                 reader.read_interleaved_u32_array(&mut ints).unwrap();
 
-                let values = ints
-                    .into_iter()
-                    .map(|int| EnumValue::from_u32(int))
-                    .collect();
+                let values = ints.into_iter().map(EnumValue::from_u32).collect();
 
                 Some(DecodedValues::Enum(values))
             }
@@ -534,7 +531,7 @@ mod unknown_buffer {
 
     use serde::Serializer;
 
-    pub fn serialize<S>(value: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/rbx_dom_weak/src/viewer.rs
+++ b/rbx_dom_weak/src/viewer.rs
@@ -106,6 +106,12 @@ impl DomViewer {
     }
 }
 
+impl Default for DomViewer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A transformed view into a `WeakDom` or `Instance` that has been redacted and
 /// transformed to be more readable.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -1,3 +1,7 @@
+// Creating a default reflection database implicitly doesn't really make sense
+// for most cases.
+#![allow(clippy::new_without_default)]
+
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},

--- a/rbx_types/src/binary_string.rs
+++ b/rbx_types/src/binary_string.rs
@@ -3,7 +3,7 @@
 /// `BinaryString` is used in cases where the type of the underlying data is
 /// unknown or unimplemented. Where possible, stronger types that interpret the
 /// underlying bytes should be preferred.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct BinaryString {
     buffer: Vec<u8>,
 }

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -1,7 +1,7 @@
 /// A reference to a Roblox asset.
 ///
 /// When exposed to Lua, this is just a string.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -1,3 +1,6 @@
+// Refs are random, and so implementing Default doesn't really make sense.
+#![allow(clippy::new_without_default)]
+
 use std::num::NonZeroU128;
 
 /// An universally unique, optional reference to a Roblox instance.

--- a/rbx_types/src/serde_util.rs
+++ b/rbx_types/src/serde_util.rs
@@ -12,7 +12,7 @@ macro_rules! serde_tuple {
                 where
                     S: serde::Serializer,
                 {
-                    ( $( (&self).$field_name, )* ).serialize(serializer)
+                    ( $( self.$field_name, )* ).serialize(serializer)
                 }
             }
 

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -34,6 +34,7 @@ pub fn decode_internal<R: Read>(source: R, options: DecodeOptions) -> Result<Wea
 /// Describes the strategy that rbx_xml should use when deserializing
 /// properties.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum DecodePropertyBehavior {
     /// Ignores properties that aren't known by rbx_xml.
     ///
@@ -61,9 +62,6 @@ pub enum DecodePropertyBehavior {
     /// user to deal with oddities like how `Part.FormFactor` is actually
     /// serialized as `Part.formFactorRaw`.
     NoReflection,
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Options available for deserializing an XML-format model or place.
@@ -85,10 +83,7 @@ impl DecodeOptions {
     /// ones.
     #[inline]
     pub fn property_behavior(self, property_behavior: DecodePropertyBehavior) -> Self {
-        DecodeOptions {
-            property_behavior,
-            ..self
-        }
+        DecodeOptions { property_behavior }
     }
 
     /// A utility function to determine whether or not we should reference the
@@ -242,9 +237,8 @@ fn deserialize_root<R: Read>(
     let mut doc_version = None;
 
     for attribute in doc_attributes.into_iter() {
-        match attribute.name.local_name.as_str() {
-            "version" => doc_version = Some(attribute.value),
-            _ => {}
+        if attribute.name.local_name.as_str() == "version" {
+            doc_version = Some(attribute.value);
         }
     }
 
@@ -309,9 +303,8 @@ fn deserialize_metadata<R: Read>(
         let mut name = None;
 
         for attribute in attributes.into_iter() {
-            match attribute.name.local_name.as_str() {
-                "name" => name = Some(attribute.value),
-                _ => {}
+            if attribute.name.local_name.as_str() == "name" {
+                name = Some(attribute.value);
             }
         }
 
@@ -624,7 +617,6 @@ fn deserialize_properties<R: Read>(
                         property_name: xml_property_name,
                     }));
                 }
-                DecodePropertyBehavior::__Nonexhaustive => unreachable!(),
             }
         }
     }

--- a/rbx_xml/src/deserializer_core.rs
+++ b/rbx_xml/src/deserializer_core.rs
@@ -214,11 +214,8 @@ impl<R: Read> XmlEventReader<R> {
             None => return Ok(String::new()),
         };
 
-        loop {
-            match self.read_one_characters_event()? {
-                Some(piece) => buffer.push_str(&piece),
-                None => break,
-            }
+        while let Some(piece) = self.read_one_characters_event()? {
+            buffer.push_str(&piece);
         }
 
         Ok(buffer)

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -40,6 +40,7 @@ pub fn encode_internal<W: Write>(
 
 /// Describes the strategy that rbx_xml should use when serializing properties.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum EncodePropertyBehavior {
     /// Ignores properties that aren't known by rbx_xml.
     ///
@@ -65,9 +66,6 @@ pub enum EncodePropertyBehavior {
     /// user to deal with oddities like how `Part.FormFactor` is actually
     /// serialized as `Part.formFactorRaw`.
     NoReflection,
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Options available for serializing an XML-format model or place.
@@ -89,10 +87,7 @@ impl EncodeOptions {
     /// ones.
     #[inline]
     pub fn property_behavior(self, property_behavior: EncodePropertyBehavior) -> Self {
-        EncodeOptions {
-            property_behavior,
-            ..self
-        }
+        EncodeOptions { property_behavior }
     }
 
     pub(crate) fn use_reflection(&self) -> bool {
@@ -229,7 +224,6 @@ fn serialize_instance<'a, W: Write>(
                         property_name: property_name.clone(),
                     }));
                 }
-                EncodePropertyBehavior::__Nonexhaustive => unreachable!(),
             }
         }
     }

--- a/rbx_xml/src/types/axes.rs
+++ b/rbx_xml/src/types/axes.rs
@@ -25,7 +25,7 @@ impl XmlType for Axes {
             .map_err(|e| reader.error(e))?;
 
         Self::from_bits(value)
-            .ok_or(reader.error(DecodeErrorKind::InvalidContent("Axes value out of range")))
+            .ok_or_else(|| reader.error(DecodeErrorKind::InvalidContent("Axes value out of range")))
     }
 }
 

--- a/rbx_xml/src/types/cframe.rs
+++ b/rbx_xml/src/types/cframe.rs
@@ -41,8 +41,7 @@ impl XmlType for CFrame {
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
         let mut value = CFrame::new(Vector3::new(0.0, 0.0, 0.0), Matrix3::identity());
 
-        for index in 0..12 {
-            let tag_name = TAG_NAMES[index];
+        for &tag_name in &TAG_NAMES {
             let component: f32 = reader.read_value_in_tag(tag_name)?;
 
             match tag_name {

--- a/rbx_xml/src/types/color_sequence.rs
+++ b/rbx_xml/src/types/color_sequence.rs
@@ -35,7 +35,7 @@ impl XmlType for ColorSequence {
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
         let contents = reader.read_characters()?;
         let mut pieces = contents
-            .split(" ")
+            .split(' ')
             .filter(|slice| !slice.is_empty())
             .map(|piece| piece.parse::<f32>().map_err(|e| reader.error(e)));
         let mut keypoints = Vec::new();
@@ -46,6 +46,9 @@ impl XmlType for ColorSequence {
             ))
         };
 
+        // Because next() returns Option<Result<_>> here, it's cleaner to use
+        // loop instead of while-let.
+        #[allow(clippy::while_let_loop)]
         loop {
             let time = match pieces.next() {
                 Some(value) => value?,

--- a/rbx_xml/src/types/content.rs
+++ b/rbx_xml/src/types/content.rs
@@ -48,7 +48,7 @@ impl XmlType for Content {
                     let value = reader.read_characters()?;
                     reader.expect_end_with_name("url")?;
 
-                    value.to_owned()
+                    value
                 }
                 _ => {
                     let event = XmlReadEvent::StartElement {

--- a/rbx_xml/src/types/faces.rs
+++ b/rbx_xml/src/types/faces.rs
@@ -24,8 +24,9 @@ impl XmlType for Faces {
             .parse::<u8>()
             .map_err(|e| reader.error(e))?;
 
-        Self::from_bits(value)
-            .ok_or(reader.error(DecodeErrorKind::InvalidContent("Faces value out of range")))
+        Self::from_bits(value).ok_or_else(|| {
+            reader.error(DecodeErrorKind::InvalidContent("Faces value out of range"))
+        })
     }
 }
 

--- a/rbx_xml/src/types/number_range.rs
+++ b/rbx_xml/src/types/number_range.rs
@@ -24,7 +24,7 @@ impl XmlType for NumberRange {
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
         let contents = reader.read_characters()?;
         let mut pieces = contents
-            .split(" ")
+            .split(' ')
             .filter(|slice| !slice.is_empty())
             .map(|piece| piece.parse::<f32>().map_err(|e| reader.error(e)));
 

--- a/rbx_xml/src/types/number_sequence.rs
+++ b/rbx_xml/src/types/number_sequence.rs
@@ -28,7 +28,7 @@ impl XmlType for NumberSequence {
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
         let contents = reader.read_characters()?;
         let mut pieces = contents
-            .split(" ")
+            .split(' ')
             .filter(|slice| !slice.is_empty())
             .map(|piece| piece.parse::<f32>().map_err(|e| reader.error(e)));
         let mut keypoints = Vec::new();
@@ -39,6 +39,9 @@ impl XmlType for NumberSequence {
             ))
         };
 
+        // Because next() returns Option<Result<_>> here, it's cleaner to use
+        // loop instead of while-let.
+        #[allow(clippy::while_let_loop)]
         loop {
             let time = match pieces.next() {
                 Some(value) => value?,

--- a/rbx_xml/src/types/numbers.rs
+++ b/rbx_xml/src/types/numbers.rs
@@ -106,6 +106,10 @@ mod test {
         );
 
         // Can't just use test_util::test_xml_deserialize, because NaN != NaN!
+
+        // Clippy's suggestion here doesn't work and is less clear than just
+        // using as_bytes.
+        #[allow(clippy::string_lit_as_bytes)]
         let mut reader = XmlEventReader::from_source(r#"<float name="foo">NAN</float>"#.as_bytes());
         reader.next().unwrap().unwrap(); // Eat StartDocument event
         let value = f32::read_outer_xml(&mut reader).unwrap();

--- a/rbx_xml/src/types/referent.rs
+++ b/rbx_xml/src/types/referent.rs
@@ -21,7 +21,7 @@ use crate::{
     serializer_core::{XmlEventWriter, XmlWriteEvent},
 };
 
-pub const XML_TAG_NAME: &'static str = "Ref";
+pub const XML_TAG_NAME: &str = "Ref";
 
 pub fn write_ref<W: Write>(
     writer: &mut XmlEventWriter<W>,

--- a/rbx_xml/src/types/shared_string.rs
+++ b/rbx_xml/src/types/shared_string.rs
@@ -12,7 +12,7 @@ use crate::{
     serializer_core::{XmlEventWriter, XmlWriteEvent},
 };
 
-pub const XML_TAG_NAME: &'static str = "SharedString";
+pub const XML_TAG_NAME: &str = "SharedString";
 
 pub fn write_shared_string<W: Write>(
     writer: &mut XmlEventWriter<W>,


### PR DESCRIPTION
Closes #137.

This PR pins a version of Rust that we'll use for running Clippy, and then makes warnings fail the build. Previously, Clippy was running on the latest stable and would only error for lints that were deny-by-default. This was better than nothing, but obviously not the full purpose of Clippy.

I'm also fixing all of the Clippy issues in the codebase at the same time, since I sorta have to.