### PR TITLE
Perf: Cache (name, value_ty) pairs before checking reflection

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -266,6 +266,15 @@ impl<'a, W: Write> SerializerState<'a, W> {
         type_info.object_refs.push(referent);
 
         for (prop_name, prop_value) in &instance.properties {
+            // Discover and track any shared strings we come across.
+            if let Variant::SharedString(shared_string) = prop_value {
+                if !self.shared_string_ids.contains_key(shared_string) {
+                    let id = self.shared_strings.len() as u32;
+                    self.shared_string_ids.insert(shared_string.clone(), id);
+                    self.shared_strings.push(shared_string.clone())
+                }
+            }
+
             // Skip this property+value type pair if we've already seen it.
             if type_info
                 .properties_visited
@@ -379,14 +388,6 @@ impl<'a, W: Write> SerializerState<'a, W> {
 
                 if !prop_info.aliases.contains(prop_name) {
                     prop_info.aliases.insert(prop_name.clone());
-                }
-            }
-
-            if let Variant::SharedString(shared_string) = prop_value {
-                if !self.shared_string_ids.contains_key(shared_string) {
-                    let id = self.shared_strings.len() as u32;
-                    self.shared_string_ids.insert(shared_string.clone(), id);
-                    self.shared_strings.push(shared_string.clone())
                 }
             }
         }


### PR DESCRIPTION
This fix makes `collect_type_info` around 3.5x faster for the benchmark model submitted by @Brian1KB. Projects with more repeated instances will see bigger wins.

Before:
![Tracy_LXhoCaCDUH](https://user-images.githubusercontent.com/654598/170654068-cc69e218-cf67-4660-bacd-824ff7300913.png)

After:
![Tracy_Cx45h0ozEp](https://user-images.githubusercontent.com/654598/170654084-57ca67a6-c2fa-4b3b-b94e-173d13540c2a.png)
