### PR TITLE
Add dataType member to rbx_dom_lua's PropertyDescriptor

### DIFF
--- a/rbx_dom_lua/src/PropertyDescriptor.lua
+++ b/rbx_dom_lua/src/PropertyDescriptor.lua
@@ -20,10 +20,21 @@ local function set(container, key, value)
 end
 
 function PropertyDescriptor.fromRaw(data, className, propertyName)
-	local dataType, ty = next(data.DataType)
+	local key, value = next(data.DataType)
 
 	return setmetatable({
-		dataType = dataType == "Enum" and dataType or ty,
+		-- The meanings of the key and value in DataType differ when the type of
+		-- the property is Enum. When the property is of type Enum, the key is
+		-- the name of the type:
+		--
+		-- { Enum = "<name of enum>" }
+		--
+		-- When the property is not of type Enum, the value is the name of the
+		-- type:
+		--
+		-- { Value = "<data type>" }
+		dataType = key == "Enum" and key or value,
+
 		scriptability = data.Scriptability,
 		className = className,
 		name = propertyName,

--- a/rbx_dom_lua/src/PropertyDescriptor.lua
+++ b/rbx_dom_lua/src/PropertyDescriptor.lua
@@ -20,7 +20,10 @@ local function set(container, key, value)
 end
 
 function PropertyDescriptor.fromRaw(data, className, propertyName)
+	local dataType, ty = next(data.DataType)
+
 	return setmetatable({
+		dataType = dataType == "Enum" and dataType or ty,
 		scriptability = data.Scriptability,
 		className = className,
 		name = propertyName,


### PR DESCRIPTION
For Rojo's two-way sync, the plugin needs to be able to get a property's data type from a `PropertyDescriptor` so that it can use `EncodedValue.encode` to encode values destined for the server. Rojo's reconciler used to have a method that was hard coded to do this only for the `String` type, but it was lost after https://github.com/rojo-rbx/rojo/commit/f66860bdfe1b6a5f0174465c0a6c964b56e304cb. 