### PR TITLE
Bump MSRV from 1.40.0 to 1.46.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.40.0"]
+        rust_version: [stable, "1.46.0"]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Criterion recently [changed its MSRV to 1.46.0 and began using `matches!`](https://github.com/bheisler/criterion.rs/commit/976d51730ce479d3d032d2dbb176022e45b22b57),  causing our CI to fail.