### PR TITLE
Rename OptionalCoordinateFrame to Optional and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,43 +58,43 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 
 ## Property Type Coverage
 
-| Property Type           | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary
-|:------------------------|:--------------------------------|:--:|:--:|:--:|:--:|
-| Axes                    | `ArcHandles.Axes`               | ✔ | ✔ | ✔ | ✔ |
-| BinaryString            | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
-| Bool                    | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |
-| BrickColor              | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
-| CFrame                  | `Camera.CFrame`                 | ✔ | ✔ | ✔ | ✔ |
-| Color3                  | `Lighting.Ambient`              | ✔ | ✔ | ✔ | ✔ |
-| Color3uint8             | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
-| ColorSequence           | `Beam.Color`                    | ✔ | ✔ | ✔ | ✔ |
-| Content                 | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
-| Enum                    | `Part.Shape`                    | ✔ | ✔ | ✔ | ✔ |
-| Faces                   | `Handles.Faces`                 | ✔ | ✔ | ✔ | ✔ |
-| Float32                 | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
-| Float64                 | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |
-| Int32                   | `Frame.ZIndex`                  | ✔ | ✔ | ✔ | ✔ |
-| Int64                   | `Player.UserId`                 | ✔ | ✔ | ✔ | ✔ |
-| NumberRange             | `ParticleEmitter.Lifetime`      | ✔ | ✔ | ✔ | ✔ |
-| NumberSequence          | `Beam.Transparency`             | ✔ | ✔ | ✔ | ✔ |
-| OptionalCoordinateFrame | `Model.WorldPivotData`          | ✔ | ❌ | ✔ | ✔ |
-| PhysicalProperties      | `Part.CustomPhysicalProperties` | ✔ | ✔ | ✔ | ✔ |
-| ProtectedString         | `ModuleScript.Source`           | ✔ | ✔ | ✔ | ✔ |
-| Ray                     | `RayValue.Value`                | ✔ | ✔ | ✔ | ✔ |
-| Rect                    | `ImageButton.SliceCenter`       | ✔ | ✔ | ✔ | ✔ |
-| Ref                     | `Model.PrimaryPart`             | ✔ | ✔ | ✔ | ✔ |
-| Region3                 | N/A                             | ✔ | ✔ | ❌ | ❌ |
-| Region3int16            | `Terrain.MaxExtents`            | ✔ | ✔ | ❌ | ❌ |
-| SharedString            | N/A                             | ✔ | ✔ | ✔ | ✔ |
-| String                  | `Instance.Name`                 | ✔ | ✔ | ✔ | ✔ |
-| UDim                    | `UIListLayout.Padding`          | ✔ | ✔ | ✔ | ✔ |
-| UDim2                   | `Frame.Size`                    | ✔ | ✔ | ✔ | ✔ |
-| Vector2                 | `ImageLabel.ImageRectSize`      | ✔ | ✔ | ✔ | ✔ |
-| Vector2int16            | N/A                             | ✔ | ✔ | ✔ | ❌ |
-| Vector3                 | `Part.Size`                     | ✔ | ✔ | ✔ | ✔ |
-| Vector3int16            | `TerrainRegion.ExtentsMax`      | ✔ | ✔ | ✔ | ✔ |
-| QDir                    | `Studio.Auto-Save Path`         | ⛔ | ⛔ | ⛔ | ⛔ |
-| QFont                   | `Studio.Font`                   | ⛔ | ⛔ | ⛔ | ⛔ |
+| Property Type      | Example Property                | rbx_types | rbx_dom_lua | rbx_xml | rbx_binary
+|:-------------------|:--------------------------------|:--:|:--:|:--:|:--:|
+| Axes               | `ArcHandles.Axes`               | ✔ | ✔ | ✔ | ✔ |
+| BinaryString       | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
+| Bool               | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |
+| BrickColor         | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
+| CFrame             | `Camera.CFrame`                 | ✔ | ✔ | ✔ | ✔ |
+| Color3             | `Lighting.Ambient`              | ✔ | ✔ | ✔ | ✔ |
+| Color3uint8        | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
+| ColorSequence      | `Beam.Color`                    | ✔ | ✔ | ✔ | ✔ |
+| Content            | `Decal.Texture`                 | ✔ | ✔ | ✔ | ✔ |
+| Enum               | `Part.Shape`                    | ✔ | ✔ | ✔ | ✔ |
+| Faces              | `Handles.Faces`                 | ✔ | ✔ | ✔ | ✔ |
+| Float32            | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
+| Float64            | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |
+| Int32              | `Frame.ZIndex`                  | ✔ | ✔ | ✔ | ✔ |
+| Int64              | `Player.UserId`                 | ✔ | ✔ | ✔ | ✔ |
+| NumberRange        | `ParticleEmitter.Lifetime`      | ✔ | ✔ | ✔ | ✔ |
+| NumberSequence     | `Beam.Transparency`             | ✔ | ✔ | ✔ | ✔ |
+| Optional           | `Model.WorldPivotData`          | ✔ | ❌ | ✔ | ✔ |
+| PhysicalProperties | `Part.CustomPhysicalProperties` | ✔ | ✔ | ✔ | ✔ |
+| ProtectedString    | `ModuleScript.Source`           | ✔ | ✔ | ✔ | ✔ |
+| Ray                | `RayValue.Value`                | ✔ | ✔ | ✔ | ✔ |
+| Rect               | `ImageButton.SliceCenter`       | ✔ | ✔ | ✔ | ✔ |
+| Ref                | `Model.PrimaryPart`             | ✔ | ✔ | ✔ | ✔ |
+| Region3            | N/A                             | ✔ | ✔ | ❌ | ❌ |
+| Region3int16       | `Terrain.MaxExtents`            | ✔ | ✔ | ❌ | ❌ |
+| SharedString       | N/A                             | ✔ | ✔ | ✔ | ✔ |
+| String             | `Instance.Name`                 | ✔ | ✔ | ✔ | ✔ |
+| UDim               | `UIListLayout.Padding`          | ✔ | ✔ | ✔ | ✔ |
+| UDim2              | `Frame.Size`                    | ✔ | ✔ | ✔ | ✔ |
+| Vector2            | `ImageLabel.ImageRectSize`      | ✔ | ✔ | ✔ | ✔ |
+| Vector2int16       | N/A                             | ✔ | ✔ | ✔ | ❌ |
+| Vector3            | `Part.Size`                     | ✔ | ✔ | ✔ | ✔ |
+| Vector3int16       | `TerrainRegion.ExtentsMax`      | ✔ | ✔ | ✔ | ✔ |
+| QDir               | `Studio.Auto-Save Path`         | ⛔ | ⛔ | ⛔ | ⛔ |
+| QFont              | `Studio.Font`                   | ⛔ | ⛔ | ⛔ | ⛔ |
 
 ✔ Implemented | ❌ Unimplemented | ➖ Partially Implemented | ⛔ Never
 


### PR DESCRIPTION
As per #193:
 - Rename `OptionalCoordinateFrame` to `Optional`
 - Revamp the `PROP` chunk description to make `Values` its own field
 - Redefine `Optional` to be a struct composed of two `Values`

Notably, I did not indicate that the `Values` field of `PROP` is optional, despite it being proposed in #193. This is because the one time it has been not present, it was indicated to be a mistake by the engineer responsible so I don't anticipate it happening again. It also complicates implementations somewhat to assume it's optional, so I'd prefer we not.

I am more than open to feedback on the phrasing or layout of the revisions because I'm not certain of them, but this should be a good starting point if nothing else.