### PR TITLE
fixed Property Descriptor Custom erroring

### DIFF
--- a/rbx_dom_lua/src/PropertyDescriptor.lua
+++ b/rbx_dom_lua/src/PropertyDescriptor.lua
@@ -53,6 +53,11 @@ function PropertyDescriptor:read(instance)
 	end
 
 	if self.scriptability == "Custom" then
+		if customProperties[self.className] == nil then
+			local fullName = ("%s.%s"):format(instance.className, self.name)
+			return false, Error.new(Error.Kind.PropertyNotReadable, fullName)
+		end
+
 		local interface = customProperties[self.className][self.name]
 
 		return interface.read(instance, self.name)
@@ -79,6 +84,11 @@ function PropertyDescriptor:write(instance, value)
 	end
 
 	if self.scriptability == "Custom" then
+		if customProperties[self.className] == nil then
+			local fullName = ("%s.%s"):format(instance.className, self.name)
+			return false, Error.new(Error.Kind.PropertyNotWritable, fullName)
+		end
+
 		local interface = customProperties[self.className][self.name]
 
 		return interface.write(instance, self.name, value)


### PR DESCRIPTION
property Descriptor would error here `customProperties[self.className][self.name]` since is some ceases `customProperties[self.className]` returns nil what would cause the script to error out.