### PR TITLE
Tidy up the rbx_binary deserializer

### DIFF
--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__default-inserted-modulescript__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__default-inserted-modulescript__decoded.snap
@@ -10,7 +10,7 @@ expression: decoded_viewed
       Type: BinaryString
       Value: ""
     LinkedSource:
-      Type: String
+      Type: Content
       Value: ""
     ScriptGuid:
       Type: BinaryString


### PR DESCRIPTION
This PR changes the strategy that rbx_binary's deserializer uses when constructing instances. Instead of pushing properties into its `Instance` type and constructing `InstanceBuilder` objects when actually populating the `WeakDom`, we now incrementally build `InstanceBuilder` objects. This has the advantage of assigning referents much earlier in the process, which makes implementing the `Ref` type much easier.

As part of this change, I moved the portion of the code where we special case the `Name` property. I think the new home is a better spot.

Incidentally, this change let us drop a lot of boilerplate around constructing `Variant` objects because the `InstanceBuilder` methods are generic. This might increase compile times a small amount, but it is an ergonomic win that we should keep unless the drop is large. These monomorphizations are also likely to be instantiated by other code, so I'm not too worried.