### PR TITLE
Harden rbx_xml against unknown property types

### DIFF
--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,10 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* rbx_xml now ignore unknown property types. ([#170][pr-170])
+	* This fixes our interactions with the new, partially-released `OptionalCoordinateFrame` type that is now showing up in place and model files.
+
+[pr-170]: https://github.com/rojo-rbx/rbx-dom/pull/170
 
 ## 0.12.0-alpha.3 (2021-03-08)
 * BrickColor properties will now deserialize as the `BrickColor` type.

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -175,7 +175,7 @@ impl<'a> ParseState<'a> {
 
         log::warn!(
             "Unknown value type name \"{name}\" in Roblox XML model file. \
-                 Found in property {class}.{prop}.",
+             Found in property {class}.{prop}.",
             name = type_name,
             class = instance.class,
             prop = property_name,

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, io::Read};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Read,
+};
 
 use log::trace;
 use rbx_dom_weak::{
@@ -129,6 +132,10 @@ pub struct ParseState<'a> {
     /// pass. This works just like referent rewriting since the shared string
     /// dictionary is usually at the end of the XML file.
     shared_string_rewrites: Vec<SharedStringRewrite>,
+
+    /// Contains all of the unknown types that have been found so far. Tracking
+    /// them here helps ensure that we only output a warning once per type.
+    unknown_type_names: HashSet<String>,
 }
 
 struct ReferentRewrite {
@@ -153,7 +160,26 @@ impl<'a> ParseState<'a> {
             referent_rewrites: Vec::new(),
             known_shared_strings: HashMap::new(),
             shared_string_rewrites: Vec::new(),
+            unknown_type_names: HashSet::new(),
         }
+    }
+
+    /// Called when the deserializer encounters an unknown property type.
+    pub fn unknown_type_visited(&mut self, id: Ref, property_name: &str, type_name: &str) {
+        if self.unknown_type_names.contains(type_name) {
+            return;
+        }
+
+        self.unknown_type_names.insert(type_name.to_owned());
+        let instance = self.tree.get_by_ref(id).unwrap();
+
+        log::warn!(
+            "Unknown value type name \"{name}\" in Roblox XML model file. \
+                 Found in property {class}.{prop}.",
+            name = type_name,
+            class = instance.class,
+            prop = property_name,
+        );
     }
 
     /// Marks that a property on this instance needs to be rewritten once we
@@ -540,7 +566,11 @@ fn deserialize_properties<R: Read>(
 
         if let Some(descriptor) = maybe_descriptor {
             let value =
-                read_value_xml(reader, state, &xml_type_name, instance_id, &descriptor.name)?;
+                match read_value_xml(reader, state, &xml_type_name, instance_id, &descriptor.name)?
+                {
+                    Some(value) => value,
+                    None => continue,
+                };
 
             let xml_ty = value.ty();
 
@@ -596,13 +626,16 @@ fn deserialize_properties<R: Read>(
                     // We'll take this value as-is with no conversions on either
                     // the name or value.
 
-                    let value = read_value_xml(
+                    let value = match read_value_xml(
                         reader,
                         state,
                         &xml_type_name,
                         instance_id,
                         &xml_property_name,
-                    )?;
+                    )? {
+                        Some(value) => value,
+                        None => continue,
+                    };
                     props.insert(xml_property_name, value);
                 }
                 DecodePropertyBehavior::ErrorOnUnknown => {

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -83,7 +83,6 @@ pub(crate) enum DecodeErrorKind {
         class_name: String,
         property_name: String,
     },
-    UnknownPropertyType(String),
     InvalidContent(&'static str),
     NameMustBeString(VariantType),
     UnsupportedPropertyConversion {
@@ -121,9 +120,6 @@ impl fmt::Display for DecodeErrorKind {
                 "Property {}.{} is unknown",
                 class_name, property_name
             ),
-            UnknownPropertyType(prop_name) => {
-                write!(output, "Unknown property type '{}'", prop_name)
-            }
             InvalidContent(explain) => write!(output, "Invalid text content: {}", explain),
             NameMustBeString(ty) => write!(
                 output,
@@ -161,7 +157,6 @@ impl std::error::Error for DecodeErrorKind {
             | UnexpectedXmlEvent(_)
             | MissingAttribute(_)
             | UnknownProperty { .. }
-            | UnknownPropertyType(_)
             | InvalidContent(_)
             | NameMustBeString(_)
             | UnsupportedPropertyConversion { .. } => None,

--- a/rbx_xml/src/types/mod.rs
+++ b/rbx_xml/src/types/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     core::XmlType,
     deserializer::ParseState,
     deserializer_core::XmlEventReader,
-    error::{DecodeError, DecodeErrorKind, EncodeError, EncodeErrorKind},
+    error::{DecodeError, EncodeError, EncodeErrorKind},
     serializer::EmitState,
     serializer_core::XmlEventWriter,
 };
@@ -64,21 +64,23 @@ macro_rules! declare_rbx_types {
             xml_type_name: &str,
             instance_id: Ref,
             property_name: &str,
-        ) -> Result<Variant, DecodeError> {
+        ) -> Result<Option<Variant>, DecodeError> {
             match xml_type_name {
-                $(<$inner_type>::XML_TAG_NAME => Ok(Variant::$variant_name(<$inner_type>::read_outer_xml(reader)?)),)*
+                $(<$inner_type>::XML_TAG_NAME => Ok(Some(Variant::$variant_name(<$inner_type>::read_outer_xml(reader)?))),)*
 
                 // Protected strings are only read, never written
                 self::strings::ProtectedStringDummy::XML_TAG_NAME => {
                     let value = self::strings::ProtectedStringDummy::read_outer_xml(reader)?;
-                    Ok(Variant::String(value.0))
+                    Ok(Some(Variant::String(value.0)))
                 },
 
-                self::referent::XML_TAG_NAME => Ok(Variant::Ref(read_ref(reader, instance_id, property_name, state)?)),
-                self::shared_string::XML_TAG_NAME => read_shared_string(reader, instance_id, property_name, state),
+                self::referent::XML_TAG_NAME => Ok(Some(Variant::Ref(read_ref(reader, instance_id, property_name, state)?))),
+                self::shared_string::XML_TAG_NAME => read_shared_string(reader, instance_id, property_name, state).map(Some),
 
                 _ => {
-                    Err(reader.error(DecodeErrorKind::UnknownPropertyType(xml_type_name.to_owned())))
+                    state.unknown_type_visited(instance_id, property_name, xml_type_name);
+
+                    Ok(None)
                 },
             }
         }

--- a/rbx_xml/src/types/mod.rs
+++ b/rbx_xml/src/types/mod.rs
@@ -79,6 +79,7 @@ macro_rules! declare_rbx_types {
 
                 _ => {
                     state.unknown_type_visited(instance_id, property_name, xml_type_name);
+                    reader.eat_unknown_tag()?;
 
                     Ok(None)
                 },

--- a/rbx_xml/tests/snapshots/test_files__unknown_type.snap
+++ b/rbx_xml/tests/snapshots/test_files__unknown_type.snap
@@ -1,0 +1,9 @@
+---
+source: rbx_xml/tests/test-files.rs
+expression: viewer.view_children(&dom)
+---
+- referent: referent-0
+  name: A NumberValue
+  class: NumberValue
+  properties: {}
+  children: []

--- a/rbx_xml/tests/test-files.rs
+++ b/rbx_xml/tests/test-files.rs
@@ -9,7 +9,7 @@ macro_rules! test_models {
             fn $test_name() {
                 let _ = env_logger::try_init();
 
-                let mut path = Path::new("../test-files/models").join($file_name);
+                let mut path = Path::new("../test-files").join($file_name);
                 path.push("xml.rbxmx");
 
                 let contents = fs::read_to_string(path).unwrap();
@@ -24,14 +24,13 @@ macro_rules! test_models {
 }
 
 test_models! {
-    ball_socket_constraint: "ball-socket-constraint",
-    default_inserted_folder: "default-inserted-folder",
-    default_inserted_part: "default-inserted-part",
-    // faces: "faces",
-    // axes: "axes",
-    ref_adjacent: "ref-adjacent",
-    ref_child: "ref-child",
-    ref_parent: "ref-parent",
-    body_movers: "body-movers",
-    // default_inserted_modulescript: "default-inserted-modulescript",
+    ball_socket_constraint: "models/ball-socket-constraint",
+    default_inserted_folder: "models/default-inserted-folder",
+    default_inserted_part: "models/default-inserted-part",
+    ref_adjacent: "models/ref-adjacent",
+    ref_child: "models/ref-child",
+    ref_parent: "models/ref-parent",
+    body_movers: "models/body-movers",
+
+    unknown_type: "edge-cases/xml-unknown-type",
 }


### PR DESCRIPTION
XML sibling to #168.

`read_xml_value` has changed to return a `Result<Option<Variant>, _>` instead of `Result<Variant, _>` to encode the possibility of an unknown value independently of deserialization errors. It's not excellent, but it's the best we can do with the way this codebase is structured right now.

## TODO
- [x] Automated tests