### PR TITLE
Preparations for rojo to support Tags/Attributes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Cargo stuff
-/target
+**/target
 **/*.rs.bk
 Cargo.lock
 

--- a/generate_reflection/patches/instance.yml
+++ b/generate_reflection/patches/instance.yml
@@ -18,7 +18,7 @@ Add:
       Serialization:
         Type: SerializesAs
         As: AttributesSerialize
-      Scriptability: None
+      Scriptability: Custom
     AttributesSerialize:
       DataType:
         Value: BinaryString

--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -1,4 +1,16 @@
+local EncodedValue = {}
+
+local ALL_AXES = {"X", "Y", "Z"}
+local ALL_FACES = {"Right", "Top", "Back", "Left", "Bottom", "Front"}
+
+local PRIMITIVE_TO_VARIANT = {
+	boolean = "Bool",
+	string = "String",
+	number = "Float64",
+}
+
 local base64 = require(script.Parent.base64)
+local types
 
 local function identity(...)
 	return ...
@@ -11,20 +23,85 @@ local function unpackDecoder(f)
 end
 
 local function serializeFloat(value)
-	-- TODO: Figure out a better way to serialize infinity and NaN, neither of
-	-- which fit into JSON.
-	if value == math.huge or value == -math.huge then
-		return 999999999 * math.sign(value)
+	if value == value and math.abs(value) ~= 1/0 then
+		return value
+	else
+		return tostring(value)
 	end
 
 	return value
 end
 
-local ALL_AXES = {"X", "Y", "Z"}
-local ALL_FACES = {"Right", "Top", "Back", "Left", "Bottom", "Front"}
+function EncodedValue.decode(encodedValue: any): (boolean, any)
+	local ty, value = next(encodedValue)
+	local typeImpl = types[ty]
+	
+	if typeImpl == nil then
+		return false, "Couldn't decode value " .. tostring(ty)
+	end
 
-local types
+	return pcall(typeImpl.fromPod, value)
+end
+
+function EncodedValue.encode(rbxValue: any, propertyType: string): (boolean, any)
+	assert(propertyType ~= nil, "Property type descriptor is required")
+	local typeImpl = types[propertyType]
+
+	if typeImpl == nil then
+		return false, ("Missing encoder for property type %q"):format(propertyType)
+	end
+
+	return pcall(function ()
+		return {
+			[propertyType] = typeImpl.toPod(rbxValue),
+		}
+	end)
+end
+
 types = {
+	Attributes = {
+		fromPod = function(pod)
+			local attributes = {}
+
+			for name, encoded in pairs(pod) do
+				local ok, result = EncodedValue.decode(encoded)
+
+				if ok then
+					attributes[name] = result
+					continue
+				end
+
+				local typeName = next(encoded)
+				warn(("Unable to decode attribute %q (Type: %s, Error: %s)"):format(name, typeName, result))
+			end
+
+			return attributes
+		end,
+
+		toPod = function(roblox)
+			local attributes = {}
+
+			for name, value in pairs(roblox) do
+				local typeName = typeof(value)
+
+				if PRIMITIVE_TO_VARIANT[typeName] then
+					typeName = PRIMITIVE_TO_VARIANT[typeName]
+				end
+
+				local ok, result = EncodedValue.encode(value, typeName)
+
+				if ok then
+					attributes[name] = result
+					continue
+				end
+
+				warn(("Unable to encode attribute %q (Type: %s, Error: %s)"):format(name, typeName, result))
+			end
+
+			return attributes
+		end,
+	},
+	
 	Axes = {
 		fromPod = function(pod)
 			local axes = {}
@@ -192,12 +269,12 @@ types = {
 	},
 
 	Float32 = {
-		fromPod = identity,
+		fromPod = tonumber,
 		toPod = serializeFloat,
 	},
 
 	Float64 = {
-		fromPod = identity,
+		fromPod = tonumber,
 		toPod = serializeFloat,
 	},
 
@@ -432,31 +509,5 @@ types = {
 		end,
 	},
 }
-
-local EncodedValue = {}
-
-function EncodedValue.decode(encodedValue)
-	local ty, value = next(encodedValue)
-
-	local typeImpl = types[ty]
-	if typeImpl == nil then
-		return false, "Couldn't decode value " .. tostring(ty)
-	end
-
-	return true, typeImpl.fromPod(value)
-end
-
-function EncodedValue.encode(rbxValue, propertyType)
-	assert(propertyType ~= nil, "Property type descriptor is required")
-
-	local typeImpl = types[propertyType]
-	if typeImpl == nil then
-		return false, ("Missing encoder for property type %q"):format(propertyType)
-	end
-
-	return true, {
-		[propertyType] = typeImpl.toPod(rbxValue),
-	}
-end
 
 return EncodedValue

--- a/rbx_dom_lua/src/Error.lua
+++ b/rbx_dom_lua/src/Error.lua
@@ -2,10 +2,12 @@ local Error = {}
 Error.__index = Error
 
 Error.Kind = {
+	Roblox = "Roblox",
 	UnknownProperty = "UnknownProperty",
 	PropertyNotReadable = "PropertyNotReadable",
 	PropertyNotWritable = "PropertyNotWritable",
-	Roblox = "Roblox",
+	InvalidAttributeName = "InvalidAttributeName",
+	UnsupportedAttributeValue = "UnsupportedAttributeValue",
 }
 
 setmetatable(Error.Kind, {

--- a/rbx_dom_lua/src/allValues.json
+++ b/rbx_dom_lua/src/allValues.json
@@ -1,4 +1,24 @@
 {
+  "Attributes": {
+    "value": {
+      "Attributes": {
+        "TestBool": {
+          "Bool": true
+        },
+        "TestString": {
+          "String": "Test"
+        },
+        "TestVector3": {
+          "Vector3": [
+            1.0,
+            2.0,
+            3.0
+          ]
+        }
+      }
+    },
+    "ty": "Attributes"
+  },
   "Axes": {
     "value": {
       "Axes": [

--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -1,18 +1,20 @@
 local CollectionService = game:GetService("CollectionService")
+local setAttribute = require(script.Parent.setAttribute)
 
 -- Defines how to read and write properties that aren't directly scriptable.
---
 -- The reflection database refers to these as having scriptability = "Custom"
+
 return {
 	Instance = {
 		Tags = {
 			read = function(instance)
 				return true, CollectionService:GetTags(instance)
 			end,
+
 			write = function(instance, _, value)
 				local existingTags = CollectionService:GetTags(instance)
-
 				local unseenTags = {}
+
 				for _, tag in ipairs(existingTags) do
 					unseenTags[tag] = true
 				end
@@ -29,13 +31,46 @@ return {
 				return true
 			end,
 		},
+
+		Attributes = {
+			read = function(instance)
+				return true, instance:GetAttributes()
+			end,
+
+			write = function (instance, attributes)
+				local existingAttributes = instance:GetAttributes()
+				local unseenAttributes = {}
+
+				for name in pairs(existingAttributes) do
+					unseenAttributes[name] = true
+				end
+
+				for name, value in pairs(attributes) do
+					local ok, err = setAttribute(instance, name, value)
+
+					if ok then
+						unseenAttributes[name] = nil
+					else
+						return false, err
+					end
+				end
+
+				for name in pairs(unseenAttributes) do
+					instance:SetAttribute(name, nil)
+				end
+
+				return true
+			end,
+		}
 	},
+	
 	LocalizationTable = {
 		Contents = {
-			read = function(instance, key)
+			read = function(instance)
 				return true, instance:GetContents()
 			end,
-			write = function(instance, key, value)
+
+			write = function(instance, _, value)
 				instance:SetContents(value)
 				return true
 			end,

--- a/rbx_dom_lua/src/setAttributes.lua
+++ b/rbx_dom_lua/src/setAttributes.lua
@@ -1,0 +1,51 @@
+local Error = require(script.Parent.Error)
+
+local validTypes = {
+    string = true,
+    boolean = true,
+    number = true,
+    UDim = true,
+    UDim2 = true,
+    BrickColor = true,
+    Color3 = true,
+    Vector2 = true,
+    Vector3 = true,
+    NumberSequence = true,
+    ColorSequence = true,
+    NumberRange = true,
+    Rect = true,
+}
+
+local function setAttribute(inst, name, value)
+    local validName = typeof(name) == "string"
+        and #name == math.clamp(#name, 1, 100)
+        and name:match("[A-z0-9_]+")
+        and name:sub(1, 3) ~= "RBX"
+
+    if not validName then
+        return false, Error.new(Error.Kind.InvalidAttributeName, {
+            inst = inst,
+            name = name,
+            value = value,
+        })
+    end
+
+    if value ~= nil then
+        local valueType = typeof(value)
+
+        if not validTypes[valueType] then
+            return false, Error.new(Error.Kind.UnsupportedAttributeValue, {
+                inst = inst,
+                name = name,
+                value = value,
+            })
+        end
+    end
+
+    -- TODO: Does this pcall ever fail?
+    return pcall(function()
+        inst:SetAttribute(name, value)
+    end)
+end
+
+return setAttribute

--- a/rbx_dom_lua/src/setAttributes.spec.lua
+++ b/rbx_dom_lua/src/setAttributes.spec.lua
@@ -1,0 +1,83 @@
+return function()
+    local setAttribute = require(script.Parent.setAttribute)
+    local inst = Instance.new("Folder")
+
+    it("should accept supported attribute types", function()
+        local values = {
+            "Test",
+
+            true,
+            1337.9001,
+
+            UDim.new(1, 2),
+            UDim2.new(3, 4, 5, 6),
+
+            BrickColor.Red(),
+            Color3.new(),
+
+            Vector2.new(),
+            Vector3.new(),
+
+            ColorSequence.new(Color3.new()),
+            NumberSequence.new(0),
+
+            NumberRange.new(0),
+            Rect.new(),
+        }
+
+        for _, value in ipairs(values) do
+            local set = setAttribute(inst, "Test", value)
+            expect(set).to.be.ok()
+
+            local read = inst:GetAttribute("Test")
+            expect(read).to.equal(value)
+        end
+    end)
+
+    it("should not accept names that start with RBX", function()
+        local set = setAttribute(inst, "RBXTest", 0)
+        expect(set).to.never.be.ok()
+    end)
+
+    it("should not accept names outside the range of [1,100] characters.", function()
+        local tooMany = string.rep("A", 101)
+        local tooFew = ""
+
+        local set = setAttribute(inst, tooMany, 0)
+        expect(set).to.never.be.ok()
+
+        set = setAttribute(inst, tooFew, 0)
+        expect(set).to.never.be.ok()
+    end)
+
+    it("should not accept names if characters aren't alphanumeric/underscores", function()
+        local badNames = {
+            "no spaces",
+            "  bad",
+            "mad  ",
+            " pad ",
+            "#####",
+            "?.:@/~",
+        }
+
+        for _, badName in ipairs(badNames) do
+            local set = setAttribute(inst, badName, 0)
+            expect(set).to.never.be.ok()
+        end
+    end)
+
+    it("should accept names that start with numbers or underscores", function()
+        local coolNames = {
+            "___",
+            "1_3_3_7",
+            "_neat",
+            "__index",
+            "_epic_",
+        }
+
+        for _, coolName in ipairs(coolNames) do
+            local set = setAttribute(inst, coolName, 0)
+            expect(set).to.be.ok()
+        end
+    end)
+end

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -222,6 +222,7 @@ impl std::error::Error for EncodeError {
 pub(crate) enum EncodeErrorKind {
     Io(io::Error),
     Xml(xml::writer::Error),
+    TypeError(rbx_dom_weak::types::Error),
 
     UnknownProperty {
         class_name: String,
@@ -244,6 +245,7 @@ impl fmt::Display for EncodeErrorKind {
         match self {
             Io(err) => write!(output, "{}", err),
             Xml(err) => write!(output, "{}", err),
+            TypeError(err) => write!(output, "{}", err),
 
             UnknownProperty {
                 class_name,
@@ -279,6 +281,7 @@ impl std::error::Error for EncodeErrorKind {
         match self {
             Io(err) => Some(err),
             Xml(err) => Some(err),
+            TypeError(err) => Some(err),
 
             UnknownProperty { .. }
             | UnsupportedPropertyType(_)

--- a/rbx_xml/src/types/attributes.rs
+++ b/rbx_xml/src/types/attributes.rs
@@ -1,0 +1,33 @@
+use std::io::Write;
+use rbx_dom_weak::types::Attributes;
+
+use crate::{
+    serializer_core::{XmlEventWriter, XmlWriteEvent},
+    error::{EncodeError, EncodeErrorKind},
+};
+
+pub const XML_TAG_NAME: &str = "BinaryString";
+
+pub fn write_attributes<W: Write>(
+    writer: &mut XmlEventWriter<W>,
+    property_name: &str,
+    value: &Attributes,
+) -> Result<(), EncodeError> {
+    let mut buffer = Vec::new();
+    let encode = value.to_writer(&mut buffer);
+
+    if encode.is_err() {
+        let err = encode.unwrap_err();
+        return Err(writer.error(EncodeErrorKind::TypeError(err)));
+    }
+
+    let value = base64::encode(&buffer);
+    writer.write(XmlWriteEvent::start_element(XML_TAG_NAME).attr("name", property_name))?;
+
+    if !value.is_empty() {
+        writer.write(XmlWriteEvent::cdata(&value))?;
+    }
+
+    writer.write(XmlWriteEvent::end_element())?;
+    Ok(())
+}

--- a/rbx_xml/src/types/mod.rs
+++ b/rbx_xml/src/types/mod.rs
@@ -7,6 +7,7 @@
 //! 2. Add a 'mod' statement immediately below this comment
 //! 3. Add the type(s) to the declare_rbx_types! macro invocation
 
+mod attributes;
 mod axes;
 mod binary_string;
 mod bool;
@@ -48,6 +49,7 @@ use crate::{
 };
 
 use self::{
+    attributes::write_attributes,
     referent::{read_ref, write_ref},
     shared_string::{read_shared_string, write_shared_string},
     tags::write_tags,
@@ -99,6 +101,7 @@ macro_rules! declare_rbx_types {
         ) -> Result<(), EncodeError> {
             match value {
                 $(Variant::$variant_name(value) => value.write_outer_xml(xml_property_name, writer),)*
+                Variant::Attributes(value) => write_attributes(writer, xml_property_name, value),
 
                 // BrickColor values just encode as 32-bit ints, and have no
                 // unique appearance for reading.

--- a/rbx_xml/src/types/tags.rs
+++ b/rbx_xml/src/types/tags.rs
@@ -14,11 +14,13 @@ pub fn write_tags<W: Write>(
     property_name: &str,
     value: &Tags,
 ) -> Result<(), EncodeError> {
-    let encoded = value.encode();
-
+    let encoded = base64::encode(&value.encode());
     writer.write(XmlWriteEvent::start_element(XML_TAG_NAME).attr("name", property_name))?;
-    writer.write_string(&base64::encode(&encoded))?;
-    writer.write(XmlWriteEvent::end_element())?;
 
+    if !encoded.is_empty() {
+        writer.write_string(&base64::encode(&encoded))?;
+    }
+
+    writer.write(XmlWriteEvent::end_element())?;
     Ok(())
 }


### PR DESCRIPTION
- Attributes are now written in rbx_xml.
- Tags are no longer written if the container is empty.
- Attributes now have pods implemented in rbx_dom_lua.
- Improved pods for inf/nan values in Float32 and Float64.