### PR TITLE
Production version of generate_reflection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
 	"generate_reflection",
 	"rbx_binary",
 	"rbx_dom_weak",
+	"rbx_reflector",
 	"rbx_reflection",
 	"rbx_reflection_database",
 	"rbx_types",

--- a/rbx_reflector/Cargo.toml
+++ b/rbx_reflector/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rbx_reflector"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rbx_dom_weak = { version = "2.3.0", path = "../rbx_dom_weak" }
+
+anyhow = "1.0.57"
+clap = { version = "3.1.12", features = ["derive"] }
+roblox_install = "1.0.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
+tempfile = "3.3.0"
+rbx_reflection = "4.2.0"
+rmp-serde = "1.1.0"
+fs-err = "2.7.0"

--- a/rbx_reflector/src/api_dump/conversion.rs
+++ b/rbx_reflector/src/api_dump/conversion.rs
@@ -1,0 +1,64 @@
+//! Defines the conversion from Roblox Studio's API dump format into rbx-dom's
+//! reflection database format.
+
+use anyhow::bail;
+use rbx_dom_weak::types::VariantType;
+use rbx_reflection::ReflectionDatabase;
+
+use super::types::Dump;
+
+pub fn database_from_dump(dump: &Dump) -> ReflectionDatabase {
+    ReflectionDatabase::new() // TODO
+}
+
+fn variant_type_from_str(value: &str) -> anyhow::Result<Option<VariantType>> {
+    Ok(Some(match value {
+        "Axes" => VariantType::Axes,
+        "BinaryString" => VariantType::BinaryString,
+        "BrickColor" => VariantType::BrickColor,
+        "CFrame" => VariantType::CFrame,
+        "Color3" => VariantType::Color3,
+        "ColorSequence" => VariantType::ColorSequence,
+        "Content" => VariantType::Content,
+        "Faces" => VariantType::Faces,
+        "Instance" => VariantType::Ref,
+        "NumberRange" => VariantType::NumberRange,
+        "NumberSequence" => VariantType::NumberSequence,
+        "PhysicalProperties" => VariantType::PhysicalProperties,
+        "Ray" => VariantType::Ray,
+        "Rect" => VariantType::Rect,
+        "Region3" => VariantType::Region3,
+        "Region3int16" => VariantType::Region3int16,
+        "UDim" => VariantType::UDim,
+        "UDim2" => VariantType::UDim2,
+        "Vector2" => VariantType::Vector2,
+        "Vector2int16" => VariantType::Vector2int16,
+        "Vector3" => VariantType::Vector3,
+        "Vector3int16" => VariantType::Vector3int16,
+        "bool" => VariantType::Bool,
+        "double" => VariantType::Float64,
+        "float" => VariantType::Float32,
+        "int" => VariantType::Int32,
+        "int64" => VariantType::Int64,
+        "string" => VariantType::String,
+
+        // ProtectedString is handled as the same as string
+        "ProtectedString" => VariantType::String,
+
+        // TweenInfo is not supported by rbx_types yet
+        "TweenInfo" => return Ok(None),
+
+        // Font is not supported by rbx_types yet
+        "Font" => return Ok(None),
+
+        // While DateTime is possible to Serialize, the only use it has as a
+        // DataType is for the TextChatMessage class, which cannot be serialized
+        // (at least not saved to file as it is locked to nil parent)
+        "DateTime" => return Ok(None),
+
+        // These types are not generally implemented right now.
+        "QDir" | "QFont" => return Ok(None),
+
+        _ => bail!("Unknown type {}", value),
+    }))
+}

--- a/rbx_reflector/src/api_dump/mod.rs
+++ b/rbx_reflector/src/api_dump/mod.rs
@@ -1,0 +1,5 @@
+mod conversion;
+mod types;
+
+pub use conversion::database_from_dump;
+pub use types::*;

