### PR TITLE
Remove Serialize/Deserialize from SharedString

### DIFF
--- a/rbx_types/src/shared_string.rs
+++ b/rbx_types/src/shared_string.rs
@@ -118,24 +118,29 @@ impl SharedStringHash {
 }
 
 #[cfg(feature = "serde")]
-mod serde_impl {
+pub(crate) mod variant_serialization {
     use super::*;
 
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::de::Error as _;
+    use serde::ser::Error as _;
+    use serde::{Deserializer, Serializer};
 
-    // Mock implementations of traits to get things compiling. We'll need to
-    // decide how to actually serialize SharedString at some point.
-
-    impl Serialize for SharedString {
-        fn serialize<S: Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
-            unimplemented!();
-        }
+    pub fn serialize<S>(_value: &SharedString, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Err(S::Error::custom(
+            "SharedString cannot be serialized as part of a Variant",
+        ))
     }
 
-    impl<'de> Deserialize<'de> for SharedString {
-        fn deserialize<D: Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
-            unimplemented!();
-        }
+    pub fn deserialize<'de, D>(_deserializer: D) -> Result<SharedString, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Err(D::Error::custom(
+            "SharedString cannot be deserialized as part of a Variant",
+        ))
     }
 }
 

--- a/rbx_types/src/variant.rs
+++ b/rbx_types/src/variant.rs
@@ -87,6 +87,9 @@ macro_rules! make_variant {
     };
 }
 
+// IMPORTANT! The order of this enum is very important in order to preserve the
+// discriminant values that Rust assigns for both Variant and VariantType. Any
+// newly-added variants MUST be added to the end!
 make_variant! {
     Axes(Axes),
     BinaryString(BinaryString),

--- a/rbx_types/src/variant.rs
+++ b/rbx_types/src/variant.rs
@@ -7,7 +7,12 @@ use crate::{
 /// Reduces boilerplate from listing different values of Variant by wrapping
 /// them into a macro.
 macro_rules! make_variant {
-    ( $( $variant_name: ident($inner_type: ty), )* ) => {
+    (
+        $(
+            $( #[$attr:meta] )*
+            $variant_name:ident ($inner_type:ty),
+        )*
+    ) => {
         /// Represents any Roblox type. Useful for operating generically on
         /// Roblox instances.
         ///
@@ -24,14 +29,11 @@ macro_rules! make_variant {
         )]
         pub enum Variant {
             $(
+                $(
+                    #[$attr]
+                )*
                 $variant_name($inner_type),
             )*
-
-            #[cfg_attr(
-                feature = "serde",
-                serde(with = "crate::shared_string::variant_serialization"),
-            )]
-            SharedString(SharedString),
         }
 
         impl Variant {
@@ -40,8 +42,6 @@ macro_rules! make_variant {
                     $(
                         Variant::$variant_name(_) => VariantType::$variant_name,
                     )*
-
-                    Variant::SharedString(_) => VariantType::SharedString,
                 }
             }
         }
@@ -54,12 +54,6 @@ macro_rules! make_variant {
             }
         )*
 
-        impl From<SharedString> for Variant {
-            fn from(value: SharedString) -> Self {
-                Self::SharedString(value)
-            }
-        }
-
         /// Represents any type that can be held in a `Variant`.
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         #[non_exhaustive]
@@ -71,8 +65,6 @@ macro_rules! make_variant {
             $(
                 $variant_name,
             )*
-
-            SharedString,
         }
 
         #[cfg(test)]
@@ -119,6 +111,11 @@ make_variant! {
     Ref(Ref),
     Region3(Region3),
     Region3int16(Region3int16),
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::shared_string::variant_serialization"),
+    )]
+    SharedString(SharedString),
     String(String),
     UDim(UDim),
     UDim2(UDim2),


### PR DESCRIPTION
This PR removes the serde implementations from `SharedString` and replaces them with `#[serde(with)]` annotations on `Variant`. This is a little more accurate to the actual state of these types. The new implementation also gracefully returns an error instead of panicking with `unimplemented!()`.