### PR TITLE
Implement Vector3int16 in rbx-binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | Vector2            | `ImageLabel.ImageRectSize`      | ✔ | ✔ | ✔ | ✔ |
 | Vector2int16       | N/A                             | ✔ | ✔ | ✔ | ❌ |
 | Vector3            | `Part.Size`                     | ✔ | ✔ | ✔ | ✔ |
-| Vector3int16       | N/A                             | ✔ | ✔ | ✔ | ❌ |
+| Vector3int16       | N/A                             | ✔ | ✔ | ✔ | ✔ |
 | QDir               | `Studio.Auto-Save Path`         | ⛔ | ⛔ | ⛔ | ⛔ |
 | QFont              | `Studio.Font`                   | ⛔ | ⛔ | ⛔ | ⛔ |
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | Vector2            | `ImageLabel.ImageRectSize`      | ✔ | ✔ | ✔ | ✔ |
 | Vector2int16       | N/A                             | ✔ | ✔ | ✔ | ❌ |
 | Vector3            | `Part.Size`                     | ✔ | ✔ | ✔ | ✔ |
-| Vector3int16       | N/A                             | ✔ | ✔ | ✔ | ✔ |
+| Vector3int16       | `TerrainRegion.ExtentsMax`      | ✔ | ✔ | ✔ | ✔ |
 | QDir               | `Studio.Auto-Save Path`         | ⛔ | ⛔ | ⛔ | ⛔ |
 | QFont              | `Studio.Font`                   | ⛔ | ⛔ | ⛔ | ⛔ |
 

--- a/format/binary.md
+++ b/format/binary.md
@@ -450,6 +450,16 @@ The **correct** interpretation of this data, with accumulation, is:
 ### Vector3int16
 **Type ID 0x14**
 
+The `Vector3int16` type is stored as two little-endian `i16`s:
+
+| Field Name | Format | Value                                |
+|:-----------|:-------|:-------------------------------------|
+| X          | i16    | The `X` component of the Vector3in16 |
+| X          | i16    | The `Y` component of the Vector3in16 |
+| X          | i16    | The `Z` component of the Vector3in16 |
+
+Multiple `Vector3int16`s are stored in sequence without any transformations or interleaving. Two `Vector3int16`s with values `1, 2, 3` and `-1, -2, -3` are stored like this: `00 01 00 02 00 03 FF FF FE FF FD FF`.
+
 ### NumberSequence
 **Type ID 0x15**
 

--- a/format/binary.md
+++ b/format/binary.md
@@ -450,7 +450,7 @@ The **correct** interpretation of this data, with accumulation, is:
 ### Vector3int16
 **Type ID 0x14**
 
-The `Vector3int16` type is stored as two little-endian `i16`s:
+The `Vector3int16` type is stored as three little-endian `i16`s:
 
 | Field Name | Format | Value                                |
 |:-----------|:-------|:-------------------------------------|

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -24,6 +24,13 @@ pub trait RbxReadExt: Read {
         Ok(u16::from_le_bytes(bytes))
     }
 
+    fn read_le_i16(&mut self) -> io::Result<i16> {
+        let mut bytes = [0; 2];
+        self.read_exact(&mut bytes)?;
+
+        Ok(i16::from_le_bytes(bytes))
+    }
+
     fn read_le_f32(&mut self) -> io::Result<f32> {
         let mut buffer = [0u8; 4];
         self.read_exact(&mut buffer)?;
@@ -177,6 +184,12 @@ pub trait RbxWriteExt: Write {
     }
 
     fn write_le_u16(&mut self, value: u16) -> io::Result<()> {
+        self.write_all(&value.to_le_bytes())?;
+
+        Ok(())
+    }
+
+    fn write_le_i16(&mut self, value: i16) -> io::Result<()> {
         self.write_all(&value.to_le_bytes())?;
 
         Ok(())

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -10,7 +10,7 @@ use rbx_dom_weak::{
         Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
         ColorSequenceKeypoint, Content, CustomPhysicalProperties, EnumValue, Faces, Matrix3,
         NumberRange, NumberSequence, NumberSequenceKeypoint, PhysicalProperties, Ray, Rect, Ref,
-        SharedString, UDim, UDim2, Variant, VariantType, Vector2, Vector3,
+        SharedString, UDim, UDim2, Variant, VariantType, Vector2, Vector3, Vector3int16,
     },
     InstanceBuilder, WeakDom,
 };
@@ -963,7 +963,29 @@ impl<R: Read> BinaryDeserializer<R> {
                     });
                 }
             },