--- a/rbx_reflector/src/api_dump/types.rs
+++ b/rbx_reflector/src/api_dump/types.rs
@@ -1,0 +1,138 @@
+use std::fs;
+use std::process::Command;
+
+use anyhow::Context;
+use roblox_install::RobloxStudio;
+use serde::Deserialize;
+use tempfile::tempdir;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Dump {
+    pub classes: Vec<DumpClass>,
+    pub enums: Vec<DumpEnum>,
+}
+
+impl Dump {
+    pub fn read() -> anyhow::Result<Dump> {
+        let studio_install =
+            RobloxStudio::locate().context("Could not locate Roblox Studio install")?;
+
+        let dir = tempdir()?;
+        let dump_path = dir.path().join("api-dump.json");
+
+        Command::new(studio_install.application_path())
+            .arg("-API")
+            .arg(&dump_path)
+            .status()?;
+
+        let contents = fs::read_to_string(&dump_path).context("Could not read API dump")?;
+        let dump: Dump = serde_json::from_str(&contents)
+            .context("Roblox Studio produced an invalid API dump")?;
+
+        Ok(dump)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DumpClass {
+    pub name: String,
+    pub superclass: String,
+
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub members: Vec<DumpClassMember>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "MemberType")]
+pub enum DumpClassMember {
+    Property(DumpClassProperty),
+
+    #[serde(rename_all = "PascalCase")]
+    Function {
+        name: String,
+    },
+
+    #[serde(rename_all = "PascalCase")]
+    Event {
+        name: String,
+    },
+
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DumpClassProperty {
+    pub name: String,
+    pub value_type: ValueType,
+    pub serialization: Serialization,
+    pub security: PropertySecurity,
+
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ValueType {
+    pub name: String,
+    pub category: ValueCategory,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub enum ValueCategory {
+    /// Lua primitives like float or string
+    Primitive,
+
+    /// Roblox data types like Vector3 or CFrame
+    DataType,
+
+    /// Roblox enum like FormFactor or Genre
+    Enum,
+
+    /// An instance reference
+    Class,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[allow(clippy::enum_variant_names)]
+pub enum Security {
+    None,
+    LocalUserSecurity,
+    PluginSecurity,
+    RobloxScriptSecurity,
+    NotAccessibleSecurity,
+    RobloxSecurity,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PropertySecurity {
+    pub read: Security,
+    pub write: Security,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Serialization {
+    pub can_save: bool,
+    pub can_load: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DumpEnum {
+    pub name: String,
+    pub items: Vec<DumpEnumItem>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DumpEnumItem {
+    pub name: String,
+    pub value: u32,
+}

--- a/rbx_reflector/src/cli/dump.rs
+++ b/rbx_reflector/src/cli/dump.rs
@@ -1,0 +1,54 @@
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{bail, Context};
+use clap::Parser;
+use fs_err::File;
+
+use crate::api_dump::{database_from_dump, Dump};
+
+/// Generate a reflection database from the system's Roblox Studio installation
+/// and write it to disk.
+#[derive(Debug, Parser)]
+pub struct DumpSubcommand {
+    /// Where to output the reflection database. The output format is inferred
+    /// from the file path and supports JSON (.json) and MessagePack (.msgpack).
+    pub output: Vec<PathBuf>,
+}
+
+impl DumpSubcommand {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let dump = Dump::read().context("Could not read API dump from Roblox Studio")?;
+        let database = database_from_dump(&dump);
+
+        for path in &self.output {
+            let extension = path.extension().with_context(|| {
+                format!("Could not infer output type for path {}", path.display())
+            })?;
+
+            let mut file = BufWriter::new(File::create(path)?);
+
+            match extension.to_str() {
+                Some("json") => {
+                    serde_json::to_writer_pretty(&mut file, &database)
+                        .context("Could not serialize reflection database as JSON")?;
+                }
+                Some("msgpack") => {
+                    let buf = rmp_serde::to_vec(&database)
+                        .context("Could not serialize reflection database as MessagePack")?;
+
+                    file.write_all(&buf)?;
+                }
+                _ => bail!(
+                    "Unknown output format for path {} -- \
+                    Supported formats are JSON (.json) and MessagePack (.msgpack)",
+                    path.display()
+                ),
+            }
+
+            file.flush()?;
+        }
+
+        Ok(())
+    }
+}

--- a/rbx_reflector/src/cli/mod.rs
+++ b/rbx_reflector/src/cli/mod.rs
@@ -1,0 +1,33 @@
+mod dump;
+
+use clap::Parser;
+
+use self::dump::DumpSubcommand;
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about)]
+pub struct Args {
+    #[clap(subcommand)]
+    pub subcommand: Subcommand,
+}
+
+#[derive(Debug, Parser)]
+pub enum Subcommand {
+    Dump(DumpSubcommand),
+    Patch,
+    DefaultsPlace,
+    ComputeDefaults,
+    Generate,
+}
+
+impl Args {
+    pub fn run(&self) -> anyhow::Result<()> {
+        match &self.subcommand {
+            Subcommand::Dump(sub) => sub.run(),
+            Subcommand::Patch => todo!(),
+            Subcommand::DefaultsPlace => todo!(),
+            Subcommand::ComputeDefaults => todo!(),
+            Subcommand::Generate => todo!(),
+        }
+    }
+}

--- a/rbx_reflector/src/main.rs
+++ b/rbx_reflector/src/main.rs
@@ -1,0 +1,16 @@
+mod api_dump;
+mod cli;
+
+use clap::Parser;
+
+use crate::cli::Args;
+
+fn main() {
+    let args = Args::parse();
+    println!("{args:?}");
+
+    if let Err(err) = args.run() {
+        eprintln!("Error: {:?}", err);
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
This PR introduces a new tool, `rbx_reflector`, that is a production-quality rewrite of `generate_reflection`/`gen_reflection` that is suitable for CI and end users.

This tool has a much better interface for generating all sorts of reflection information and will let users manage their own reflection databases and patches when they encounter issues with Rojo or other tools.