### PR TITLE
Add an option to disable reflection in `rbx_binary`

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_binary Changelog
 
 ## Unreleased
+* Added an option to disable property reflection in the deserializer.
 
 ## 0.6.0-alpha.5 (2021-05-14)
 * Added `OptionalCoordinateFrame` support. ([#176][pr-176])

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -1083,7 +1083,7 @@ impl<R: Read> BinaryDeserializer<R> {
                 }
             },
             Type::Color3uint8 => match canonical_type {
-                VariantType::Color3 => {
+                VariantType::Color3 | VariantType::Color3uint8 => {
                     let len = type_info.referents.len();
                     let mut r = vec![0; len];
                     let mut g = vec![0; len];

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -30,10 +30,20 @@ pub mod text_format {
 
 pub use crate::{deserializer::Error as DecodeError, serializer::Error as EncodeError};
 
+pub use deserializer::DecodePropertyBehavior;
+
 /// Decodes an binary format model or place from something that implements the
 /// `std::io::Read` trait.
 pub fn from_reader_default<R: Read>(reader: R) -> Result<WeakDom, DecodeError> {
-    decode(reader)
+    decode(reader, DecodePropertyBehavior::Default)
+}
+
+/// Decodes a binary format model or place using the provided decode behavior.
+pub fn from_reader<R: Read>(
+    reader: R,
+    decode_behavior: DecodePropertyBehavior,
+) -> Result<WeakDom, DecodeError> {
+    decode(reader, decode_behavior)
 }
 
 /// Serializes a subset of the given DOM to a binary format model or place,

--- a/rbx_binary/src/tests/util.rs
+++ b/rbx_binary/src/tests/util.rs
@@ -2,7 +2,11 @@ use std::{fs, path::Path};
 
 use rbx_dom_weak::DomViewer;
 
-use crate::{deserializer::decode, encode, text_deserializer::DecodedModel};
+use crate::{
+    deserializer::{decode, DecodePropertyBehavior},
+    encode,
+    text_deserializer::DecodedModel,
+};
 
 /// Run a basic gauntlet of tests to verify that the serializer and deserializer
 /// can handle this model correctly.
@@ -28,7 +32,7 @@ pub fn run_model_base_suite(model_path: impl AsRef<Path>) {
 
     // Decode the test file and snapshot a stable version of the resulting tree.
     // This should properly test the deserializer.
-    let decoded = decode(contents.as_slice()).unwrap();
+    let decoded = decode(contents.as_slice(), DecodePropertyBehavior::Default).unwrap();
     let decoded_viewed = DomViewer::new().view_children(&decoded);
     insta::assert_yaml_snapshot!(format!("{}__decoded", model_stem), decoded_viewed);
 
@@ -51,5 +55,5 @@ pub fn run_model_base_suite(model_path: impl AsRef<Path>) {
     // We don't make any assertions about the result right now, as our format
     // support is still lacking. In the future, we should assert that this is
     // the same as the original decoding of the test file.
-    decode(encoded.as_slice()).unwrap();
+    decode(encoded.as_slice(), DecodePropertyBehavior::Default).unwrap();
 }


### PR DESCRIPTION
`rbx_binary` needs to bypass the reflection database for #181. This PR thus adds the enum `DecodePropertyBehavior` to the deserializer. It has two variants: `Default` and `NoReflection`. `Default` corresponds to the original behavior. `NoReflection` causes the deserializer to read property names and types verbatim without consulting the reflection database.

`rbx_xml` has a similar mechanism: the struct `DecodeOptions`. I'm not 100% on whether we should also use such a struct here, or if an enum is enough (since we only need the one option). I'm also not 100% on the ramifications of totally bypassing reflection here - there might be something spooky that I've missed!