### PR TITLE
Set CollisionGroups Scriptability to None

### DIFF
--- a/generate_reflection/patches/workspace.yml
+++ b/generate_reflection/patches/workspace.yml
@@ -7,7 +7,7 @@ Add:
         Type: Serializes
       DataType:
         Value: String
-      Scriptability: Custom
+      Scriptability: None
     ExplicitAutoJoints:
       Serialization:
         Type: Serializes


### PR DESCRIPTION
Currently if you use CollisionGroups inside of a project.json the project will fail to sync, this means that projects using CollisionGroups need 2 project.jsons's one for syncing and one for building.
This PR is a temporary fix until #206 is merged.

Fixes: rojo-rbx/rojo#476