### PR TITLE
Add documentation for ProtectedString (PROP 29)

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -48,6 +48,7 @@ This document is based on:
 	- [Color3uint8](#color3uint8)
 	- [Int64](#int64)
 	- [SharedString](#sharedstring)
+	- [ProtectedString](#protectedstring)
 	- [OptionalCoordinateFrame](#optionalcoordinateframe)
 - [Data Storage Notes](#data-storage-notes)
 	- [Integer Transformations](#integer-transformations)
@@ -611,6 +612,11 @@ When an array of `Int64` values is present, the bytes of the integers are subjec
 **Type ID `0x1c`**
 
 `SharedString` values are stored as an [Interleaved Array](#byte-interleaving) of `u32` values that represent indices in the [`SSTR`](#sstr-chunk) string array.
+
+### ProtectedString
+**Type ID `0x1d`**
+
+`ProtectedString` values are stored identically to [Strings](#string) with the difference that they are read as binary data.
 
 ### OptionalCoordinateFrame
 **Type ID `0x1e`**


### PR DESCRIPTION
Added documentation for the ProtectedString prop type.

This property was exposed to us when Roblox released a collection of RBXMs with bytecode in them (then again, the prop type had been accesible since Roblox started shipping the Client scripts with the same PROP type)

![image](https://user-images.githubusercontent.com/41757236/157084232-bec7d99e-67c2-42db-9f51-f84c197dd279.png)

Generally, there's no real usecase to actually exposing this into the tool itself, but I've added it here for reference anyway. As far I'm aware, the only place where this is usable is with plugins.