### PR TITLE
Fix null refs not being written for invalid instance IDs

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 * Fixed null Refs not being written for unserialized instances. ([#184][pr-184])
 
-[pr-184]: https://github.com/rojo-rbx/pull/184
+[pr-184]: https://github.com/rojo-rbx/rbx-dom/pull/184
 
 ## 0.6.0-alpha.5 (2021-05-14)
 * Added `OptionalCoordinateFrame` support. ([#176][pr-176])

--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,7 +1,7 @@
 # rbx_binary Changelog
 
 ## Unreleased
-* Fixed null Refs not being written for unserialized instances. [#184][pr-184]
+* Fixed null Refs not being written for unserialized instances.
 
 ## 0.6.0-alpha.5 (2021-05-14)
 * Added `OptionalCoordinateFrame` support. ([#176][pr-176])

--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,7 +1,9 @@
 # rbx_binary Changelog
 
 ## Unreleased
-* Fixed null Refs not being written for unserialized instances.
+* Fixed null Refs not being written for unserialized instances. ([#184][pr-184])
+
+[pr-184]: https://github.com/rojo-rbx/pull/184
 
 ## 0.6.0-alpha.5 (2021-05-14)
 * Added `OptionalCoordinateFrame` support. ([#176][pr-176])

--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_binary Changelog
 
 ## Unreleased
+* Fixed null Refs not being written for unserialized instances. [#184][pr-184]
 
 ## 0.6.0-alpha.5 (2021-05-14)
 * Added `OptionalCoordinateFrame` support. ([#176][pr-176])

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -892,10 +892,10 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
 
                         for (i, rbx_value) in values {
                             if let Variant::Ref(value) = rbx_value.as_ref() {
-                                if value.is_none() {
-                                    buf.push(-1);
-                                } else if let Some(id) = self.id_to_referent.get(value) {
+                                if let Some(id) = self.id_to_referent.get(value) {
                                     buf.push(*id);
+                                } else {
+                                    buf.push(-1);
                                 }
                             } else {
                                 return type_mismatch(i, &rbx_value, "Ref");


### PR DESCRIPTION
The serializer does not handle the case where an instance ID refers to an unserialized instance, resulting in nothing being written. This PR ensures that the null `Ref` is written for all IDs that do not refer to an instance, whether their Refs are `None` or are simply invalid.