### PR TITLE
Add custom reader/writer for CollisionGroups in rbx_dom_lua

### DIFF
--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -1,9 +1,117 @@
 local CollectionService = game:GetService("CollectionService")
+local PhysicsService = game:GetService("PhysicsService")
+local HttpService = game:GetService("HttpService")
+
+local function encodeCollisionGroup(collisionGroup)
+	return string.format("%s^%i^%i", collisionGroup.name, collisionGroup.id, collisionGroup.mask)
+end
+
+local function decodeCollisionGroup(encodedCollisionGroup)
+	local decoded = string.split(encodedCollisionGroup, "^")
+
+	return {
+		name = decoded[1],
+		id = tonumber(decoded[2]),
+		mask = tonumber(decoded[3]),
+	}
+end
 
 -- Defines how to read and write properties that aren't directly scriptable.
 --
 -- The reflection database refers to these as having scriptability = "Custom"
 return {
+	Workspace = {
+		CollisionGroups = {
+			read = function()
+				local collisionGroups = PhysicsService:GetCollisionGroups()
+
+				-- We expect collision groups to be sorted by their IDs in increasing
+				-- order. GetCollisionGroups seems to always return a list that is sorted
+				-- this way, but we'll sort it here anyway to avoid relying on that.
+				table.sort(collisionGroups, function(lhs, rhs)
+					return lhs.id < rhs.id
+				end)
+
+				local encoded = table.create(#collisionGroups)
+
+				for i, collisionGroup in ipairs(collisionGroups) do
+					encoded[i] = encodeCollisionGroup(collisionGroup)
+				end
+
+				return true, table.concat(encoded, "\\")
+			end,
+			write = function(_, _, value)
+				local existingCollisionGroups = PhysicsService:GetCollisionGroups()
+
+				-- The simplest thing to do right now is remove all the existing collision
+				-- groups writing the new ones. This is similar to the Tags writer's
+				-- behavior of removing any unknown tags.
+				for _, existingCollisionGroup in ipairs(existingCollisionGroups) do
+					if existingCollisionGroup.name ~= "Default" then
+						PhysicsService:RemoveCollisionGroup(existingCollisionGroup.name)
+					end
+				end
+
+				local encodedCollisionGroups = string.split(value, "\\")
+				local temporaryCollisionGroups = {}
+				local currentCollisionGroupId = 0
+
+				for _, encodedCollisionGroup in ipairs(encodedCollisionGroups) do
+					local collisionGroup = decodeCollisionGroup(encodedCollisionGroup)
+
+					-- The default collision group always exists and has an ID of 0, so it
+					-- can be totally skipped.
+					if collisionGroup.name == "Default" then
+						continue
+					end
+
+					-- It's critical that we preserve the name -> ID mapping because the
+					-- IDs are used to index a bitset and also to indicate parts' presence
+					-- in a collision group. The encoded list of collision groups is
+					-- always sorted in order of increasing ID, but there may be gaps
+					-- between the IDs since collision groups may be removed. This
+					-- presents a small challenge because it's not directly possible to
+					-- create a collision group with a particular ID.
+
+					while currentCollisionGroupId ~= collisionGroup.id - 1 do
+						-- This path is taken when a gap is encountered. The strategy here
+						-- is to backfill any gaps with temporary collision groups before
+						-- creating the desired collision group (which will then have the
+						-- correct ID).
+						local tempName = HttpService:GenerateGUID(false)
+
+						currentCollisionGroupId = PhysicsService:CreateCollisionGroup(tempName)
+						table.insert(temporaryCollisionGroups, tempName)
+					end
+
+					currentCollisionGroupId = PhysicsService:CreateCollisionGroup(collisionGroup.name)
+				end
+
+				for _, tempName in ipairs(temporaryCollisionGroups) do
+					PhysicsService:RemoveCollisionGroup(tempName)
+				end
+
+				-- Finally, we set collidabilities between each collision group.
+				for _, encodedCollisionGroup in ipairs(encodedCollisionGroups) do
+					local collisionGroup = decodeCollisionGroup(encodedCollisionGroup)
+
+					for id = 0, 31 do
+						local collisionGroupName = PhysicsService:GetCollisionGroupName(id)
+
+						if collisionGroupName == nil or collisionGroupName == "" then
+							continue
+						end
+
+						local isCollidable = bit32.extract(collisionGroup.mask, id) == 1 and true or false
+
+						PhysicsService:CollisionGroupSetCollidable(collisionGroup.name, collisionGroupName, isCollidable)
+					end
+				end
+
+				return true
+			end,
+		},
+	},
 	Instance = {
 		Tags = {
 			read = function(instance, key)

--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -44,8 +44,8 @@ return {
 				local existingCollisionGroups = PhysicsService:GetCollisionGroups()
 
 				-- The simplest thing to do right now is remove all the existing collision
-				-- groups writing the new ones. This is similar to the Tags writer's
-				-- behavior of removing any unknown tags.
+				-- groups prior to writing the new ones. This is similar to the Tags
+				-- writer's behavior of removing any unknown tags.
 				for _, existingCollisionGroup in ipairs(existingCollisionGroups) do
 					if existingCollisionGroup.name ~= "Default" then
 						PhysicsService:RemoveCollisionGroup(existingCollisionGroup.name)

--- a/rbx_dom_lua/src/customProperties.spec.lua
+++ b/rbx_dom_lua/src/customProperties.spec.lua
@@ -1,0 +1,104 @@
+return function()
+	local PhysicsService = game:GetService("PhysicsService")
+
+	local customProperties = require(script.Parent.customProperties)
+
+	local function clearCollisionGroups()
+		for _, collisionGroup in ipairs(PhysicsService:GetCollisionGroups()) do
+			if collisionGroup.name ~= "Default" then
+				PhysicsService:RemoveCollisionGroup(collisionGroup.name)
+			end
+		end
+	end
+
+	local function doesCollisionGroupExist(name)
+		return pcall(PhysicsService.GetCollisionGroupId, PhysicsService, name)
+	end
+
+	describe("CollisionGroups", function()
+		describe("write", function()
+			local writeCollisionGroups = customProperties.Workspace.CollisionGroups.write
+
+			it("should write a list of collision groups when they have sequential IDs", function()
+				clearCollisionGroups()
+
+				writeCollisionGroups(nil, nil, "Default^0^-1\\Time^1^-1\\Doesn't^2^-1\\Exist^3^-1")
+
+				expect(PhysicsService:GetCollisionGroupId("Time")).to.equal(1)
+				expect(PhysicsService:GetCollisionGroupId("Doesn't")).to.equal(2)
+				expect(PhysicsService:GetCollisionGroupId("Exist")).to.equal(3)
+			end)
+
+			it("should write a list of collision groups with gaps in between their IDs", function()
+				clearCollisionGroups()
+
+				writeCollisionGroups(nil, nil, "Default^0^-1\\Clocks^2^-1\\Do^5^-1\\Exist^9^-1")
+
+				expect(PhysicsService:GetCollisionGroupId("Clocks")).to.equal(2)
+				expect(PhysicsService:GetCollisionGroupId("Do")).to.equal(5)
+				expect(PhysicsService:GetCollisionGroupId("Exist")).to.equal(9)
+
+				-- The developer hub documentation says that GetCollisionGroupName returns
+				-- nil for a "group that has not been named." If the group was named and
+				-- then removed it seems to return the empty string :D
+				expect(PhysicsService:GetCollisionGroupName(1)).to.equal("")
+				expect(PhysicsService:GetCollisionGroupName(3)).to.equal("")
+				expect(PhysicsService:GetCollisionGroupName(4)).to.equal("")
+				expect(PhysicsService:GetCollisionGroupName(6)).to.equal("")
+				expect(PhysicsService:GetCollisionGroupName(7)).to.equal("")
+				expect(PhysicsService:GetCollisionGroupName(8)).to.equal("")
+			end)
+
+			it("should work when there were collision groups defined previously", function()
+				clearCollisionGroups()
+
+				PhysicsService:CreateCollisionGroup("A")
+				PhysicsService:CreateCollisionGroup("B")
+				PhysicsService:CreateCollisionGroup("C")
+				PhysicsService:CreateCollisionGroup("D")
+				PhysicsService:CreateCollisionGroup("E")
+
+				-- And for good measure we'll also remove some
+				PhysicsService:RemoveCollisionGroup("B")
+				PhysicsService:RemoveCollisionGroup("D")
+
+				writeCollisionGroups(nil, nil, "Default^0^-1\\Clocks^2^-1\\Do^5^-1\\Exist^9^-1")
+
+				expect(PhysicsService:GetCollisionGroupId("Clocks")).to.equal(2)
+				expect(PhysicsService:GetCollisionGroupId("Do")).to.equal(5)
+				expect(PhysicsService:GetCollisionGroupId("Exist")).to.equal(9)
+			end)
+
+			it("should preserve the collidability of collision groups", function()
+				clearCollisionGroups()
+
+				writeCollisionGroups(nil, nil, "Default^0^-3\\A^2^-262\\B^5^-321\\C^6^-33\\D^8^-37")
+
+				expect(PhysicsService:CollisionGroupsAreCollidable("A", "A")).to.equal(false)
+				expect(PhysicsService:CollisionGroupsAreCollidable("A", "Default")).to.equal(false)
+
+				expect(PhysicsService:CollisionGroupsAreCollidable("C", "B")).to.equal(false)
+
+				expect(PhysicsService:CollisionGroupsAreCollidable("D", "A")).to.equal(false)
+				expect(PhysicsService:CollisionGroupsAreCollidable("D", "B")).to.equal(false)
+			end)
+		end)
+
+		describe("read", function()
+			local readCollisionGroups = customProperties.Workspace.CollisionGroups.read
+
+			it("should read all collision groups", function()
+				clearCollisionGroups()
+
+				PhysicsService:CreateCollisionGroup("A")
+				PhysicsService:CreateCollisionGroup("B")
+				PhysicsService:CreateCollisionGroup("C")
+				PhysicsService:CreateCollisionGroup("D")
+
+				local _, encoded = readCollisionGroups()
+
+				expect(encoded).to.equal("Default^0^-1\\A^1^-1\\B^2^-1\\C^3^-1\\D^4^-1")
+			end)
+		end)
+	end)
+end


### PR DESCRIPTION
This PR adds a custom reader and writer for `Workspace.CollisionGroups` to rbx_dom_lua. This property causes the Rojo plugin to error during live-sync for some users who use Remodel to copy `Workspace` into a Rojo project.

Similar to `Tags`, all the parsing that this implementation does can and should be removed once we have a better representation for `CollisionGroups` in rbx_types.
