### PR TITLE
Implement OptionalCoordinateFrame in rbx_binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,42 +58,43 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 
 ## Property Type Coverage
 
-| Property Type      | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary
-|:------------------ |:------------------------------- |:--:|:--:|:--:|:--:|
-| Axes               | `ArcHandles.Axes`               | ✔ | ✔ | ✔ | ✔ |
-| BinaryString       | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
-| Bool               | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |
-| BrickColor         | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
-| CFrame             | `Camera.CFrame`                 | ✔ | ✔ | ✔ | ✔ |
-| Color3             | `Lighting.Ambient`              | ✔ | ✔ | ✔ | ✔ |
-| Color3uint8        | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
-| ColorSequence      | `Beam.Color`                    | ✔ | ✔ | ✔ | ✔ |
-| Content            | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
-| Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ✔ |
-| Faces              | `Handles.Faces`                 | ✔ | ✔ | ✔ | ✔ |
-| Float32            | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
-| Float64            | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |
-| Int32              | `Frame.ZIndex`                  | ✔ | ✔ | ✔ | ✔ |
-| Int64              | `Player.UserId`                 | ✔ | ✔ | ✔ | ✔ |
-| NumberRange        | `ParticleEmitter.Lifetime`      | ✔ | ✔ | ✔ | ✔ |
-| NumberSequence     | `Beam.Transparency`             | ✔ | ✔ | ✔ | ✔ |
-| PhysicalProperties | `Part.CustomPhysicalProperties` | ✔ | ✔ | ✔ | ✔ |
-| ProtectedString    | `ModuleScript.Source`           | ✔ | ✔ | ✔ | ✔ |
-| Ray                | `RayValue.Value`                | ✔ | ✔ | ✔ | ✔ |
-| Rect               | `ImageButton.SliceCenter`       | ✔ | ✔ | ✔ | ✔ |
-| Ref                | `Model.PrimaryPart`             | ✔ | ✔ | ✔ | ✔ |
-| Region3            | N/A                             | ✔ | ✔ | ❌ | ❌ |
-| Region3int16       | `Terrain.MaxExtents`            | ✔ | ✔ | ❌ | ❌ |
-| SharedString       | N/A                             | ✔ | ✔ | ✔ | ✔ |
-| String             | `Instance.Name`                 | ✔ | ✔ | ✔ | ✔ |
-| UDim               | `UIListLayout.Padding`          | ✔ | ✔ | ✔ | ✔ |
-| UDim2              | `Frame.Size`                    | ✔ | ✔ | ✔ | ✔ |
-| Vector2            | `ImageLabel.ImageRectSize`      | ✔ | ✔ | ✔ | ✔ |
-| Vector2int16       | N/A                             | ✔ | ✔ | ✔ | ❌ |
-| Vector3            | `Part.Size`                     | ✔ | ✔ | ✔ | ✔ |
-| Vector3int16       | `TerrainRegion.ExtentsMax`      | ✔ | ✔ | ✔ | ✔ |
-| QDir               | `Studio.Auto-Save Path`         | ⛔ | ⛔ | ⛔ | ⛔ |
-| QFont              | `Studio.Font`                   | ⛔ | ⛔ | ⛔ | ⛔ |
+| Property Type           | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary |
+|:------------------------|:--------------------------------|:---------:|:-----------:|:-------:|:----------:|
+| Axes                    | `ArcHandles.Axes`               | ✔         | ✔           | ✔       | ✔          |
+| BinaryString            | `Terrain.MaterialColors`        | ✔         | ➖          | ✔       | ✔          |
+| Bool                    | `Part.Anchored`                 | ✔         | ✔           | ✔       | ✔          |
+| BrickColor              | `Part.BrickColor`               | ✔         | ✔           | ✔       | ✔          |
+| CFrame                  | `Camera.CFrame`                 | ✔         | ✔           | ✔       | ✔          |
+| Color3                  | `Lighting.Ambient`              | ✔         | ✔           | ✔       | ✔          |
+| Color3uint8             | `Part.BrickColor`               | ✔         | ✔           | ✔       | ✔          |
+| ColorSequence           | `Beam.Color`                    | ✔         | ✔           | ✔       | ✔          |
+| Content                 | `Decal.Texture`                 | ✔         | ✔           | ✔       | ✔          |
+| Enum                    | `Part.Shape`                    | ✔         | ✔           | ✔       | ✔          |
+| Faces                   | `Handles.Faces`                 | ✔         | ✔           | ✔       | ✔          |
+| Float32                 | `Players.RespawnTime`           | ✔         | ✔           | ✔       | ✔          |
+| Float64                 | `Sound.PlaybackLoudness`        | ✔         | ✔           | ✔       | ✔          |
+| Int32                   | `Frame.ZIndex`                  | ✔         | ✔           | ✔       | ✔          |
+| Int64                   | `Player.UserId`                 | ✔         | ✔           | ✔       | ✔          |
+| NumberRange             | `ParticleEmitter.Lifetime`      | ✔         | ✔           | ✔       | ✔          |
+| NumberSequence          | `Beam.Transparency`             | ✔         | ✔           | ✔       | ✔          |
+| OptionalCoordinateFrame | `Model.WorldPivotData`          | ✔         | ❌          | ❌      | ✔          |
+| PhysicalProperties      | `Part.CustomPhysicalProperties` | ✔         | ✔           | ✔       | ✔          |
+| ProtectedString         | `ModuleScript.Source`           | ✔         | ✔           | ✔       | ✔          |
+| Ray                     | `RayValue.Value`                | ✔         | ✔           | ✔       | ✔          |
+| Rect                    | `ImageButton.SliceCenter`       | ✔         | ✔           | ✔       | ✔          |
+| Ref                     | `Model.PrimaryPart`             | ✔         | ✔           | ✔       | ✔          |
+| Region3                 | N/A                             | ✔         | ✔           | ❌      | ❌         |
+| Region3int16            | `Terrain.MaxExtents`            | ✔         | ✔           | ❌      | ❌         |
+| SharedString            | N/A                             | ✔         | ✔           | ✔       | ✔          |
+| String                  | `Instance.Name`                 | ✔         | ✔           | ✔       | ✔          |
+| UDim                    | `UIListLayout.Padding`          | ✔         | ✔           | ✔       | ✔          |
+| UDim2                   | `Frame.Size`                    | ✔         | ✔           | ✔       | ✔          |
+| Vector2                 | `ImageLabel.ImageRectSize`      | ✔         | ✔           | ✔       | ✔          |
+| Vector2int16            | N/A                             | ✔         | ✔           | ✔       | ❌         |
+| Vector3                 | `Part.Size`                     | ✔         | ✔           | ✔       | ✔          |
+| Vector3int16            | `TerrainRegion.ExtentsMax`      | ✔         | ✔           | ✔       | ✔          |
+| QDir                    | `Studio.Auto-Save Path`         | ⛔        | ⛔          | ⛔      | ⛔         |
+| QFont                   | `Studio.Font`                   | ⛔        | ⛔          | ⛔      | ⛔         |
 
 ✔ Implemented | ❌ Unimplemented | ➖ Partially Implemented | ⛔ Never
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 ## Property Type Coverage
 
 | Property Type           | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary |
