### PR TITLE
[rbx_dom_lua] Support Axes, Faces, and Ray, improve Rect support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 
 | Property Type      | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary
 |:------------------ |:------------------------------- |:--:|:--:|:--:|:--:|
-| Axes               | `ArcHandles.Axes`               | ✔ | ❌ | ✔ | ✔ |
+| Axes               | `ArcHandles.Axes`               | ✔ | ✔ | ✔ | ✔ |
 | BinaryString       | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
 | Bool               | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |
 | BrickColor         | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
@@ -70,7 +70,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | ColorSequence      | `Beam.Color`                    | ✔ | ✔ | ✔ | ✔ |
 | Content            | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
 | Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ✔ |
-| Faces              | `Handles.Faces`                 | ✔ | ❌ | ✔ | ✔ |
+| Faces              | `Handles.Faces`                 | ✔ | ✔ | ✔ | ✔ |
 | Float32            | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
 | Float64            | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |
 | Int32              | `Frame.ZIndex`                  | ✔ | ✔ | ✔ | ✔ |
@@ -79,7 +79,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | NumberSequence     | `Beam.Transparency`             | ✔ | ✔ | ✔ | ✔ |
 | PhysicalProperties | `Part.CustomPhysicalProperties` | ✔ | ✔ | ✔ | ✔ |
 | ProtectedString    | `ModuleScript.Source`           | ✔ | ✔ | ✔ | ✔ |
-| Ray                | `RayValue.Value`                | ✔ | ❌ | ✔ | ✔ |
+| Ray                | `RayValue.Value`                | ✔ | ✔ | ✔ | ✔ |
 | Rect               | `ImageButton.SliceCenter`       | ✔ | ✔ | ✔ | ✔ |
 | Ref                | `Model.PrimaryPart`             | ✔ | ✔ | ✔ | ✔ |
 | Region3            | N/A                             | ✔ | ✔ | ❌ | ❌ |

--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -20,6 +20,41 @@ local function serializeFloat(value)
 	return value
 end
 
