### PR TITLE
Make generate_reflection save the fixture place automatically

### DIFF
--- a/generate_reflection/Cargo.toml
+++ b/generate_reflection/Cargo.toml
@@ -26,3 +26,4 @@ structopt = "0.3.9"
 tempfile = "3.1.0"
 tiny_http = "0.7.0"
 toml = "0.5.0"
+winapi = { version = "0.3.9", features = ["winuser", "impl-default"] }

--- a/generate_reflection/src/defaults_place.rs
+++ b/generate_reflection/src/defaults_place.rs
@@ -21,7 +21,10 @@ use rbx_reflection::{PropertyDescriptor, PropertyKind, PropertySerialization, Re
 use roblox_install::RobloxStudio;
 use tempfile::tempdir;
 
-use crate::plugin_injector::{PluginInjector, StudioInfo};
+use crate::{
+    plugin_injector::{PluginInjector, StudioInfo},
+    studio_keyboard::{Key, StudioKeyboard},
+};
 
 /// Use Roblox Studio to populate the reflection database with default values
 /// for as many properties as possible.
@@ -225,10 +228,8 @@ fn roundtrip_place_through_studio(place_contents: &str) -> anyhow::Result<Studio
     watcher.watch(&output_path, notify::RecursiveMode::NonRecursive)?;
 
     log::info!("Waiting for Roblox Studio to re-save place...");
-    println!("Please save the opened place in Roblox Studio (ctrl+s).");
-
-    // TODO: User currently has to manually save the place. We could use a crate
-    // like enigo or maybe raw input calls to do this for them.
+    let keyboard = StudioKeyboard::new(&studio_process);
+    keyboard.send_chord(&[Key::Control, Key::S]);
 
     loop {
         if let DebouncedEvent::Write(_) = rx.recv()? {

--- a/generate_reflection/src/main.rs
+++ b/generate_reflection/src/main.rs
@@ -2,6 +2,7 @@ mod api_dump;
 mod defaults_place;
 mod plugin_injector;
 mod property_patches;
+mod studio_keyboard;
 mod values;
 
 use std::fs;

--- a/generate_reflection/src/studio_keyboard.rs
+++ b/generate_reflection/src/studio_keyboard.rs
@@ -1,0 +1,150 @@
+use std::{mem::size_of, process, ptr};
+
+use winapi::{
+    ctypes::{c_int, c_uint},
+    shared::{
+        minwindef::{BOOL, DWORD, FALSE, LPARAM, TRUE, WORD},
+        windef::HWND__,
+    },
+    um::winuser::{
+        AttachThreadInput, EnumWindows, GetForegroundWindow, GetWindowThreadProcessId, INPUT_u,
+        IsWindowVisible, SendInput, SetForegroundWindow, INPUT, INPUT_KEYBOARD, KEYBDINPUT,
+        KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, VK_LCONTROL, VK_LWIN, VK_MENU, VK_RWIN, VK_SHIFT,
+    },
+};
+
+#[derive(Clone, Copy)]
+#[repr(i32)]
+pub enum Key {
+    Control = VK_LCONTROL,
+    S = 0x53,
+    Alt = VK_MENU,
+    Shift = VK_SHIFT,
+    LeftWindows = VK_LWIN,
+    RightWindows = VK_RWIN,
+}
+
+#[derive(Clone, Copy)]
+#[repr(u32)]
+enum Flags {
+    ExtKeyUp = KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP,
+    KeyDown = 0,
+    KeyUp = KEYEVENTF_KEYUP,
+}
+
+pub struct StudioKeyboard<'a> {
+    process: &'a process::Child,
+}
+
+#[derive(Clone, Copy)]
+struct KeyEvent<'a> {
+    func: &'a dyn Fn(),
+    process_id: u32,
+}
+
+impl<'a> StudioKeyboard<'a> {
+    pub fn new(process: &'a process::Child) -> StudioKeyboard {
+        Self { process }
+    }
+
+    pub fn send_chord(&self, keys: &[Key]) {
+        self.hook(|| {
+            Self::send_input(keys, Flags::KeyDown);
+            Self::send_input(keys, Flags::KeyUp);
+        });
+    }
+
+    fn hook<F>(&self, func: F)
+    where
+        F: Fn(),
+    {
+        let key_event = KeyEvent {
+            func: &func,
+            process_id: self.process.id(),
+        };
+
+        unsafe extern "system" fn callback(window: *mut HWND__, event_ptr: LPARAM) -> BOOL {
+            let mut window_process: DWORD = 0;
+            let window_thread = GetWindowThreadProcessId(window, &mut window_process as *mut _);
+            let key_event = event_ptr as *const KeyEvent;
+
+            if window_process == (*key_event).process_id && IsWindowVisible(window) == TRUE {
+                StudioKeyboard::try_attach(window_thread, *key_event);
+                FALSE
+            } else {
+                TRUE
+            }
+        }
+
+        unsafe { EnumWindows(Some(callback), &key_event as *const _ as LPARAM) };
+    }
+
+    fn try_attach(thread: DWORD, key_event: KeyEvent) {
+        let foreground_window = unsafe { GetForegroundWindow() };
+        let foreground_thread =
+            unsafe { GetWindowThreadProcessId(GetForegroundWindow(), ptr::null_mut()) };
+
+        // This is a hack! We attach Roblox Studio's input processing to the current
+        // foreground thread's to ensure Studio receives our keystrokes.
+
+        // AttachThreadInput fails when the attached-to thread is a system thread, or if
+        // the attached-to thread doesn't have an input queue. This can happen when the
+        // Start Menu or a Command Prompt window is open, among others. Studio will not
+        // receive our keystrokes in these cases, so we bail out early.
+
+        // AttachThreadInput also fails when the thread IDs are equal. This means Studio
+        // is in the foreground and has keyboard focus. Studio will process our keystrokes
+        // in this case, so we can continue.
+        if foreground_thread != thread
+            && unsafe { AttachThreadInput(thread, foreground_thread, TRUE) } == 0
+        {
+            log::warn!(
+                "Failed to send keystrokes to Roblox Studio. Please save the place manually."
+            )
+        } else {
+            // AttachThreadInput makes the threads share input state, so we need to clear
+            // any modifiers that can mess up our keypresses - the "extended" keys are
+            // ones on the right side of the keyboard.
+            Self::send_input(&[Key::Alt, Key::Shift, Key::LeftWindows], Flags::KeyUp);
+            Self::send_input(&[Key::Alt, Key::Shift, Key::RightWindows], Flags::ExtKeyUp);
+            (key_event.func)();
+
+            unsafe {
+                AttachThreadInput(thread, foreground_thread, FALSE);
+                SetForegroundWindow(foreground_window);
+            }
+        };
+    }
+
+    fn send_input(keys: &[Key], flags: Flags) {
+        let mut inputs: Vec<INPUT> = keys
+            .iter()
+            .map(|key| {
+                let mut input = INPUT_u::default();
+
+                unsafe {
+                    *input.ki_mut() = KEYBDINPUT {
+                        dwExtraInfo: 0,
+                        dwFlags: flags as DWORD,
+                        time: 0,
+                        wScan: 0,
+                        wVk: *key as WORD,
+                    };
+                };
+
+                INPUT {
+                    type_: INPUT_KEYBOARD,
+                    u: input,
+                }
+            })
+            .collect();
+
+        unsafe {
+            SendInput(
+                inputs.len() as c_uint,
+                inputs.as_mut_ptr(),
+                size_of::<INPUT>() as c_int,
+            )
+        };
+    }
+}


### PR DESCRIPTION
enigo has some problems (at least on Windows)<sup>1</sup>, and to get this to work more-or-less reliably we need to do things with the WinAPI that no crate I'm aware of currently does... so we'll do it live! 

This PR adds the struct `StudioKeyboard` that can send keystrokes to Roblox Studio, or indeed any process' top-level visible window. It does so by attaching Roblox Studio's input processing mechanism to the current foreground thread's via `AttachThreadInput` and sending keyboard events with `SendInput`. AutoHotKey also uses this technique. 

The failure cases feel kind of bad as an end user who is probably using cmd or powershell, but it definitely makes it easier for us to use this tool and makes it possible to run it on a CI machine. 

<sup>1</sup>For example, it uses a `transmute_copy` that invokes UB  to create keyboard events. It also doesn't properly use `SendInput` - the entire point is that it can insert multiple events serially into the input stream (which is why it takes an array), but enigo only passes one at a time!