### PR TITLE
Specify CSK value as color components

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -514,13 +514,15 @@ The `ColorSequence` type is stored as a `u32` indicating how many `ColorSequence
 
 `ColorSequenceKeypoint` is a struct composed of the following fields:
 
-| Field Name        | Format              | Value                                          |
-|:------------------|:--------------------|:-----------------------------------------------|
-| Time              | `f32`               | The time value of the `ColorSequenceKeypoint`  |
-| Color             | [`Color3`](#Color3) | The color value of the `ColorSequenceKeypoint` |
-| Envelope (unused) | `f32`               | n/a; serialized, but not used                  |
+| Field Name        | Format              | Value                                              |
+|:------------------|:--------------------|:---------------------------------------------------|
+| Time              | `f32`               | The time value of the `ColorSequenceKeypoint`      |
+| ColorR            | `f32`               | The red component of the keypoint's color value.   |
+| ColorG            | `f32`               | The green component of the keypoint's color value. |
+| ColorB            | `f32`               | The blue component of the keypoint's color value.  |
+| Envelope (unused) | `f32`               | n/a; serialized, but not used                      |
 
-Note that `Color` is **not** subject to interleaving like a normal `Color3`. When multiple `ColorSequence` values are present, they are stored in sequence with no transformation or interleaving. Two `ColorSequence` values
+When multiple `ColorSequence` values are present, they are stored in sequence with no transformation or interleaving. Two `ColorSequence` values
 
 ```lua
 ColorSequence.new(

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -514,13 +514,13 @@ The `ColorSequence` type is stored as a `u32` indicating how many `ColorSequence
 
 `ColorSequenceKeypoint` is a struct composed of the following fields:
 
-| Field Name        | Format              | Value                                              |
-|:------------------|:--------------------|:---------------------------------------------------|
-| Time              | `f32`               | The time value of the `ColorSequenceKeypoint`      |
-| ColorR            | `f32`               | The red component of the keypoint's color value.   |
-| ColorG            | `f32`               | The green component of the keypoint's color value. |
-| ColorB            | `f32`               | The blue component of the keypoint's color value.  |
-| Envelope (unused) | `f32`               | n/a; serialized, but not used                      |
+| Field Name        | Format | Value                                              |
+|:------------------|:-------|:---------------------------------------------------|
+| Time              | `f32`  | The time value of the `ColorSequenceKeypoint`      |
+| R                 | `f32`  | The red component of the keypoint's color value.   |
+| G                 | `f32`  | The green component of the keypoint's color value. |
+| B                 | `f32`  | The blue component of the keypoint's color value.  |
+| Envelope (unused) | `f32`  | n/a; serialized, but not used                      |
 
 When multiple `ColorSequence` values are present, they are stored in sequence with no transformation or interleaving. Two `ColorSequence` values
 


### PR DESCRIPTION
Instead of treating the Color field of ColorSequenceKeypoint as an exception, CSK is specified as having fields for each color component. This is similar to how Ray is specified as six floats instead of two Vector3s.