-|:------------------------|:--------------------------------|:---------:|:-----------:|:-------:|:----------:|
+|:------------------------|:--------------------------------|:--:|:--:|:--:|:--:|
 | Axes                    | `ArcHandles.Axes`               | ✔ | ✔ | ✔ | ✔ |
 | BinaryString            | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
 | Bool                    | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |

--- a/README.md
+++ b/README.md
@@ -60,41 +60,41 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 
 | Property Type           | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary |
 |:------------------------|:--------------------------------|:---------:|:-----------:|:-------:|:----------:|
-| Axes                    | `ArcHandles.Axes`               | ✔         | ✔           | ✔       | ✔          |
-| BinaryString            | `Terrain.MaterialColors`        | ✔         | ➖          | ✔       | ✔          |
-| Bool                    | `Part.Anchored`                 | ✔         | ✔           | ✔       | ✔          |
-| BrickColor              | `Part.BrickColor`               | ✔         | ✔           | ✔       | ✔          |
-| CFrame                  | `Camera.CFrame`                 | ✔         | ✔           | ✔       | ✔          |
-| Color3                  | `Lighting.Ambient`              | ✔         | ✔           | ✔       | ✔          |
-| Color3uint8             | `Part.BrickColor`               | ✔         | ✔           | ✔       | ✔          |
-| ColorSequence           | `Beam.Color`                    | ✔         | ✔           | ✔       | ✔          |
-| Content                 | `Decal.Texture`                 | ✔         | ✔           | ✔       | ✔          |
-| Enum                    | `Part.Shape`                    | ✔         | ✔           | ✔       | ✔          |
-| Faces                   | `Handles.Faces`                 | ✔         | ✔           | ✔       | ✔          |
-| Float32                 | `Players.RespawnTime`           | ✔         | ✔           | ✔       | ✔          |
-| Float64                 | `Sound.PlaybackLoudness`        | ✔         | ✔           | ✔       | ✔          |
-| Int32                   | `Frame.ZIndex`                  | ✔         | ✔           | ✔       | ✔          |
-| Int64                   | `Player.UserId`                 | ✔         | ✔           | ✔       | ✔          |
-| NumberRange             | `ParticleEmitter.Lifetime`      | ✔         | ✔           | ✔       | ✔          |
-| NumberSequence          | `Beam.Transparency`             | ✔         | ✔           | ✔       | ✔          |
-| OptionalCoordinateFrame | `Model.WorldPivotData`          | ✔         | ❌          | ❌      | ✔          |
-| PhysicalProperties      | `Part.CustomPhysicalProperties` | ✔         | ✔           | ✔       | ✔          |
-| ProtectedString         | `ModuleScript.Source`           | ✔         | ✔           | ✔       | ✔          |
-| Ray                     | `RayValue.Value`                | ✔         | ✔           | ✔       | ✔          |
-| Rect                    | `ImageButton.SliceCenter`       | ✔         | ✔           | ✔       | ✔          |
-| Ref                     | `Model.PrimaryPart`             | ✔         | ✔           | ✔       | ✔          |
-| Region3                 | N/A                             | ✔         | ✔           | ❌      | ❌         |
-| Region3int16            | `Terrain.MaxExtents`            | ✔         | ✔           | ❌      | ❌         |
-| SharedString            | N/A                             | ✔         | ✔           | ✔       | ✔          |
-| String                  | `Instance.Name`                 | ✔         | ✔           | ✔       | ✔          |
-| UDim                    | `UIListLayout.Padding`          | ✔         | ✔           | ✔       | ✔          |
-| UDim2                   | `Frame.Size`                    | ✔         | ✔           | ✔       | ✔          |
-| Vector2                 | `ImageLabel.ImageRectSize`      | ✔         | ✔           | ✔       | ✔          |
-| Vector2int16            | N/A                             | ✔         | ✔           | ✔       | ❌         |
-| Vector3                 | `Part.Size`                     | ✔         | ✔           | ✔       | ✔          |
-| Vector3int16            | `TerrainRegion.ExtentsMax`      | ✔         | ✔           | ✔       | ✔          |
-| QDir                    | `Studio.Auto-Save Path`         | ⛔        | ⛔          | ⛔      | ⛔         |
-| QFont                   | `Studio.Font`                   | ⛔        | ⛔          | ⛔      | ⛔         |
+| Axes                    | `ArcHandles.Axes`               | ✔ | ✔ | ✔ | ✔ |
+| BinaryString            | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
+| Bool                    | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |
+| BrickColor              | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
+| CFrame                  | `Camera.CFrame`                 | ✔ | ✔ | ✔ | ✔ |
+| Color3                  | `Lighting.Ambient`              | ✔ | ✔ | ✔ | ✔ |
+| Color3uint8             | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
+| ColorSequence           | `Beam.Color`                    | ✔ | ✔ | ✔ | ✔ |
+| Content                 | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
+| Enum                    | `Part.Shape`                    | ✔ | ✔ | ✔ | ✔ |
+| Faces                   | `Handles.Faces`                 | ✔ | ✔ | ✔ | ✔ |
+| Float32                 | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
+| Float64                 | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |
+| Int32                   | `Frame.ZIndex`                  | ✔ | ✔ | ✔ | ✔ |
+| Int64                   | `Player.UserId`                 | ✔ | ✔ | ✔ | ✔ |
+| NumberRange             | `ParticleEmitter.Lifetime`      | ✔ | ✔ | ✔ | ✔ |
+| NumberSequence          | `Beam.Transparency`             | ✔ | ✔ | ✔ | ✔ |
+| OptionalCoordinateFrame | `Model.WorldPivotData`          | ✔ | ❌ | ❌ | ✔ |
+| PhysicalProperties      | `Part.CustomPhysicalProperties` | ✔ | ✔ | ✔ | ✔ |
+| ProtectedString         | `ModuleScript.Source`           | ✔ | ✔ | ✔ | ✔ |
+| Ray                     | `RayValue.Value`                | ✔ | ✔ | ✔ | ✔ |
+| Rect                    | `ImageButton.SliceCenter`       | ✔ | ✔ | ✔ | ✔ |
+| Ref                     | `Model.PrimaryPart`             | ✔ | ✔ | ✔ | ✔ |
+| Region3                 | N/A                             | ✔ | ✔ | ❌ | ❌ |
+| Region3int16            | `Terrain.MaxExtents`            | ✔ | ✔ | ❌ | ❌ |
+| SharedString            | N/A                             | ✔ | ✔ | ✔ | ✔ |
+| String                  | `Instance.Name`                 | ✔ | ✔ | ✔ | ✔ |
+| UDim                    | `UIListLayout.Padding`          | ✔ | ✔ | ✔ | ✔ |
+| UDim2                   | `Frame.Size`                    | ✔ | ✔ | ✔ | ✔ |
+| Vector2                 | `ImageLabel.ImageRectSize`      | ✔ | ✔ | ✔ | ✔ |
+| Vector2int16            | N/A                             | ✔ | ✔ | ✔ | ❌ |
+| Vector3                 | `Part.Size`                     | ✔ | ✔ | ✔ | ✔ |
+| Vector3int16            | `TerrainRegion.ExtentsMax`      | ✔ | ✔ | ✔ | ✔ |
+| QDir                    | `Studio.Auto-Save Path`         | ⛔ | ⛔ | ⛔ | ⛔ |
+| QFont                   | `Studio.Font`                   | ⛔ | ⛔ | ⛔ | ⛔ |
 
 ✔ Implemented | ❌ Unimplemented | ➖ Partially Implemented | ⛔ Never
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 
 ## Property Type Coverage
 
