### PR TITLE
Fix certain hyperlinks in `/docs`

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -1,7 +1,7 @@
 # Roblox Binary Model Format, Version 0
 This is unofficial documentation for Roblox's binary model format. The binary model format is used for places (`.rbxl` files), models (`.rbxm` files), and many objects uploaded to Roblox's asset storage.
 
-The binary model format intended to supersede Roblox's older [XML model format](/xml).
+The binary model format intended to supersede Roblox's older [XML model format](xml.md).
 
 This document is based on:
 - [*ROBLOX File Format* by Gregory Comer](http://www.classy-studios.com/Downloads/RobloxFileSpec.pdf)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ This is the home for rbx-dom, a collection of libraries for working with the Rob
 ## Unofficial Specifications
 We maintain high quality documentation for Roblox's formats. This documentation is sourced entirely from the community and contains lessons learned from implementing these formats as part of rbx-dom.
 
-* [Binary Model Format](/binary)
-* [Attributes Format](/attributes)
-* [DOM Data Model](/dom) (stub)
-* [XML Model Format](/xml) (stub)
+* [Binary Model Format](binary.md)
+* [Attributes Format](attributes.md)
+* [DOM Data Model](dom.md) (stub)
+* [XML Model Format](xml.md) (stub)


### PR DESCRIPTION
### Commits: (In-Order)
- [Fix hyperlink to `docs/xml.md` in `docs/binary.md`](https://github.com/regginator/rbx-dom/commit/1264362c29b9afeffed40259eb7d2bf17f1d410f)
- [Fix doc hyperlinks in `docs/index.md`](https://github.com/regginator/rbx-dom/commit/b1aea036386a52225d1c46e6afc9ff34b601dfc3)

<hr>

### Added*
I'm currently working on some documentation for the XML format, and will PR when I get everything I can!