### PR TITLE
Fix non-determinstic behaviour for shared string dictionary

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -393,18 +393,16 @@ impl<'dom, W: Write> SerializerState<'dom, W> {
         Ok(())
     }
 
-
     /// Sort and finalize the shared string dictionary.
     // The reason this is left until later is too allow for all
     // shared strings to be discovered before writing the dictionary,
     // allowing us to sort them for consistent behaviour.
     pub fn finalize_shared_strings(&mut self) {
-        self.shared_strings.sort_by(|a, b| {
-            a.hash().cmp(&b.hash())
-        });
-        
+        self.shared_strings.sort_by(|a, b| a.hash().cmp(&b.hash()));
+
         for (i, shared_string) in self.shared_strings.iter().enumerate() {
-            self.shared_string_ids.insert(shared_string.clone(), i as u32);
+            self.shared_string_ids
+                .insert(shared_string.clone(), i as u32);
         }
     }
 

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__unions__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__unions__encoded.snap
@@ -1,5 +1,6 @@
 ---
 source: rbx_binary/src/tests/util.rs
+assertion_line: 46
 expression: text_roundtrip
 ---
 num_types: 1
@@ -8,10 +9,10 @@ chunks:
   - Sstr:
       version: 0
       entries:
-        - len: 1803
-          hash: db0e2bce2a871addfc49da3894a9b0c8ef97b3b83c962717ece20aa97635fee3
         - len: 1367
           hash: cc62d7045ec238081b7ebbd97ce5ce7dc15166e688168c307247089135718bdb
+        - len: 1803
+          hash: db0e2bce2a871addfc49da3894a9b0c8ef97b3b83c962717ece20aa97635fee3
   - Inst:
       type_id: 0
       type_name: UnionOperation
@@ -348,9 +349,9 @@ chunks:
       prop_name: PhysicalConfigData
       prop_type: SharedString
       values:
-        - 0
-        - 0
         - 1
+        - 1
+        - 0
   - Prop:
       type_id: 0
       prop_name: PhysicsData


### PR DESCRIPTION
The current way rbxm files are saved leads to some non-derminsitic behaviour due to how the shared string dictionary is filled. This PR aims to make this correct this behaviour.