### PR TITLE
safeguard for Plugins folder not existing inside the studio directory during reflection generation

### DIFF
--- a/generate_reflection/src/plugin_injector.rs
+++ b/generate_reflection/src/plugin_injector.rs
@@ -65,6 +65,9 @@ fn install_plugin(roblox_studio: &RobloxStudio) {
         .plugins_path()
         .join("RbxDomGenerateReflectionPlugin.rbxmx");
 
+    // trying to write to plugin_path fails if plugins_path() doesn't already exist
+    fs_err::create_dir_all(roblox_studio.plugins_path()).expect("Couldn't create plugins path");
+
     let output = BufWriter::new(File::create(plugin_path).unwrap());
     rbx_xml::to_writer_default(output, &plugin, &[plugin.root_ref()]).unwrap();
 }


### PR DESCRIPTION
I accidentally closed the last pull request by forgetting to commit again
https://github.com/rojo-rbx/rbx-dom/pull/239