### PR TITLE
Fix PackageLink binary serialization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Roblox/testez.git
 [submodule "rbx-test-files"]
 	path = test-files
-	url = https://github.com/FilamentGames/rbx-test-files.git
+	url = https://github.com/rojo-rbx/rbx-test-files.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Roblox/testez.git
 [submodule "rbx-test-files"]
 	path = test-files
-	url = https://github.com/rojo-rbx/rbx-test-files.git
+	url = https://github.com/FilamentGames/rbx-test-files.git

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -11,7 +11,7 @@ use rbx_dom_weak::{
         Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
         ColorSequenceKeypoint, Enum, Faces, Matrix3, NumberRange, NumberSequence,
         NumberSequenceKeypoint, PhysicalProperties, Ray, Rect, Ref, SharedString, Tags, UDim,
-        UDim2, Variant, VariantType, Vector2, Vector3, Vector3int16,
+        UDim2, Variant, VariantType, Vector2, Vector3, Vector3int16, Content,
     },
     WeakDom,
 };
@@ -1189,6 +1189,7 @@ impl<'a, W: Write> SerializerState<'a, W> {
             VariantType::SharedString => Variant::SharedString(SharedString::new(Vec::new())),
             VariantType::OptionalCFrame => Variant::OptionalCFrame(None),
             VariantType::Tags => Variant::Tags(Tags::new()),
+            VariantType::Content => Variant::Content(Content::new()),
             _ => return None,
         })
     }

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -57,4 +57,5 @@ binary_tests! {
     two_ray_values,
     two_terrainregions,
     weldconstraint,
+    package_link,
 }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__package-link__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__package-link__decoded.snap
@@ -1,0 +1,65 @@
+---
+source: rbx_binary/src/tests/util.rs
+assertion_line: 33
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Model
+  class: Model
+  properties:
+    AttributesSerialize:
+      BinaryString: ""
+    LevelOfDetail:
+      Enum: 0
+    ModelMeshCFrame:
+      CFrame:
+        position:
+          - 0.0
+          - 0.0
+          - 0.0
+        orientation:
+          - - 1.0
+            - 0.0
+            - 0.0
+          - - 0.0
+            - 1.0
+            - 0.0
+          - - 0.0
+            - 0.0
+            - 1.0
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Vector3:
+        - 0.0
+        - 0.0
+        - 0.0
+    NeedsPivotMigration:
+      Bool: false
+    PrimaryPart: "null"
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    WorldPivotData:
+      OptionalCFrame: ~
+  children:
+    - referent: referent-1
+      name: PackageLink
+      class: PackageLink
+      properties:
+        AttributesSerialize:
+          BinaryString: ""
+        AutoUpdate:
+          Bool: false
+        PackageId:
+          Content: "rbxassetid://9111823334"
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        VersionIdSerialize:
+          Int64: 1
+      children: []
+

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__package-link__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__package-link__encoded.snap
@@ -1,0 +1,157 @@
+---
+source: rbx_binary/src/tests/util.rs
+assertion_line: 46
+expression: text_roundtrip
+---
+num_types: 2
+num_instances: 2
+chunks:
+  - Sstr:
+      version: 0
+      entries:
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+  - Inst:
+      type_id: 0
+      type_name: Model
+      object_format: 0
+      referents:
+        - 0
+  - Inst:
+      type_id: 1
+      type_name: PackageLink
+      object_format: 0
+      referents:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0.0
+            - 0.0
+            - 0.0
+          orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Model
+  - Prop:
+      type_id: 0
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - ~
+  - Prop:
+      type_id: 1
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: AutoUpdate
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: Name
+      prop_type: String
+      values:
+        - PackageLink
+  - Prop:
+      type_id: 1
+      prop_name: PackageIdSerialize
+      prop_type: String
+      values:
+        - "rbxassetid://9111823334"
+  - Prop:
+      type_id: 1
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 1
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: VersionIdSerialize
+      prop_type: Int64
+      values:
+        - 1
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - 0
+  - End
+

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__package-link__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__package-link__input.snap
@@ -1,0 +1,161 @@
+---
+source: rbx_binary/src/tests/util.rs
+assertion_line: 27
+expression: text_decoded
+---
+num_types: 2
+num_instances: 2
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Sstr:
+      version: 0
+      entries:
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+  - Inst:
+      type_id: 0
+      type_name: Model
+      object_format: 0
+      referents:
+        - 0
+  - Inst:
+      type_id: 1
+      type_name: PackageLink
+      object_format: 0
+      referents:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0.0
+            - 0.0
+            - 0.0
+          orientation:
+            - - 1.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 1.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 1.0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0.0
+          - 0.0
+          - 0.0
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Model
+  - Prop:
+      type_id: 0
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - ~
+  - Prop:
+      type_id: 1
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: AutoUpdate
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: Name
+      prop_type: String
+      values:
+        - PackageLink
+  - Prop:
+      type_id: 1
+      prop_name: PackageIdSerialize
+      prop_type: String
+      values:
+        - "rbxassetid://9111823334"
+  - Prop:
+      type_id: 1
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 1
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: VersionIdSerialize
+      prop_type: Int64
+      values:
+        - 1
+  - Prnt:
+      version: 0
+      links:
+        - - 1
+          - 0
+        - - 0
+          - -1
+  - End
+


### PR DESCRIPTION
When serializing a DOM containing a PackageLink to binary via remodel or rojo, it results in this error: `Unsupported property type: PackageLink.PackageId is of type Content`.

It appears the fix is to just add a fallback for the Content type.