-            Type::Vector3int16 => {}
+            Type::Vector3int16 => match canonical_type {
+                VariantType::Vector3int16 => {
+                    for referent in &type_info.referents {
+                        let instance = self.instances_by_ref.get_mut(referent).unwrap();
+                        instance.builder.add_property(
+                            &canonical_name,
+                            Vector3int16::new(
+                                chunk.read_le_i16()?,
+                                chunk.read_le_i16()?,
+                                chunk.read_le_i16()?,
+                            ),
+                        )
+                    }
+                }
+                invalid_type => {
+                    return Err(InnerError::PropTypeMismatch {
+                        type_name: type_info.type_name.clone(),
+                        prop_name,
+                        valid_type_names: "Vector3int16",
+                        actual_type_name: format!("{:?}", invalid_type),
+                    });
+                }
+            },
             Type::NumberSequence => match canonical_type {
                 VariantType::NumberSequence => {
                     for referent in &type_info.referents {

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -1045,13 +1045,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                         }
 
                         chunk.write_interleaved_u32_array(&entries)?;
-                    } // _ => {
-                      //     return Err(InnerError::UnsupportedPropType {
-                      //         type_name: type_name.clone(),
-                      //         prop_name: prop_name.to_string(),
-                      //         prop_type: format!("binary type {:?}", prop_info.prop_type),
-                      //     });
-                      // }
+                    }
                 }
 
                 chunk.dump(&mut self.output)?;

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -11,7 +11,7 @@ use rbx_dom_weak::{
         Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
         ColorSequenceKeypoint, EnumValue, Faces, Matrix3, NumberRange, NumberSequence,
         NumberSequenceKeypoint, PhysicalProperties, Ray, Rect, Ref, SharedString, UDim, UDim2,
-        Variant, VariantType, Vector2, Vector3,
+        Variant, VariantType, Vector2, Vector3, Vector3int16,
     },
     WeakDom,
 };
@@ -899,6 +899,17 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
 
                         chunk.write_referent_array(buf.into_iter())?;
                     }
+                    Type::Vector3int16 => {
+                        for (i, rbx_value) in values {
+                            if let Variant::Vector3int16(value) = rbx_value.as_ref() {
+                                chunk.write_le_i16(value.x)?;
+                                chunk.write_le_i16(value.y)?;
+                                chunk.write_le_i16(value.z)?;
+                            } else {
+                                return type_mismatch(i, &rbx_value, "Vector3int16");
+                            }
+                        }
+                    }
                     Type::NumberSequence => {
                         for (i, rbx_value) in values {
                             if let Variant::NumberSequence(value) = rbx_value.as_ref() {
@@ -1034,14 +1045,13 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                         }
 
                         chunk.write_interleaved_u32_array(&entries)?;
-                    }
-                    _ => {
-                        return Err(InnerError::UnsupportedPropType {
-                            type_name: type_name.clone(),
-                            prop_name: prop_name.to_string(),
-                            prop_type: format!("binary type {:?}", prop_info.prop_type),
-                        });
-                    }
+                    } // _ => {
+                      //     return Err(InnerError::UnsupportedPropType {
+                      //         type_name: type_name.clone(),
+                      //         prop_name: prop_name.to_string(),
+                      //         prop_type: format!("binary type {:?}", prop_info.prop_type),
+                      //     });
+                      // }
                 }
 
                 chunk.dump(&mut self.output)?;
@@ -1150,6 +1160,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
             VariantType::Vector2 => Variant::Vector2(Vector2::new(0.0, 0.0)),
             VariantType::Vector3 => Variant::Vector3(Vector3::new(0.0, 0.0, 0.0)),
             VariantType::Ref => Variant::Ref(Ref::none()),
