### PR TITLE
Correct endian-ness for Float in binary spec file

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -267,7 +267,7 @@ When an array of `Int32` values is present, the bytes of the integers are subjec
 ### Float32
 **Type ID `0x04`**
 
-The `Float32` type is stored using the [Roblox float format](#roblox-float-format) and is little-endian. This datatype is also called `float` or `single`.
+The `Float32` type is stored using the [Roblox float format](#roblox-float-format) and is big-endian. This datatype is also called `float` or `single`.
 
 When an array of `Float32` values is present, the bytes of the floats are subject to [byte interleaving](#byte-interleaving).
 


### PR DESCRIPTION
I am genuinely unsure how this ended up being wrong, but I've discovered that we incorrectly list Float as being little-endian.

Floats are in fact big-endian. A simple look at rbx_binary's source will confirm that. This PR fixes it in the spec document.