-| Property Type           | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary |
+| Property Type           | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary
 |:------------------------|:--------------------------------|:--:|:--:|:--:|:--:|
 | Axes                    | `ArcHandles.Axes`               | ✔ | ✔ | ✔ | ✔ |
 | BinaryString            | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |

--- a/format/binary.md
+++ b/format/binary.md
@@ -44,7 +44,8 @@ This document is based on:
 	- [Color3uint8](#color3uint8)
 	- [Int64](#int64)
 	- [SharedString](#sharedstring)
-- [Data Storage Notes](#data-storage-notes)
+	- [OptionalCoordinateFrame](#optionalcooordinateframe)
+	- [Data Storage Notes](#data-storage-notes)
 	- [Integer Transformations](#integer-transformations)
 	- [Byte Interleaving](#byte-interleaving)
 	- [Roblox Float Format](#roblox-float-format)
@@ -605,6 +606,15 @@ When an array of Int64s is present, the bytes of the integers are subject to [by
 **Type ID 0x1C**
 
 SharedStrings are stored as an [Interleaved Array](#byte-interleaving) of `u32`s that represent indices in the [`SSTR`](#sstr-chunk) string array.
+
+### OptionalCoordinateFrame
+**Type ID 0x1E**
+
+`OptionalCoordinateFrame` is stored the same way as [CFrame](#cframe), but with a couple interesting differences:
+* Immediately following OptionalCoordinateFrame's type ID is CFrame's type ID (0x10);
+* At the end of the chunk there is an array of Bools (preceded by Bool's type ID, 0x02) that indicates which OptionalCoordinateFrames have a value.
+
+An `OptionalCoordinateFrame` with value `CFrame.new(0, 0, 1, 0, -1, 0, 1, 0, 0, 0, 0, 1)` followed by an `OptionalCoordinateFrame` with no value looks like this: `1e 10 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7f 00 00 00 00 00 00 00 02 01 00`.
 
 ## Data Storage Notes
 

--- a/format/binary.md
+++ b/format/binary.md
@@ -614,7 +614,7 @@ SharedStrings are stored as an [Interleaved Array](#byte-interleaving) of `u32`s
 * Immediately following OptionalCoordinateFrame's type ID is CFrame's type ID (`10`);
 * At the end of the chunk there is an array of Bools (preceded by Bool's type ID, `02`) that indicates which OptionalCoordinateFrames have a value.
 
-An `OptionalCoordinateFrame` with value `CFrame.new(0, 0, 1, 0, -1, 0, 1, 0, 0, 0, 0, 1)` followed by an `OptionalCoordinateFrame` with no value looks like this: `10 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7f 00 00 00 00 00 00 00 02 01 00`.
+An `OptionalCoordinateFrame` with value `CFrame.new(0, 0, 1, 0, -1, 0, 1, 0, 0, 0, 0, 1)` followed by an `OptionalCoordinateFrame` with no value looks like this: `10 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7f 00 00 00 00 00 00 00 02 01 00`. Note that the valueless `OptionalCoordinateFrame` is written as the identity `CFrame` with its corresponding boolean `00` codifying its valuelessness.
 
 ## Data Storage Notes
 

--- a/format/binary.md
+++ b/format/binary.md
@@ -44,7 +44,7 @@ This document is based on:
 	- [Color3uint8](#color3uint8)
 	- [Int64](#int64)
 	- [SharedString](#sharedstring)
-	- [OptionalCoordinateFrame](#optionalcooordinateframe)
+	- [OptionalCoordinateFrame](#optionalcoordinateframe)
 	- [Data Storage Notes](#data-storage-notes)
 	- [Integer Transformations](#integer-transformations)
 	- [Byte Interleaving](#byte-interleaving)

--- a/format/binary.md
+++ b/format/binary.md
@@ -611,8 +611,8 @@ SharedStrings are stored as an [Interleaved Array](#byte-interleaving) of `u32`s
 **Type ID 0x1E**
 
 `OptionalCoordinateFrame` is stored the same way as [CFrame](#cframe), but with a couple interesting differences:
-* Immediately following OptionalCoordinateFrame's type ID is CFrame's type ID (0x10);
-* At the end of the chunk there is an array of Bools (preceded by Bool's type ID, 0x02) that indicates which OptionalCoordinateFrames have a value.
+* Immediately following OptionalCoordinateFrame's type ID is CFrame's type ID (`10`);
+* At the end of the chunk there is an array of Bools (preceded by Bool's type ID, `02`) that indicates which OptionalCoordinateFrames have a value.
 
 An `OptionalCoordinateFrame` with value `CFrame.new(0, 0, 1, 0, -1, 0, 1, 0, 0, 0, 0, 1)` followed by an `OptionalCoordinateFrame` with no value looks like this: `1e 10 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7f 00 00 00 00 00 00 00 02 01 00`.
 

--- a/format/binary.md
+++ b/format/binary.md
@@ -45,7 +45,7 @@ This document is based on:
 	- [Int64](#int64)
 	- [SharedString](#sharedstring)
 	- [OptionalCoordinateFrame](#optionalcoordinateframe)
-	- [Data Storage Notes](#data-storage-notes)
+- [Data Storage Notes](#data-storage-notes)
 	- [Integer Transformations](#integer-transformations)
 	- [Byte Interleaving](#byte-interleaving)
 	- [Roblox Float Format](#roblox-float-format)

--- a/format/binary.md
+++ b/format/binary.md
@@ -614,7 +614,7 @@ SharedStrings are stored as an [Interleaved Array](#byte-interleaving) of `u32`s
 * Immediately following OptionalCoordinateFrame's type ID is CFrame's type ID (`10`);
 * At the end of the chunk there is an array of Bools (preceded by Bool's type ID, `02`) that indicates which OptionalCoordinateFrames have a value.
 
-An `OptionalCoordinateFrame` with value `CFrame.new(0, 0, 1, 0, -1, 0, 1, 0, 0, 0, 0, 1)` followed by an `OptionalCoordinateFrame` with no value looks like this: `1e 10 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7f 00 00 00 00 00 00 00 02 01 00`.
+An `OptionalCoordinateFrame` with value `CFrame.new(0, 0, 1, 0, -1, 0, 1, 0, 0, 0, 0, 1)` followed by an `OptionalCoordinateFrame` with no value looks like this: `10 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7f 00 00 00 00 00 00 00 02 01 00`.
 
 ## Data Storage Notes
 

--- a/rbx_binary/src/cframe.rs
+++ b/rbx_binary/src/cframe.rs
@@ -144,6 +144,7 @@ pub(crate) fn from_basic_rotation_id(id: u8) -> Option<Matrix3> {
         _ => None,
     }
 }
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -787,7 +787,7 @@ impl<R: Read> BinaryDeserializer<R> {
                         } else {
                             return Err(InnerError::BadRotationId {
                                 type_name: type_info.type_name.clone(),
-                                prop_name: prop_name.clone(),
+                                prop_name,
                                 id,
                             });
                         }
@@ -1154,7 +1154,7 @@ impl<R: Read> BinaryDeserializer<R> {
                         } else {
                             return Err(InnerError::BadRotationId {
                                 type_name: type_info.type_name.clone(),
-                                prop_name: prop_name.clone(),
+                                prop_name,
                                 id,
                             });
                         }

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -1127,7 +1127,6 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     // Roblox writes a type marker for CFrame here that we don't
                     // need to use.
-
                     let cframe_type_id = chunk.read_u8()?;
                     assert!(
                         cframe_type_id == Type::CFrame as u8,

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -96,7 +96,7 @@ pub(crate) enum InnerError {
         id: u8,
     },
 
-    #[error("Expected type id for {expected_type_name}, ({expected_type_id}) when reading OptionalCFrame; got {actual_type_id}")]
+    #[error("Expected type id for {expected_type_name}, ({expected_type_id:02x}) when reading OptionalCFrame; got {actual_type_id:02x}")]
     BadOptionalCFrameFormat {
         expected_type_name: String,
         expected_type_id: u8,

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -1127,7 +1127,14 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     // Roblox writes a type marker for CFrame here that we don't
                     // need to use.
-                    assert!(chunk.read_u8()? == Type::CFrame as u8);
+
+                    let cframe_type_id = chunk.read_u8()?;
+                    assert!(
+                        cframe_type_id == Type::CFrame as u8,
+                        "Expected type id for CFrame ({}) when reading OptionalCFrame; got {}",
+                        Type::CFrame as u8,
+                        cframe_type_id,
+                    );
 
                     for _ in 0..referents.len() {
                         let id = chunk.read_u8()?;
@@ -1170,7 +1177,13 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     // Roblox writes a type marker for Bool here that we don't
                     // need to use.
-                    assert!(chunk.read_u8()? == Type::Bool as u8);
+                    let bool_type_id = chunk.read_u8()?;
+                    assert!(
+                        bool_type_id == Type::Bool as u8,
+                        "Expected type id for Bool ({}) when reading OptionalCFrame; got {}",
+                        Type::Bool as u8,
+                        bool_type_id,
+                    );
 
                     let values = x
                         .into_iter()

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -1127,7 +1127,7 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     // Roblox writes a type marker for CFrame here that we don't
                     // need to use.
-                    chunk.read_u8()?;
+                    assert!(chunk.read_u8()? == Type::CFrame as u8);
 
                     for _ in 0..referents.len() {
                         let id = chunk.read_u8()?;
@@ -1170,7 +1170,7 @@ impl<R: Read> BinaryDeserializer<R> {
 
                     // Roblox writes a type marker for Bool here that we don't
                     // need to use.
-                    chunk.read_u8()?;
+                    assert!(chunk.read_u8()? == Type::Bool as u8);
 
                     let values = x
                         .into_iter()

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -1200,7 +1200,7 @@ impl<R: Read> BinaryDeserializer<R> {
                         return Err(InnerError::PropTypeMismatch {
                             type_name: type_info.type_name.clone(),
                             prop_name,
-                            valid_type_names: "CFrame",
+                            valid_type_names: "OptionalCFrame",
                             actual_type_name: format!("{:?}", invalid_type),
                         });
                     }

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -96,7 +96,7 @@ pub(crate) enum InnerError {
         id: u8,
     },
 
-    #[error("Expected type id for {expected_type_name}, ({expected_type_id:02x}) when reading OptionalCFrame; got {actual_type_id:02x}")]
+    #[error("Expected type id for {expected_type_name} ({expected_type_id:02x}) when reading OptionalCFrame; got {actual_type_id:02x}")]
     BadOptionalCFrameFormat {
         expected_type_name: String,
         expected_type_id: u8,

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -1123,6 +1123,89 @@ impl<R: Read> BinaryDeserializer<R> {
                     })
                 }
             },
+            Type::OptionalCFrame => {
+                match canonical_type {
+                    VariantType::OptionalCFrame => {
+                        let referents = &type_info.referents;
+                        let mut rotations = Vec::with_capacity(referents.len());
+
+                        // Roblox writes a type marker for CFrame here that we don't
+                        // need to use.
+                        chunk.read_u8()?;
+
+                        for _ in 0..referents.len() {
+                            let id = chunk.read_u8()?;
+                            if id == 0 {
+                                rotations.push(Matrix3::new(
+                                    Vector3::new(
+                                        chunk.read_le_f32()?,
+                                        chunk.read_le_f32()?,
+                                        chunk.read_le_f32()?,
+                                    ),
+                                    Vector3::new(
+                                        chunk.read_le_f32()?,
+                                        chunk.read_le_f32()?,
+                                        chunk.read_le_f32()?,
+                                    ),
+                                    Vector3::new(
+                                        chunk.read_le_f32()?,
+                                        chunk.read_le_f32()?,
+                                        chunk.read_le_f32()?,
+                                    ),
+                                ));
+                            } else {
+                                let basic_rotation = cframe::from_basic_rotation_id(id)
+                                    .ok_or_else(|| InnerError::BadRotationId {
+                                        type_name: type_info.type_name.clone(),
+                                        prop_name: prop_name.clone(),
+                                        id,
+                                    })?;
+
+                                rotations.push(basic_rotation);
+                            }
+                        }
+
+                        let mut x = vec![0.0; referents.len()];
+                        let mut y = vec![0.0; referents.len()];
+                        let mut z = vec![0.0; referents.len()];
+
+                        chunk.read_interleaved_f32_array(&mut x)?;
+                        chunk.read_interleaved_f32_array(&mut y)?;
+                        chunk.read_interleaved_f32_array(&mut z)?;
+
+                        // Roblox writes a type marker for Bool here that we don't
+                        // need to use.
+                        chunk.read_u8()?;
+
+                        let values = x
+                            .into_iter()
+                            .zip(y)
+                            .zip(z)
+                            .map(|((x, y), z)| Vector3::new(x, y, z))
+                            .zip(rotations)
+                            .map(|(position, rotation)| {
+                                if chunk.read_u8().ok()? == 0 {
+                                    None
+                                } else {
+                                    Some(CFrame::new(position, rotation))
+                                }
+                            });
+
+                        for (cframe, referent) in values.zip(referents) {
+                            let instance = self.instances_by_ref.get_mut(referent).unwrap();
+                            instance.builder.add_property(&canonical_name, cframe);
+                        }
+                    }
+                    invalid_type => {
+                        return Err(InnerError::PropTypeMismatch {
+                            type_name: type_info.type_name.clone(),
+                            prop_name,
+                            valid_type_names: "CFrame",
+                            actual_type_name: format!("{:?}", invalid_type),
+                        });
+                    }
+                }
+            }
         }
 
         Ok(())

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -34,6 +34,7 @@ binary_tests! {
     faces,
     funny_numbervalue,
     funny_uipadding,
+    optionalcoordinateframe_models,
     three_beams,
     ref_adjacent,
     ref_child,

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__optionalcoordinateframe-models__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__optionalcoordinateframe-models__decoded.snap
@@ -1,0 +1,233 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: None
+  class: Model
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    LevelOfDetail:
+      Type: Enum
+      Value: 0
+    ModelInPrimary:
+      Type: CFrame
+      Value:
+        Position:
+          - 0.0
+          - 0.0
+          - 0.0
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    ModelMeshCFrame:
+      Type: CFrame
+      Value:
+        Position:
+          - 0.0
+          - 0.0
+          - 0.0
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+    NeedsPivotMigration:
+      Type: Bool
+      Value: false
+    PrimaryPart: "null"
+    SourceAssetId:
+      Type: Int64
+      Value: -1
+    Tags:
+      Type: BinaryString
+      Value: ""
+    WorldPivotData:
+      Type: OptionalCFrame
+      Value: ~
+  children: []
+- referent: referent-1
+  name: Some
+  class: Model
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    LevelOfDetail:
+      Type: Enum
+      Value: 0
+    ModelInPrimary:
+      Type: CFrame
+      Value:
+        Position:
+          - 0.0
+          - 0.0
+          - 0.0
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    ModelMeshCFrame:
+      Type: CFrame
+      Value:
+        Position:
+          - 0.0
+          - 0.0
+          - 0.0
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+    NeedsPivotMigration:
+      Type: Bool
+      Value: false
+    PrimaryPart: "null"
+    SourceAssetId:
+      Type: Int64
+      Value: -1
+    Tags:
+      Type: BinaryString
+      Value: ""
+    WorldPivotData:
+      Type: OptionalCFrame
+      Value:
+        Position:
+          - 1.0
+          - -1.0
+          - 0.5
+        Orientation:
+          - - 0.06294725090265274
+            - 0.4031980037689209
+            - 0.9129452705383301
+          - - 0.7524184584617615
+            - -0.620145320892334
+            - 0.22200526297092439
+          - - 0.6556707620620728
+            - 0.6729422211647034
+            - -0.34241002798080447
+  children: []
+- referent: referent-2
+  name: SomeInfNaN
+  class: Model
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    LevelOfDetail:
+      Type: Enum
+      Value: 0
+    ModelInPrimary:
+      Type: CFrame
+      Value:
+        Position:
+          - 0.0
+          - 0.0
+          - 0.0
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    ModelMeshCFrame:
+      Type: CFrame
+      Value:
+        Position:
+          - 0.0
+          - 0.0
+          - 0.0
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Type: Vector3
+      Value:
+        - 0.0
+        - 0.0
+        - 0.0
+    NeedsPivotMigration:
+      Type: Bool
+      Value: false
+    PrimaryPart: "null"
+    SourceAssetId:
+      Type: Int64
+      Value: -1
+    Tags:
+      Type: BinaryString
+      Value: ""
+    WorldPivotData:
+      Type: OptionalCFrame
+      Value:
+        Position:
+          - -0.5
+          - .inf
+          - .nan
+        Orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+  children: []

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__optionalcoordinateframe-models__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__optionalcoordinateframe-models__encoded.snap
@@ -1,0 +1,236 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Sstr:
+      version: 0
+      entries:
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+  - Inst:
+      type_id: 0
+      type_name: Model
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelInPrimary
+      prop_type: CFrame
+      values:
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - None
+        - Some
+        - SomeInfNaN
+  - Prop:
+      type_id: 0
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+        - -1
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - ~
+        - Position:
+            - 1.0
+            - -1.0
+            - 0.5
+          Orientation:
+            - - 0.06294725090265274
+              - 0.4031980037689209
+              - 0.9129452705383301
+            - - 0.7524184584617615
+              - -0.620145320892334
+              - 0.22200526297092439
+            - - 0.6556707620620728
+              - 0.6729422211647034
+              - -0.34241002798080447
+        - Position:
+            - -0.5
+            - .inf
+            - .nan
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__optionalcoordinateframe-models__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__optionalcoordinateframe-models__input.snap
@@ -1,0 +1,240 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Sstr:
+      version: 0
+      entries:
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+  - Inst:
+      type_id: 0
+      type_name: Model
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelInPrimary
+      prop_type: CFrame
+      values:
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+        - Position:
+            - 0.0
+            - 0.0
+            - 0.0
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - None
+        - Some
+        - SomeInfNaN
+  - Prop:
+      type_id: 0
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+        - -1
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - ~
+        - Position:
+            - 1.0
+            - -1.0
+            - 0.5
+          Orientation:
+            - - 0.06294725090265274
+              - 0.4031980037689209
+              - 0.9129452705383301
+            - - 0.7524184584617615
+              - -0.620145320892334
+              - 0.22200526297092439
+            - - 0.6556707620620728
+              - 0.6729422211647034
+              - -0.34241002798080447
+        - Position:
+            - -0.5
+            - .inf
+            - .nan
+          Orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -9,8 +9,8 @@ use std::{collections::HashMap, convert::TryInto, fmt::Write, io::Read};
 use rbx_dom_weak::types::{
     Axes, BrickColor, CFrame, Color3, Color3uint8, ColorSequence, ColorSequenceKeypoint,
     CustomPhysicalProperties, Enum, Faces, Matrix3, NumberRange, NumberSequence,
-    NumberSequenceKeypoint, OptionalCFrame, PhysicalProperties, Ray, Rect, SharedString, UDim,
-    UDim2, Vector2, Vector3, Vector3int16,
+    NumberSequenceKeypoint, PhysicalProperties, Ray, Rect, SharedString, UDim, UDim2, Vector2,
+    Vector3, Vector3int16,
 };
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 
@@ -221,7 +221,7 @@ pub enum DecodedValues {
     Color3uint8(Vec<Color3uint8>),
     Int64(Vec<i64>),
     SharedString(Vec<u32>), // For the text deserializer, we only show the index in the shared string array.
-    OptionalCFrame(Vec<OptionalCFrame>),
+    OptionalCFrame(Vec<Option<CFrame>>),
 }
 
 impl DecodedValues {

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -617,7 +617,13 @@ impl DecodedValues {
             Type::OptionalCFrame => {
                 let mut rotations = vec![Matrix3::identity(); prop_count];
 
-                assert!(reader.read_u8().unwrap() == Type::CFrame as u8);
+                let cframe_type_id = reader.read_u8().unwrap();
+                assert!(
+                    cframe_type_id == Type::CFrame as u8,
+                    "Expected type id for CFrame ({}) when reading OptionalCFrame; got {}",
+                    Type::CFrame as u8,
+                    cframe_type_id,
+                );
 
                 for rotation in rotations.iter_mut() {
                     let id = reader.read_u8().unwrap();
@@ -652,7 +658,13 @@ impl DecodedValues {
                 reader.read_interleaved_f32_array(&mut y).unwrap();
                 reader.read_interleaved_f32_array(&mut z).unwrap();
 
-                assert!(reader.read_u8().unwrap() == Type::Bool as u8);
+                let bool_type_id = reader.read_u8().unwrap();
+                assert!(
+                    bool_type_id == Type::Bool as u8,
+                    "Expected type id for Bool ({}) when reading OptionalCFrame; got {}",
+                    Type::Bool as u8,
+                    bool_type_id,
+                );
 
                 let values = x
                     .into_iter()

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -14,10 +14,7 @@ use rbx_dom_weak::types::{
 };
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 
-use crate::{
-    cframe::from_basic_rotation_id, chunk::Chunk, core::RbxReadExt, deserializer::FileHeader,
-    types::Type,
-};
+use crate::{cframe, chunk::Chunk, core::RbxReadExt, deserializer::FileHeader, types::Type};
 
 #[derive(Debug, Serialize)]
 pub struct DecodedModel {
@@ -384,7 +381,7 @@ impl DecodedValues {
                             ),
                         );
                     } else {
-                        *rotation = from_basic_rotation_id(id).unwrap();
+                        *rotation = cframe::from_basic_rotation_id(id).unwrap();
                     }
                 }
 

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -617,13 +617,7 @@ impl DecodedValues {
             Type::OptionalCFrame => {
                 let mut rotations = vec![Matrix3::identity(); prop_count];
 
-                let cframe_type_id = reader.read_u8().unwrap();
-                assert!(
-                    cframe_type_id == Type::CFrame as u8,
-                    "Expected type id for CFrame ({}) when reading OptionalCFrame; got {}",
-                    Type::CFrame as u8,
-                    cframe_type_id,
-                );
+                reader.read_u8().unwrap();
 
                 for rotation in rotations.iter_mut() {
                     let id = reader.read_u8().unwrap();
@@ -658,13 +652,7 @@ impl DecodedValues {
                 reader.read_interleaved_f32_array(&mut y).unwrap();
                 reader.read_interleaved_f32_array(&mut z).unwrap();
 
-                let bool_type_id = reader.read_u8().unwrap();
-                assert!(
-                    bool_type_id == Type::Bool as u8,
-                    "Expected type id for Bool ({}) when reading OptionalCFrame; got {}",
-                    Type::Bool as u8,
-                    bool_type_id,
-                );
+                reader.read_u8().unwrap();
 
                 let values = x
                     .into_iter()

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -617,7 +617,7 @@ impl DecodedValues {
             Type::OptionalCFrame => {
                 let mut rotations = vec![Matrix3::identity(); prop_count];
 
-                reader.read_u8().unwrap();
+                assert!(reader.read_u8().unwrap() == Type::CFrame as u8);
 
                 for rotation in rotations.iter_mut() {
                     let id = reader.read_u8().unwrap();
@@ -652,7 +652,7 @@ impl DecodedValues {
                 reader.read_interleaved_f32_array(&mut y).unwrap();
                 reader.read_interleaved_f32_array(&mut z).unwrap();
 
-                reader.read_u8().unwrap();
+                assert!(reader.read_u8().unwrap() == Type::Bool as u8);
 
                 let values = x
                     .into_iter()

--- a/rbx_binary/src/types.rs
+++ b/rbx_binary/src/types.rs
@@ -38,6 +38,7 @@ pub enum Type {
     Color3uint8 = 0x1A,
     Int64 = 0x1B,
     SharedString = 0x1C,
+    OptionalCFrame = 0x1E,
 }
 
 impl Type {
@@ -73,7 +74,7 @@ impl Type {
             VariantType::Color3uint8 => Type::Color3uint8,
             VariantType::Int64 => Type::Int64,
             VariantType::SharedString => Type::SharedString,
-
+            VariantType::OptionalCFrame => Type::OptionalCFrame,
             _ => return None,
         })
     }
@@ -108,6 +109,7 @@ impl Type {
             Type::Color3uint8 => VariantType::Color3uint8,
             Type::Int64 => VariantType::Int64,
             Type::SharedString => VariantType::SharedString,
+            Type::OptionalCFrame => VariantType::OptionalCFrame,
         })
     }
 }
@@ -145,6 +147,7 @@ impl TryFrom<u8> for Type {
             0x1A => Color3uint8,
             0x1B => Int64,
             0x1C => SharedString,
+            0x1E => OptionalCFrame,
             _ => return Err(InvalidTypeError(value)),
         })
     }

--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -166,6 +166,8 @@ impl CFrame {
     }
 }
 
+pub type OptionalCFrame = Option<CFrame>;
+
 /// Used to represent the `orientation` field of `CFrame` and not a standalone
 /// type in Roblox.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -166,8 +166,6 @@ impl CFrame {
     }
 }
 
-pub type OptionalCFrame = Option<CFrame>;
-
 /// Used to represent the `orientation` field of `CFrame` and not a standalone
 /// type in Roblox.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/rbx_types/src/variant.rs
+++ b/rbx_types/src/variant.rs
@@ -1,7 +1,7 @@
 use crate::{
     Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence, Content, Enum,
-    Faces, NumberRange, NumberSequence, OptionalCFrame, PhysicalProperties, Ray, Rect, Ref,
-    Region3, Region3int16, SharedString, UDim, UDim2, Vector2, Vector2int16, Vector3, Vector3int16,
+    Faces, NumberRange, NumberSequence, PhysicalProperties, Ray, Rect, Ref, Region3, Region3int16,
+    SharedString, UDim, UDim2, Vector2, Vector2int16, Vector3, Vector3int16,
 };
 
 /// Reduces boilerplate from listing different values of Variant by wrapping
@@ -126,7 +126,7 @@ make_variant! {
     Vector2int16(Vector2int16),
     Vector3(Vector3),
     Vector3int16(Vector3int16),
-    OptionalCFrame(OptionalCFrame),
+    OptionalCFrame(Option<CFrame>),
 }
 
 impl From<&'_ str> for Variant {

--- a/rbx_types/src/variant.rs
+++ b/rbx_types/src/variant.rs
@@ -1,7 +1,7 @@
 use crate::{
     Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence, Content, Enum,
-    Faces, NumberRange, NumberSequence, PhysicalProperties, Ray, Rect, Ref, Region3, Region3int16,
-    SharedString, UDim, UDim2, Vector2, Vector2int16, Vector3, Vector3int16,
+    Faces, NumberRange, NumberSequence, OptionalCFrame, PhysicalProperties, Ray, Rect, Ref,
+    Region3, Region3int16, SharedString, UDim, UDim2, Vector2, Vector2int16, Vector3, Vector3int16,
 };
 
 /// Reduces boilerplate from listing different values of Variant by wrapping
@@ -126,6 +126,7 @@ make_variant! {
     Vector2int16(Vector2int16),
     Vector3(Vector3),
     Vector3int16(Vector3int16),
+    OptionalCFrame(OptionalCFrame),
 }
 
 impl From<&'_ str> for Variant {


### PR DESCRIPTION
There's quite a bit of code duplicated between `CFrame` and `OptionalCFrame`. It's not clear to me how we can easily avoid it with the current structure of the code, especially in the deserializer.

`yaml-rust` serializes a `None` as a `~` in our snapshots. Do we want to change this, or is it okay?