### PR TITLE
Add conversions between Color3 and Color3uint8

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -948,9 +948,11 @@ impl<'a, W: Write> SerializerState<'a, W> {
                                     b.push(value.b);
                                 }
                                 Variant::Color3(value) => {
-                                    r.push((value.r.max(0.0).min(1.0) * 255.0).round() as u8);
-                                    g.push((value.g.max(0.0).min(1.0) * 255.0).round() as u8);
-                                    b.push((value.b.max(0.0).min(1.0) * 255.0).round() as u8);
+                                    let color3uint8: Color3uint8 = (*value).into();
+
+                                    r.push(color3uint8.r);
+                                    g.push(color3uint8.g);
+                                    b.push(color3uint8.b);
                                 }
                                 _ => return type_mismatch(i, &rbx_value, "Color3uint8 or Color3"),
                             }

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -948,11 +948,11 @@ impl<'a, W: Write> SerializerState<'a, W> {
                                     b.push(value.b);
                                 }
                                 Variant::Color3(value) => {
-                                    let color3uint8: Color3uint8 = (*value).into();
+                                    let color: Color3uint8 = (*value).into();
 
-                                    r.push(color3uint8.r);
-                                    g.push(color3uint8.g);
-                                    b.push(color3uint8.b);
+                                    r.push(color.r);
+                                    g.push(color.g);
+                                    b.push(color.b);
                                 }
                                 _ => return type_mismatch(i, &rbx_value, "Color3uint8 or Color3"),
                             }

--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_types Changelog
 
 ## Unreleased Changes
+* Implemented `From<Color3>` for `Color3uint8` and `From<Color3uint8>` for `Color3`.
 
 ## 1.1.0 (2021-07-02)
 * Critical fix: changed serde serialization of fields from PascalCase to camelCase. ([#191][#191])

--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -248,6 +248,16 @@ impl Color3uint8 {
     }
 }
 
+impl From<Color3> for Color3uint8 {
+    fn from(color3: Color3) -> Self {
+        Self {
+            r: ((color3.r.max(0.0).min(1.0)) * 255.0).round() as u8,
+            g: ((color3.g.max(0.0).min(1.0)) * 255.0).round() as u8,
+            b: ((color3.b.max(0.0).min(1.0)) * 255.0).round() as u8,
+        }
+    }
+}
+
 /// Represents a ray in 3D space. Direction does not have to be a unit vector,
 /// and is used by APIs like [`Workspace:FindPartOnRay`][FindPartOnRay] to set a
 /// max distance.

--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -215,6 +215,16 @@ impl Color3 {
     }
 }
 
+impl From<Color3uint8> for Color3 {
+    fn from(color3uint8: Color3uint8) -> Self {
+        Self {
+            r: color3uint8.r as f32 / 255.0,
+            g: color3uint8.g as f32 / 255.0,
+            b: color3uint8.b as f32 / 255.0,
+        }
+    }
+}
+
 /// Represents non-HDR colors, i.e. those whose individual color channels do not
 /// exceed 1. This type is used for serializing properties like
 /// [`BasePart.Color`][BasePart.Color], but is not exposed as a distinct type to

--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -216,11 +216,11 @@ impl Color3 {
 }
 
 impl From<Color3uint8> for Color3 {
-    fn from(color3uint8: Color3uint8) -> Self {
+    fn from(value: Color3uint8) -> Self {
         Self {
-            r: color3uint8.r as f32 / 255.0,
-            g: color3uint8.g as f32 / 255.0,
-            b: color3uint8.b as f32 / 255.0,
+            r: value.r as f32 / 255.0,
+            g: value.g as f32 / 255.0,
+            b: value.b as f32 / 255.0,
         }
     }
 }
@@ -249,11 +249,11 @@ impl Color3uint8 {
 }
 
 impl From<Color3> for Color3uint8 {
-    fn from(color3: Color3) -> Self {
+    fn from(value: Color3) -> Self {
         Self {
-            r: ((color3.r.max(0.0).min(1.0)) * 255.0).round() as u8,
-            g: ((color3.g.max(0.0).min(1.0)) * 255.0).round() as u8,
-            b: ((color3.b.max(0.0).min(1.0)) * 255.0).round() as u8,
+            r: ((value.r.max(0.0).min(1.0)) * 255.0).round() as u8,
+            g: ((value.g.max(0.0).min(1.0)) * 255.0).round() as u8,
+            b: ((value.b.max(0.0).min(1.0)) * 255.0).round() as u8,
         }
     }
 }

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,7 +1,7 @@
 # rbx_xml Changelog
 
 ## Unreleased
-* Added conversion from `Color3` to `Color3uint8` to address [rojo-rbx/rojo#443][https://github.com/rojo-rbx/rojo/issues/443].
+* Added conversion from `Color3` to `Color3uint8` to address [rojo-rbx/rojo#443](https://github.com/rojo-rbx/rojo/issues/443).
 
 ## 0.12.1 (2021-07-02)
 * Upgraded to rbx\_dom\_weak 2.1.

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* Added conversion from `Color3` to `Color3uint8` to address [rojo-rbx/rojo#443][https://github.com/rojo-rbx/rojo/issues/443].
 
 ## 0.12.1 (2021-07-02)
 * Upgraded to rbx\_dom\_weak 2.1.

--- a/rbx_xml/src/conversion.rs
+++ b/rbx_xml/src/conversion.rs
@@ -4,7 +4,7 @@
 use std::borrow::{Borrow, Cow};
 use std::convert::TryInto;
 
-use rbx_dom_weak::types::{BrickColor, Variant, VariantType};
+use rbx_dom_weak::types::{BrickColor, Color3uint8, Variant, VariantType};
 
 pub trait ConvertVariant: Clone + Sized {
     fn try_convert(self, target_type: VariantType) -> Result<Self, String> {
@@ -36,6 +36,9 @@ impl ConvertVariant for Variant {
                     .ok_or_else(|| format!("{} is not a valid BrickColor number", value))
                     .map(Into::into)
                     .map(Cow::Owned)
+            }
+            (Variant::Color3(value), VariantType::Color3uint8) => {
+                Ok(Cow::Owned(Color3uint8::from(*value).into()))
             }
             (_, _) => Ok(value),
         }


### PR DESCRIPTION
`BasePart.Color` was being incorrectly serialized as a `Color3` instead of a `Color3uint8` in the XML format, as per rojo-rbx/rojo#443. This PR adds conversions between these two types mainly to address this issue, but also because they will likely be useful in the future.