### PR TITLE
Make rbx_binary resilient to unknown value types

### DIFF
--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     convert::TryInto,
     io::{self, Read},
     str,
@@ -278,6 +278,11 @@ struct BinaryDeserializer<R> {
     /// Referents for all of the instances with no parent, in order they appear
     /// in the file.
     root_instance_refs: Vec<i32>,
+
+    /// Contains a set of unknown type IDs that we've encountered so far while
+    /// deserializing this file. We use this map in order to ensure we only
+    /// print one warning per unknown type ID when deserializing a file.
+    unknown_type_ids: HashSet<u8>,
 }
 
 /// All the information contained in the header before any chunks are read from
@@ -334,6 +339,7 @@ impl<R: Read> BinaryDeserializer<R> {
             type_infos,
             instances_by_ref,
             root_instance_refs: Vec::new(),
+            unknown_type_ids: HashSet::new(),
         })
     }
 
@@ -416,12 +422,40 @@ impl<R: Read> BinaryDeserializer<R> {
     fn decode_prop_chunk(&mut self, mut chunk: &[u8]) -> Result<(), InnerError> {
         let type_id = chunk.read_le_u32()?;
         let prop_name = chunk.read_string()?;
-        let binary_type: Type = chunk.read_u8()?.try_into()?;
 
         let type_info = self
             .type_infos
             .get(&type_id)
             .ok_or(InnerError::InvalidTypeId { type_id })?;
+
+        // PROP chunks that contain no type byte are ignored by Roblox. This can
+        // happen when a new type is introduced.
+        //
+        // On 2021-04-08, OptionalCoordinateFrame was introduced, but its
+        // serialized format was just a type ID followed by the prop name. This
+        // leads us to believe that Roblox will silently ignore any PROP chunks
+        // that end immediately after the prop name, so we do the same.
+        let binary_type_byte = match chunk.read_u8() {
+            Ok(byte) => byte,
+            Err(_) => return Ok(()),
+        };
+
+        let binary_type: Type = match binary_type_byte.try_into() {
+            Ok(ty) => ty,
+            Err(_) => {
+                if self.unknown_type_ids.insert(binary_type_byte) {
+                    log::warn!(
+                        "Unknown value type ID {byte:#04x} ({byte}) in Roblox \
+                         binary model file. Found in property {class}.{prop}.",
+                        byte = binary_type_byte,
+                        class = type_info.type_name,
+                        prop = prop_name,
+                    );
+                }
+
+                return Ok(());
+            }
+        };
 
         log::trace!(
             "PROP chunk ({}.{}, instance type {}, prop type {}",


### PR DESCRIPTION
This PR fixes two cases:

- PROP chunks with no data are now silently ignored in order to match Roblox behavior. This is important with the new partly-released `OptionalCoordinateFrame` type.
- Unknown value types are now ignored, but print one warning per unknown type ID. The warning contains the instance type and property name of the first property in the file that has this byte. I wanted to reduce the amount of warning spam that might happen when new files starting including a type.

We'll want to backport this to dom-v1 so that we're able to patch Rojo 6.x and potentially 0.5.x as well.