+local function enumsEncoder(enum)
+	local items = enum:GetEnumItems()
+
+	return function(flags)
+		local mask = 0
+		
+		for i, item in ipairs(items) do
+			if flags[item.Name] then
+				mask += (2 ^ item.Value)
+			end
+		end
+		
+		return mask
+	end
+end
+
+local function enumsDecoder(constructor, enum)
+	local decode = unpackDecoder(constructor)
+	local items = enum:GetEnumItems()
+
+	return function(mask)
+		local set = {}
+
+		for _,item in pairs(items) do
+			local bit = (2 ^ item.Value)
+			
+			if bit32.btest(bit, mask) then
+				table.insert(set, item)
+			end
+		end
+		
+		return decode(set)
+	end
+end
+
 local encoders
 encoders = {
 	Bool = identity,
@@ -29,6 +64,9 @@ encoders = {
 	Int32 = identity,
 	Int64 = identity,
 	String = identity,
+
+	Axes = enumsEncoder(Enum.Axis),
+	Faces = enumsEncoder(Enum.NormalId),
 
 	BinaryString = base64.encode,
 	SharedString = base64.encode,
@@ -77,8 +115,8 @@ encoders = {
 	end,
 	Rect = function(value)
 		return {
-			Min = {value.Min.X, value.Min.Y},
-			Max = {value.Max.X, value.Max.Y},
+			Min = encoders.Vector2(value.Min),
+			Max = encoders.Vector2(value.Max),
 		}
 	end,
 	UDim = function(value)
@@ -121,12 +159,20 @@ encoders = {
 		end
 	end,
 
+	Ray = function(value)
+		return {
+			Origin = encoders.Vector3(value.Origin),
+			Direction = encoders.Vector3(value.Direction),
+		}
+	end,
+
 	Ref = function(value)
 		return nil
 	end,
 }
 
-local decoders = {
+local decoders
+decoders = {
 	Bool = identity,
 	Content = identity,
 	Enum = identity,
@@ -138,6 +184,9 @@ local decoders = {
 
 	BinaryString = base64.decode,
 	SharedString = base64.decode,
+
+	Axes = enumsDecoder(Axes.new, Enum.Axis),
+	Faces = enumsDecoder(Faces.new, Enum.NormalId),
 
 	BrickColor = BrickColor.new,
 
@@ -153,7 +202,17 @@ local decoders = {
 	Vector3int16 = unpackDecoder(Vector3int16.new),
 
 	Rect = function(value)
-		return Rect.new(value.Min[1], value.Min[2], value.Max[1], value.Max[2])
+		return Rect.new(
+			decoders.Vector2(value.Min),
+			decoders.Vector2(value.Max)
+		)
+	end,
+
+	Ray = function(value)
+		return Ray.new(
+			decoders.Vector3(value.Origin),
+			decoders.Vector3(value.Direction)
+		)
 	end,
 
 	NumberSequence = function(value)

--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -20,13 +20,19 @@ local function serializeFloat(value)
 	return value
 end
 
+-- enumsEncoder and enumsDecoder are used by datatypes that act as a bit-flag wrapper
+-- for their underlying enum. This includes the 'Axes' and 'Faces' datatypes, which
+-- act as bit-flags for 'Enum.Axis' and 'Enum.NormalId' respectively. By treating
+-- the boolean value of each EnumItem as a bit, we can represent their value with
+-- a single byte. 'Axes' uses 3 bits, while 'Faces' uses 6 bits.
+
 local function enumsEncoder(enum)
 	local items = enum:GetEnumItems()
 
 	return function(flags)
 		local mask = 0
 		
-		for i, item in ipairs(items) do
+		for _, item in ipairs(items) do
 			if flags[item.Name] then
 				mask += (2 ^ item.Value)
 			end
@@ -43,7 +49,7 @@ local function enumsDecoder(constructor, enum)
 	return function(mask)
 		local set = {}
 
-		for _,item in pairs(items) do
+		for _, item in ipairs(items) do
 			local bit = (2 ^ item.Value)
 			
 			if bit32.btest(bit, mask) then

--- a/rbx_dom_lua/src/EncodedValue.spec.lua
+++ b/rbx_dom_lua/src/EncodedValue.spec.lua
@@ -76,7 +76,7 @@ return function()
 
 		-- Therefore, we should expect:
 		--   Front,  Left, Top   = true 
-		-- 	 Bottom, Back, Right = false
+		--   Bottom, Back, Right = false
 
 		expect(decoded.Top).to.equal(true)
 		expect(decoded.Left).to.equal(true)

--- a/rbx_dom_lua/src/EncodedValue.spec.lua
+++ b/rbx_dom_lua/src/EncodedValue.spec.lua
@@ -50,31 +50,76 @@ return function()
 	it("should decode a 'Faces' bit-mask value", function()
 		local input = {
 			Type = "Faces",
-			Value = 0b_111111,
+			Value = 0b111111,
 		}
 
 		local ok, decoded = EncodedValue.decode(input)
 		assert(ok, decoded)
 
-		for _,normalId in pairs(Enum.NormalId:GetEnumItems()) do
+		for _, normalId in ipairs(Enum.NormalId:GetEnumItems()) do
 			local set = decoded[normalId.Name]
 			expect(set).to.equal(true)
 		end
 	end)
 
+	it("should decode a 'Faces' bit-mask value with a mixed bit input", function()
+		local input = {
+			Type = "Faces",
+			Value = 0b101010, 
+		}
+		
+		local ok, decoded = EncodedValue.decode(input)
+		assert(ok, decoded)
+
+		-- The bits correspond to the following NormalId EnumItems
+		-- from left to right: Front, Bottom, Left, Back, Top, Right
+
+		-- Therefore, we should expect:
+		--   Front,  Left, Top   = true 
+		-- 	 Bottom, Back, Right = false
+
+		expect(decoded.Top).to.equal(true)
+		expect(decoded.Left).to.equal(true)
+		expect(decoded.Front).to.equal(true)
+		
+		expect(decoded.Back).to.equal(false)
+		expect(decoded.Right).to.equal(false)
+		expect(decoded.Bottom).to.equal(false)
+	end)
+
 	it("should decode an 'Axes' bit-mask value", function()
 		local input = {
 			Type = "Axes",
-			Value = 0b_111,
+			Value = 0b111,
+		}
+		
+		local ok, decoded = EncodedValue.decode(input)
+		assert(ok, decoded)
+
+		expect(decoded.X).to.equal(true)
+		expect(decoded.Y).to.equal(true)
+		expect(decoded.Z).to.equal(true)
+	end)
+
+	it("should decode an 'Axes' bit-mask value with a mixed bit input", function()
+		local input = {
+			Type = "Axes",
+			Value = 0b101,
 		}
 
 		local ok, decoded = EncodedValue.decode(input)
 		assert(ok, decoded)
 
-		for _,axis in pairs(Enum.Axis:GetEnumItems()) do
-			local set = decoded[axis.Name]
-			expect(set).to.equal(true)
-		end
+		-- The bits correspond to the following Axis EnumItems
+		-- from left to right: Z, Y, X
+
+		-- Therefore, we should expect:
+		--   Z, X = true
+		--      Y = false
+		
+		expect(decoded.X).to.equal(true)
+		expect(decoded.Y).to.equal(false)
+		expect(decoded.Z).to.equal(true)
 	end)
 
 	it("should decode NumberSequence values", function()

--- a/rbx_dom_lua/src/EncodedValue.spec.lua
+++ b/rbx_dom_lua/src/EncodedValue.spec.lua
@@ -53,11 +53,11 @@ return function()
 			Value = 0b_111111,
 		}
 
-		local ok, output = EncodedValue.decode(encoded)
-		assert(ok, output)
+		local ok, decoded = EncodedValue.decode(input)
+		assert(ok, decoded)
 
 		for _,normalId in pairs(Enum.NormalId:GetEnumItems()) do
-			local set = output[normalId.Name]
+			local set = decoded[normalId.Name]
 			expect(set).to.equal(true)
 		end
 	end)
@@ -68,11 +68,11 @@ return function()
 			Value = 0b_111,
 		}
 
-		local ok, output = EncodedValue.decode(encoded)
-		assert(ok, output)
+		local ok, decoded = EncodedValue.decode(input)
+		assert(ok, decoded)
 
 		for _,axis in pairs(Enum.Axis:GetEnumItems()) do
-			local set = output[axis.Name]
+			local set = decoded[axis.Name]
 			expect(set).to.equal(true)
 		end
 	end)

--- a/rbx_dom_lua/src/EncodedValue.spec.lua
+++ b/rbx_dom_lua/src/EncodedValue.spec.lua
@@ -47,6 +47,36 @@ return function()
 		expect(decoded).to.equal(output)
 	end)
 
+	it("should decode Face values", function()
+		local input = {
+			Type = "Faces",
+			Value = 63,
+		}
+
+		local ok, output = EncodedValue.decode(encoded)
+		assert(ok, output)
+
+		for _,normalId in pairs(Enum.NormalId:GetEnumItems()) do
+			local set = output[normalId.Name]
+			expect(set).to.equal(true)
+		end
+	end)
+
+	it("should decode Axes values", function()
+		local input = {
+			Type = "Axes",
+			Value = 7,
+		}
+
+		local ok, output = EncodedValue.decode(encoded)
+		assert(ok, output)
+
+		for _,axis in pairs(Enum.Axis:GetEnumItems()) do
+			local set = output[axis.Name]
+			expect(set).to.equal(true)
+		end
+	end)
+
 	it("should decode NumberSequence values", function()
 		local input = {
 			Type = "NumberSequence",
@@ -102,8 +132,7 @@ return function()
 		expect(decoded).to.equal(output)
 	end)
 
-	-- This part of rbx_dom_lua needs some work still.
-	itSKIP("should encode Rect values", function()
+	it("should encode Rect values", function()
 		local input = Rect.new(10, 20, 30, 40)
 
 		local output = {

--- a/rbx_dom_lua/src/EncodedValue.spec.lua
+++ b/rbx_dom_lua/src/EncodedValue.spec.lua
@@ -47,10 +47,10 @@ return function()
 		expect(decoded).to.equal(output)
 	end)
 
-	it("should decode Face values", function()
+	it("should decode a 'Faces' bit-mask value", function()
 		local input = {
 			Type = "Faces",
-			Value = 63,
+			Value = 0b_111111,
 		}
 
 		local ok, output = EncodedValue.decode(encoded)
@@ -62,10 +62,10 @@ return function()
 		end
 	end)
 
-	it("should decode Axes values", function()
+	it("should decode an 'Axes' bit-mask value", function()
 		local input = {
 			Type = "Axes",
-			Value = 7,
+			Value = 0b_111,
 		}
 
 		local ok, output = EncodedValue.decode(encoded)


### PR DESCRIPTION
This patch implements the remaining datatypes that are missing from rbx_dom_lua, and fixes problems with encoding the Rect type.