+            VariantType::Vector3int16 => Variant::Vector3int16(Vector3int16::new(0, 0, 0)),
             VariantType::NumberSequence => Variant::NumberSequence(NumberSequence {
                 keypoints: [
                     NumberSequenceKeypoint::new(0.0, 0.0, 0.0),

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -53,4 +53,5 @@ binary_tests! {
     two_imagebuttons,
     two_particleemitters,
     two_ray_values,
+    two_terrainregions,
 }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-terrainregions__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-terrainregions__decoded.snap
@@ -1,0 +1,62 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Region 1
+  class: TerrainRegion
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    ExtentsMax:
+      Type: Vector3int16
+      Value:
+        - 1
+        - 2
+        - 3
+    ExtentsMin:
+      Type: Vector3int16
+      Value:
+        - -1
+        - -2
+        - -3
+    SmoothGrid:
+      Type: BinaryString
+      Value: AQU=
+    SourceAssetId:
+      Type: Int64
+      Value: -1
+    Tags:
+      Type: BinaryString
+      Value: ""
+  children: []
+- referent: referent-1
+  name: Region 2
+  class: TerrainRegion
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    ExtentsMax:
+      Type: Vector3int16
+      Value:
+        - 1337
+        - 100
+        - 9001
+    ExtentsMin:
+      Type: Vector3int16
+      Value:
+        - -1337
+        - -100
+        - -9001
+    SmoothGrid:
+      Type: BinaryString
+      Value: AQU=
+    SourceAssetId:
+      Type: Int64
+      Value: -1
+    Tags:
+      Type: BinaryString
+      Value: ""
+  children: []

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-terrainregions__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-terrainregions__encoded.snap
@@ -1,0 +1,79 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 1
+num_instances: 2
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: TerrainRegion
+      object_format: 0
+      referents:
+        - 0
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: ExtentsMax
+      prop_type: Vector3int16
+      values:
+        - - 1
+          - 2
+          - 3
+        - - 1337
+          - 100
+          - 9001
+  - Prop:
+      type_id: 0
+      prop_name: ExtentsMin
+      prop_type: Vector3int16
+      values:
+        - - -1
+          - -2
+          - -3
+        - - -1337
+          - -100
+          - -9001
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Region 1
+        - Region 2
+  - Prop:
+      type_id: 0
+      prop_name: SmoothGrid
+      prop_type: String
+      values:
+        - "\u0001\u0005"
+        - "\u0001\u0005"
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-terrainregions__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-terrainregions__input.snap
@@ -1,0 +1,83 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 1
+num_instances: 2
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Inst:
+      type_id: 0
+      type_name: TerrainRegion
+      object_format: 0
+      referents:
+        - 0
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: ExtentsMax
+      prop_type: Vector3int16
+      values:
+        - - 1
+          - 2
+          - 3
+        - - 1337
+          - 100
+          - 9001
+  - Prop:
+      type_id: 0
+      prop_name: ExtentsMin
+      prop_type: Vector3int16
+      values:
+        - - -1
+          - -2
+          - -3
+        - - -1337
+          - -100
+          - -9001
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Region 1
+        - Region 2
+  - Prop:
+      type_id: 0
+      prop_name: SmoothGrid
+      prop_type: String
+      values:
+        - "\u0001\u0005"
+        - "\u0001\u0005"
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+  - End

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -615,7 +615,7 @@ impl DecodedValues {
                 reader.read_interleaved_u32_array(&mut values).unwrap();
 
                 Some(DecodedValues::SharedString(values))
-            } // _ => None,
+            }
         }
     }
 }

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -10,7 +10,7 @@ use rbx_dom_weak::types::{
     Axes, BrickColor, CFrame, Color3, Color3uint8, ColorSequence, ColorSequenceKeypoint,
     CustomPhysicalProperties, EnumValue, Faces, Matrix3, NumberRange, NumberSequence,
     NumberSequenceKeypoint, PhysicalProperties, Ray, Rect, SharedString, UDim, UDim2, Vector2,
-    Vector3,
+    Vector3, Vector3int16,
 };
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 
@@ -215,6 +215,7 @@ pub enum DecodedValues {
     CFrame(Vec<CFrame>),
     Enum(Vec<EnumValue>),
     Ref(Vec<i32>),
+    Vector3int16(Vec<Vector3int16>),
     NumberSequence(Vec<NumberSequence>),
     ColorSequence(Vec<ColorSequence>),
     NumberRange(Vec<NumberRange>),
@@ -496,6 +497,19 @@ impl DecodedValues {
 
                 Some(DecodedValues::ColorSequence(values))
             }
+            Type::Vector3int16 => {
+                let mut values = Vec::with_capacity(prop_count);
+
+                for _ in 0..prop_count {
+                    values.push(Vector3int16::new(
+                        reader.read_le_i16().unwrap(),
+                        reader.read_le_i16().unwrap(),
+                        reader.read_le_i16().unwrap(),
+                    ));
+                }
+
+                Some(DecodedValues::Vector3int16(values))
+            }
             Type::NumberRange => {
                 let mut values = Vec::with_capacity(prop_count);
 
@@ -601,8 +615,7 @@ impl DecodedValues {
                 reader.read_interleaved_u32_array(&mut values).unwrap();
 
                 Some(DecodedValues::SharedString(values))
-            }
-            _ => None,
+            } // _ => None,
         }
     }
 }


### PR DESCRIPTION
Nothing clever here, just getting us up to 100% coverage.

I believe this technically closes #117 since the remaining types (Region3, Region3int16, and Vector2int16) don't exist as properties.