### PR TITLE
Implement a fix to try to catch MaterialVariant type mismatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.53.0"]
+        rust_version: [stable, "1.56.0"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.56.1"]
+        rust_version: [stable, "1.57.0"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.56.0"]
+        rust_version: [stable, "1.56.1"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: ["1.53.0"]
+        rust_version: ["1.57.0"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This project has unveiled a handful of interesting bugs and quirks in Roblox!
 - `ColorSequence`'s XML serialization contains an extra value per keypoint that was intended to be used as an envelope value, but was never implemented.
 
 ## Minimum Rust Version
-rbx-dom supports Rust 1.56.0 and newer. Updating the minimum supported Rust version will only be done when necessary, but may happen as part of minor version bumps.
+rbx-dom supports Rust 1.56.1 and newer. Updating the minimum supported Rust version will only be done when necessary, but may happen as part of minor version bumps.
 
 ## License
 rbx-dom is available under the MIT license. See [LICENSE.txt](LICENSE.txt) for details.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This project has unveiled a handful of interesting bugs and quirks in Roblox!
 - `ColorSequence`'s XML serialization contains an extra value per keypoint that was intended to be used as an envelope value, but was never implemented.
 
 ## Minimum Rust Version
-rbx-dom supports Rust 1.53.0 and newer. Updating the minimum supported Rust version will only be done when necessary, but may happen as part of minor version bumps.
+rbx-dom supports Rust 1.56.0 and newer. Updating the minimum supported Rust version will only be done when necessary, but may happen as part of minor version bumps.
 
 ## License
 rbx-dom is available under the MIT license. See [LICENSE.txt](LICENSE.txt) for details.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This project has unveiled a handful of interesting bugs and quirks in Roblox!
 - `ColorSequence`'s XML serialization contains an extra value per keypoint that was intended to be used as an envelope value, but was never implemented.
 
 ## Minimum Rust Version
-rbx-dom supports Rust 1.56.1 and newer. Updating the minimum supported Rust version will only be done when necessary, but may happen as part of minor version bumps.
+rbx-dom supports Rust 1.57.0 and newer. Updating the minimum supported Rust version will only be done when necessary, but may happen as part of minor version bumps.
 
 ## License
 rbx-dom is available under the MIT license. See [LICENSE.txt](LICENSE.txt) for details.


### PR DESCRIPTION
This fix should enable us to deserialize model files serialized between 2021-09-07 and 2021-10-12 that have the old version of the MaterialVariant property. We need to have a follow-up fix that'll make sure we don't have a regression when we update our reflection database patches later.