### PR TITLE
Fill out XML spec document

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ This is the home for rbx-dom, a collection of libraries for working with the Rob
 ## Unofficial Specifications
 We maintain high quality documentation for Roblox's formats. This documentation is sourced entirely from the community and contains lessons learned from implementing these formats as part of rbx-dom.
 
-* [Binary Model Format](binary.md)
 * [Attributes Format](attributes.md)
+* [Binary Model Format](binary.md)
 * [DOM Data Model](dom.md) (stub)
 * [XML Model Format](xml.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,4 +11,4 @@ We maintain high quality documentation for Roblox's formats. This documentation 
 * [Binary Model Format](binary.md)
 * [Attributes Format](attributes.md)
 * [DOM Data Model](dom.md) (stub)
-* [XML Model Format](xml.md) (stub)
+* [XML Model Format](xml.md)

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -45,7 +45,6 @@ This documentation is incomplete. Contributions are welcome.
 	- [UDim2](#udim2)
 	- [UniqueId](#uniqueid)
 	- [Vector2](#vector2)
-	- [Vector2int16](#vector2int16)
 	- [Vector3](#vector3)
 	- [Vector3int16](#vector3int16)
 
@@ -597,17 +596,6 @@ A `Vector2` with the value `<Infinity, 1337>` would appear as follows:
 	<X>INF</X>
 	<Y>1337</Y>
 </Vector2>
-```
-
-### Vector2int16
-
-The `Vector2int16` data type is represented as a sequence of two child elements. These child elements are named `X` and `Y` and represent the respective components of the value.
-
-Both child elements MUST be in the range `-32768` to `32767`, inclusive.
-
-A `Vector2int16` with the value `<-1337, 1337>` would appear as follows:
-
-```xml
 ```
 
 ### Vector3

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -118,14 +118,14 @@ Every child of this element is a [Type Element](#type-elements) and represents e
 
 ## SharedStrings
 
-This element acts as a repository for `SharedString` definitions. There MAY be zero or one `SharedStrings` element per file. `SharedString` elements must be under the `roblox` element.
+This element acts as a repository for `SharedString` definitions. There MAY be zero or one `SharedStrings` element per file. All `SharedStrings` elements must be under the `roblox` element.
 
 There are no attributes required for this element.
 
 ## SharedString
 [SharedString-def]: #sharedstring
 
-This element defines a single `SharedString` value for reference by [Type Elements](#type-elements). There MAY be zero or more `SharedString` elements per file. `SharedStrings` elements must be under the `SharedStrings` element.
+This element defines a single `SharedString` value for reference by [Type Elements](#type-elements). There MAY be zero or more `SharedString` elements per file. `SharedString` elements must be under the `SharedStrings` element.
 
 This element shares a name with a type element. That element is documented [here][SharedString-use].
 
@@ -135,9 +135,9 @@ The following attributes are required for this element:
 |:------|:-----------------------------------------------------------------------|
 | `md5` | A unique identifier for this element, for reference by a type element. |
 
-Despite its name, the contents of `md5` do not have to be the MD5 hash of the SharedString and instead simply MUST be a unique identifier for this SharedString.
+Despite its name, the contents of `md5` do not have to be the MD5 hash of the `SharedString` and instead simply MUST be a unique identifier for this `SharedString`.
 
-The value of this element MUST be the SharedString value encoded with Base64.
+The value of this element MUST be the `SharedString` value encoded with Base64.
 <!-- TODO: Verify what form of Base64 and put it here-->
 
 ## Type Elements
@@ -151,7 +151,7 @@ The following attributes are required for all property elements, regardless of t
 
 | Name   | Contents                                              |
 |:-------|:------------------------------------------------------|
-| `name` | The nane of the property represented by this element. |
+| `name` | The name of the property represented by this element. |
 
 The `name` of a property does not necessarily reflect its in-engine name, and some properties serialize with unexpected names. Additionally, not every property is deserialized by Roblox.
 
@@ -290,7 +290,7 @@ A `CFrame` with the components `0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1` would appear
 
 ### double
 
-The `double` data type (also known as `Float64`) is represented as a standard 64-bit floating point number would be. Specifically, it is represented by the [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) type. For full details, view the XSD specification but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `double` values.
+The `double` data type (also known as `Float64`) is represented as a standard 64-bit floating point number in [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) format. For full details, view the XSD specification but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `double` values.
 
 Positive infinity is represented as `INF` or `+INF`, negative infinity is represented as `-INF`, and NaN is represented as `NAN`. To be compatible, encoders MUST use these representations, including the all upper casing.
 
@@ -316,7 +316,7 @@ A `Faces` property with the `Front`, `Left`, and `Top` faces enabled would appea
 
 ### float
 
-The `float` data type (also known as `Float32` or `single`) is represented as a standard 32-bit floating-point number would be. Specifically, it is represented by the [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) type. For full details, view the XSD specification, but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `float` values.
+The `float` data type (also known as `Float32` or `single`) is represented as a standard 32-bit floating-point number in [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) format. For full details, view the XSD specification, but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `float` values.
 
 Positive infinity is represented as `INF` or `+INF`, negative infinity is represented as `-INF`, and NaN is represented as `NAN`. To be compatible, encoders MUST use these representations, including the all upper casing.
 
@@ -409,7 +409,7 @@ The `Optional<T>` data type represents an optional value of type `T` and is repr
 
 Elements of this type should be named `Optional` followed by the name of the type. As an example, for `Optional<CoordinateFrame>`, the element should be named `OptionalCoordinateFrame`.
 
-The name of the child element varies depending upon the type `T` is. The following is a list ofcurrently valid types for `T`, along with the name of the child element:
+The name of the child element varies depending upon the type `T` is. The following is a list of currently valid types for `T`, along with the name of the child element:
 
 | Type                                  | Child Element Name |
 |:--------------------------------------|:-------------------|
@@ -501,7 +501,7 @@ A `Ray` with the value `[<1, 2, 3>, <-1, -2, -3>]` would appear as follows:
 
 The `Rect2D` data type (also known as `Rect`) is represented as a sequence of two child elements representing the `Min` nad `Max` components of the value. These child elements are named `min` and `max` and are both [`Vector2`](#vector2) values.
 
-Despite the canonical name of the data type being `Rect`, elements of this type SHOULD be named `Rect` to maintain compatibility.
+Despite the canonical name of the data type being `Rect`, elements of this type SHOULD be named `Rect2D` to maintain compatibility.
 
 A `Rect2D` with the value `[<1, 2>, <3, 4>)` would appear as follows:
 
@@ -537,7 +537,7 @@ A `Ref` value pointing to a random `Item` may appear as follows:
 
 This element shares a name with a SharedString definition element. That element is documented [here][SharedString-def].
 
-The `SharedString` data type is represented by a string that points to a `SharedString` defined elsewhere in the file. Specifically, the contents of elements of this type should be equal to the `md5` attribute of a [`SharedString` definition][#SharedString-def].
+The `SharedString` data type is represented by a string that points to a `SharedString` defined elsewhere in the file. Specifically, the contents of elements of this type should be equal to the `md5` attribute of a [`SharedString` definition][SharedString-def].
 
 A `SharedString` value may appear as follows:
 
@@ -599,7 +599,7 @@ A `UDim2` with the value `{0.15625, 1337}, {-123, 456}` would appear as follows:
 
 ### UniqueId
 
-The `UniqueId` data type is represented as hexadecimal-encoded sequence of `16` bytes. These bytes may be split in three distinct groups, representing components of the `UniqueId`:
+The `UniqueId` data type is represented as hexadecimal-encoded sequence of `16` bytes. These bytes are split into three distinct groups, representing components of the `UniqueId`:
 
 | Range   | Component Name | Format                  |
 |:--------|:---------------|:------------------------|

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -240,7 +240,7 @@ A `Color3` with the value `INF, 1337, 0.15625` appears as follows:
 
 ### Color3uint8
 
-The `Color3uint8` data type is represented by a single unsigned 32-bit integer that is the `R`, `G`, and `B` components of the color (as integers in the range 0 to 255) packed into the lower 24 bits of the number. This integer is little-endian and written in the order `G`, `B`, `R`.
+The `Color3uint8` data type is represented by a single unsigned 32-bit integer that is the `R`, `G`, and `B` components of the color (as integers in the range 0 to 255) packed into the lower 24 bits of the number. This integer is written in the order `R`, `G`, and then `B`.
 
 The upper 8 bits of the value SHOULD be filled with `FF` (in hexadecimal). This is to maintain compatibility with Roblox.
 
@@ -249,6 +249,8 @@ A `Color3uint8` with the value `96, 64, 32` appears as follows:
 ```xml
 <Color3uint8 name="Color3uint8Example">4284497952</Color3uint8>
 ```
+
+In hexadecimal, this value's components may be represented as `60`, `40`, and `20` respectively. The number they are encoded by is represented as `FF604020`. Seperated by byte, this is `FF 60 40 20`. The individual components of the value may be extracted from the integer using basic bitwise operations.
 
 ### ColorSequence
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -157,8 +157,7 @@ The following attributes are REQUIRED for this element:
 
 The value of `md5` MUST be unique across all `SharedString` definitions. Despite the name, the value does not have to be the MD5 hash of the `SharedString` contents.
 
-The content of `SharedString` elements MUST be Base64 encoded.
-<!-- TODO: Verify what form of Base64 and put it here-->
+The content of `SharedString` elements MUST be Base64 encoded as per [RFC 2045](https://www.rfc-editor.org/rfc/rfc2045).
 
 ## Type Elements
 
@@ -193,7 +192,7 @@ An `Axes` property with only the `X` axis enabled appears as follows:
 
 ### BinaryString
 
-The `BinaryString` data type is represented by the contents of the property encoded with Base64.
+The `BinaryString` data type is represented by the contents of the property encoded with Base64 as per [RFC 2045](https://www.rfc-editor.org/rfc/rfc2045).
 
 A `BinaryString` property with the contents `Rojo is cool!` appears as follows:
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -1,6 +1,217 @@
 # Roblox XML Model Format, Version 4
 This is unofficial documentation for Roblox's XML model format. The XML model format is used for places (`.rbxlx` files), models (`.rbxmx` files), Roblox Studio settings, and many objects uploaded to Roblox's asset storage.
 
-The XML model format has generally been replaced by the newer, more efficient [binary model format](/binary). Some use cases for the XML format still exist, owing to its human readability.
+The XML model format has generally been replaced by the newer, more efficient [binary model format](binary.md). Some use cases for the XML format still exist, owing to its human readability.
 
 This documentation is incomplete. Contributions are welcome.
+
+## Contents
+- [File Structure](#file-structure)
+- [roblox](#roblox)
+- [Meta](#meta)
+- [External](#external)
+- [Item](#external)
+- [Properties](#properties)
+- [SharedStrings](#sharedstrings)
+	- [SharedString][SharedString-def] (definition)
+- [Type Elements](#type-elements)
+	- [Axes](#axes)
+	- [BinaryString](#binarystring)
+	- [BrickColor](#brickcolor)
+	- [bool](#bool)
+	- [Color3](#color3)
+	- [Color3uint8](#color3uint8)
+	- [ColorSequence](#colorsequence)
+	- [Content](#content)
+	- [CoordinateFrame](#coordinateframe)
+	- [double](#double) (Float64)
+	- [Faces](#faces)
+	- [float](#float) (Float32)
+	- [Font](#font)
+	- [int](#int) (Int32)
+	- [int64](#int64)
+	- [NumberRange](#numberrange)
+	- [NumberSequence](#numbersequence)
+	- [OptionalCoordinateFrame](#optionalcoordinateframe)
+	- [Ref](#ref) (Referent)
+	- [Rect2D](#rect2d)
+	- [SharedString][SharedString-use] (property type)
+	- [string](#string)
+	- [token](#token) (Enum)
+	- [UDim](#udim)
+	- [UDim2](#udim2)
+	- [UniqueId](#uniqueid)
+	- [Vector2](#vector2)
+	- [Vector2int16](#vector2int16)
+	- [Vector3](#vector3)
+	- [Vector3int16](#vector3int16)
+
+
+## File Structure
+Roblox XML files consist of a single `<roblox>` element, which contain a sequence of other elements. The basic layout of the file structure is as follows:
+
+- Exactly one `<roblox>` element
+	- Zero or more `<Meta>` elements
+	- Zero or more `<External>` elements
+	- One or more `<Item>` elements
+	- One `<Properties>` element
+		- Zero or more type elements
+	- Zero or more `<Item>` elements (this may nest infinitely)
+	- Zero or one `<SharedStrings>` elements
+		- Zero or more `<SharedString>` elements
+
+**To be accepted by Roblox, files MUST start with `<roblox` and end with `</roblox>`, with no whitespace.**
+
+## roblox
+
+This element is the root of the file. There MUST be one `roblox` element in the file.
+
+The following attributes are required for this element:
+
+| Name      | Contents                                                                         |
+|:----------|:---------------------------------------------------------------------------------|
+| `version` | The version of the format this document contains. This MUST be `4` at this time. |
+
+All other attributes are ignored by Roblox, including those defined by Roblox Studio when exporting files.
+
+As stated under [File Structure](#file-structure), this element MUST be the beginning and end of the file.
+
+## Meta
+
+This element represents a single key-value pair of metadata for the file. There MAY be any number of `Meta` elements in a document but they MUST all be under the `roblox` element.
+
+The following attributes are required for this element:
+
+| Name   | Contents                                     |
+|:-------|:---------------------------------------------|
+| `name` | The key part of the metadata key-value pair. |
+
+The contents of this element represent the value of the metadata key-value pair.
+
+## External
+
+This element is a legacy feature and currently does nothing. Roblox Studio encodes two of these tags when producing files, but they are optional and unused. When present, they MUST be under the `roblox` element.
+
+There are no attributes required for this element.
+
+The contents of this element represent an unknown purpose, as the element does not do anything.
+
+## Item
+
+This element describes one `Instance` value. There SHOULD be at least one of these in all files, as otherwise they serve no purpose, but Roblox accepts files with no `Item` elements. All `Item` elements must be under either the `roblox` element or other `Item` elements.
+
+The following attributes are required for this element:
+
+| Name       | Contents                                                              |
+|:-----------|:----------------------------------------------------------------------|
+| `class`    | The class of the `Instance` this element represents.                  |
+| `referent` | A unique string used to reference this element elsewhere in the file. |
+
+The value of `referent` does not need to follow any pattern, it simply must be unique for the file. Roblox generates referents by prefixing a UUID with `RBX`, but this is not a requirement.
+
+## Properties
+
+This element contains all properties for a given `Instance`. There MUST be one per `Item` element, and each `Properties` element must be under an `Item` element.
+
+There are no attributes required for this element.
+
+Every child of this element is a [Type Element](#type-elements) and represents exactly one property of an `Instance`.
+
+## SharedStrings
+
+This element acts as a repository for `SharedString` definitions. There MAY be zero or one `SharedStrings` element per file. `SharedString` elements must be under the `roblox` element.
+
+There are no attributes required for this element.
+
+## SharedString
+[SharedString-def]: #sharedstring
+
+This element defines a single `SharedString` value for reference by [Type Elements](#type-elements). There MAY be zero or more `SharedString` elements per file. `SharedStrings` elements must be under the `SharedStrings` element.
+
+This element shares a name with a type element. That element is documented [here][SharedString-use].
+
+The following attributes are required for this element:
+
+| Name  | Contents                                                               |
+|:------|:-----------------------------------------------------------------------|
+| `md5` | A unique identifier for this element, for reference by a type element. |
+
+Despite its name, the contents of `md5` do not have to be the MD5 hash of the SharedString and instead simply MUST be a unique identifier for this SharedString.
+
+The value of this element MUST be the SharedString value encoded with Base64.
+<!-- TODO: Verify what form of Base64 and put it here-->
+
+## Type Elements
+
+All elements below this point represent a single property on a single `Instance`. They all MUST be under a [`Properties`](#properties) element. There MAY be zero or more of each of these elements under each `Properties` element.
+
+The following attributes are required for all type elements:
+
+| Name   | Contents                                              |
+|:-------|:------------------------------------------------------|
+| `name` | The nane of the property represented by this element. |
+
+The `name` of a property does not necessarily reflect its in-engine name, and some properties serialize with unexpected names. Additionally, not every property is deserialized by Roblox.
+
+### Axes
+
+### BinaryString
+
+### BrickColor
+
+### bool
+
+### Color3
+
+### Color3uint8
+
+### ColorSequence
+
+### Content
+
+### CoordinateFrame
+
+### double
+
+### Faces
+
+### float
+
+### Font
+
+### int
+
+### int64
+
+### NumberRange
+
+### NumberSequence
+
+### OptionalCoordinateFrame
+
+### Ref
+
+### Rect2D
+
+### SharedString
+[SharedString-use]: #sharedstring-1
+
+This element shares a name with a SharedString definition element. That element is documented [here][SharedString-def].
+
+### string
+
+### token
+
+### UDim
+
+### UDim2
+
+### UniqueId
+
+### Vector2
+
+### Vector2int16
+
+### Vector3
+
+### Vector3int16

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -454,7 +454,7 @@ This element shares a name with a SharedString definition element. That element 
 
 The `SharedString` data type is represented by a string that points to a `SharedString` defined elsewhere in the file. Specifically, the contents of elements of this type should be equal to the `md5` attribute of a [`SharedString` definition][#SharedString-def].
 
-A `SharedString` value may look like this:
+A `SharedString` value may appear as follows:
 
 ```xml
 <!--TODO SharedString>
@@ -462,18 +462,108 @@ A `SharedString` value may look like this:
 
 ### string
 
+The `string` data type is represented as a literal sequence of characters inside an element. Any leading or trailing whitespace is trimmed from values with this type.
+
+Proper care must be taken to escape characters when necessary.
+
+A `string` value `Hello, world!` would appear as follows:
+
+```xml
+<string name="Example">Hello, world!</string>
+```
+
 ### token
+
+The `token` data type (also known as `Enum`) is represented as a sequence of numbers indicating the underlying `Value` of the enum.
+
+Despite the canonical name of the data type being `Enum`, elements of this type MUST be named `token` to maintain compatibility.
+
+A `token` representing `Enum.NormalId.Left` would appear as follows:
+
+```xml
+<token name="Example">3</token>
+```
 
 ### UDim
 
+The `UDim` data type is represented as a sequence of two child elements indicating the `Scale` and `Offset` components of the value. These child elements are named `S` and `O`. The `S` element is a [`float`](#float) and the `O` element is a [`int`](#int).
+
+A `UDim` with the value `{0.15625, 1337}` would appear as follows:
+
+```xml
+<UDim name="Example">
+	<S>0.15625</S>
+	<O>1337</O>
+</UDim>
+```
+
 ### UDim2
+
+The `UDim2` data type is represented as a sequence of four child elements indicating the `X.Scale`, `X.Offset`, `Y.Scale`, `Y.Offset` components of the value. These elements are named `XS`, `XO`, `YS`, and `YO`. The `XS` and `YS` elements are [`float`](#float) values and the `XO` and `YO` elements are [`int`](#int) values.
+
+A `UDim2` with the value `{0.15625, 1337}, {-123, 456}` would appear as follows:
+
+```
+<!--TODO UDim2-->
+```
 
 ### UniqueId
 
+The `UniqueId` data type is represented as hexadecimal-encoded sequence of `16` bytes. These bytes may be split in three distinct groups, representing components of the `UniqueId`:
+
+| Range   | Component Name | Format                  |
+|:--------|:---------------|:------------------------|
+|  0 -  7 | Random         | Unsigned 64-bit integer |
+|  8 - 11 | Time           | Unsigned 32-bit integer |
+| 12 - 15 | Index          | Unsigned 32-bit integer |
+
+**NOTE**: The `Random` component is serialized differently between the XML and [binary](binary.md) format. Specifically, in the XML format it is left-circular rotated by `1` bit. Care MUST be taken to ensure equivalent values are modified to be correctly equivalent when reading and writing between formats.
+
+A `UniqueId` may appear as follows:
+
+```xml
+<!--TODO UniqueId-->
+```
+
 ### Vector2
+
+The `Vector2` data type is represented as a sequence of two child elements. These child elements are named `X` and `Y` and represent the respective components of the value. Both of these elements are [`float`](#float) values.
+
+A `Vector2` with the value `<Infinity, 1337>` would appear as follows:
+
+```xml
+<!--TODO Vector2>
+```
 
 ### Vector2int16
 
+The `Vector2int16` data type is represented as a sequence of two child elements. These child elements are named `X` and `Y` and represent the respective components of the value.
+
+Both child elements MUST be in the range `-32768` to `32767`, inclusive.
+
+A `Vector2int16` with the value `<-1337, 1337>` would appear as follows:
+
+```xml
+```
+
 ### Vector3
 
+The `Vector3` data type is represented as a sequence of three child elements. These child elements are named `X`, `Y`, and `Z` and represent the respective components of the value. All three elements are [`float`](#float) values.
+
+A `Vector3` with the value `<-Infinity, 0.15625, -1337>` would appear as follows:
+
+```xml
+
+```
+
 ### Vector3int16
+
+The `Vector3int16` data type is represented as a sequence of three child elements. These child elements are named `X`, `Y`, and `Z` and represent the respective components of the value.
+
+All three child elements MUST be in the range `-32768` to `32767`, inclusive.
+
+A `Vector3int16` with the value `<1337, 0, -1337>` would appear as follows:
+
+```xml
+
+```

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -93,13 +93,15 @@ The following attributes are REQUIRED for this element:
 
 The contents of this element represent the value of the metadata key-value pair.
 
-Currently, Roblox encodes the following `Meta` elements:
+Currently, Roblox encodes the following `Meta` elements for **model** files:
 
 | Name                 | Value  |
 |:---------------------|:-------|
-| `ExplicitAutoJoints` | `true` | <!--TODO: Validate that this is always `true`-->
+| `ExplicitAutoJoints` | `true` |
 
 It is RECOMMENDED that every key-value pair from the above table be encoded to maintain compatibility with Roblox Studio.
+
+Roblox does not currently generate any `Meta` elements for **place** files.
 
 ## External
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -3,8 +3,6 @@ This is unofficial documentation for Roblox's XML model format. The XML model fo
 
 The XML model format has generally been replaced by the newer, more efficient [binary model format](binary.md). Some use cases for the XML format still exist, owing to its human readability.
 
-This documentation is incomplete. Contributions are welcome.
-
 ## Contents
 - [File Structure](#file-structure)
 - [roblox](#roblox)

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -175,7 +175,7 @@ The following attributes are REQUIRED for all property elements, regardless of t
 |:-------|:------------------------------------------------------|
 | `name` | The name of the property represented by this element. |
 
-The `name` of a property does not necessarily reflect its in-engine name, and some properties serialize with unexpected names. Additionally, not every property is deserialized by Roblox.
+The `name` of a property does not necessarily reflect its in-engine name, and some properties serialize with unexpected names. Additionally, not every property is both serialized and deserialized by Roblox. A property may be deserialized without being serialized, vice versa, or not be read or written by Roblox.
 
 The format for each data type is listed below.
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -71,7 +71,7 @@ Any trailing or leading whitespace in XML files are ignored by Roblox.
 
 ## roblox
 
-This element is the root of the file. There MUST be one `roblox` element in the file.
+There MUST be one `roblox` element at the root of the file.
 
 The following attributes are REQUIRED for this element:
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -560,8 +560,6 @@ A `Ref` value pointing to an `Item` with a `referent` of `RBX466F72207262782D646
 
 This element shares a name with a SharedString definition element. That element is documented [here][SharedString-def].
 
-The `SharedString` data type is represented by a string that points to a `SharedString` defined elsewhere in the file. The contents of `SharedString` elements MUST be equal to the `md5` attribute of a [`SharedString` definition][SharedString-def].
-
 The `SharedString` data type is represented by a string that points to a `SharedString` defined elsewhere in the file. Specifically, the contents of elements of this type MUST be equal to the `md5` attribute of a [`SharedString` definition][SharedString-def].
 
 A `SharedString` value pointing to the `SharedString` with its `md5` attribute equal to `ZGVra29ub3Rfd2FzX2hlcmU=` appears as follows:

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -17,8 +17,8 @@ This documentation is incomplete. Contributions are welcome.
 - [Type Elements](#type-elements)
 	- [Axes](#axes)
 	- [BinaryString](#binarystring)
-	- [BrickColor](#brickcolor)
 	- [bool](#bool)
+	- [BrickColor](#brickcolor)
 	- [Color3](#color3)
 	- [Color3uint8](#color3uint8)
 	- [ColorSequence](#colorsequence)
@@ -167,7 +167,9 @@ The `Axes` data type is represented with a single `axes` element that contains a
 An `Axes` property with only the `X` axis enabled would appear as follows:
 
 ```xml
-<Axes name="Example"><axes>1</axes></Axes>
+<Axes name="AxesExample">
+	<axes>1</axes>
+</Axes>
 ```
 
 ### BinaryString
@@ -177,19 +179,7 @@ The `BinaryString` data type is represented by the contents of the property enco
 A `BinaryString` property with the contents `Rojo is cool!` would appear as follows:
 
 ```xml
-<BinaryString name="Example">Um9qbyBpcyBjb29sIQ==</BinaryString>
-```
-
-### BrickColor
-
-The `BrickColor` data type is represented by a single 32-bit integer that represents the `Number` of the value.
-
-Roblox encodes this type with the element name `int` but by convention, the element SHOULD be named `BrickColor`.
-
-A `BrickColor` with the value `Medium Stone Grey` (whose number is `194`) would appear as follows:
-
-```xml
-<BrickColor name="Example">194</BrickColor>
+<BinaryString name="BinaryStringExample">Um9qbyBpcyBjb29sIQ==</BinaryString>
 ```
 
 ### bool
@@ -201,20 +191,32 @@ Although Roblox accepts variations such as `fAlSe` and `TRUE`, by convention val
 A `bool` with the value `false` would appear as follows:
 
 ```xml
-<bool name="Example">false</bool>
+<bool name="BoolExample">false</bool>
+```
+
+### BrickColor
+
+The `BrickColor` data type is represented by a single 32-bit integer that represents the `Number` of the value.
+
+Roblox encodes this type with the element name `int` but by convention, the element SHOULD be named `BrickColor`. Either is accepted.
+
+A `BrickColor` with the value `Medium Stone Grey` (whose number is `194`) should appear as follows:
+
+```xml
+<BrickColor name="BrickColorExample">194</BrickColor>
 ```
 
 ### Color3
 
 The `Color3` data type is represented by three child elements named `R`, `G`, and `B`. These elements contain the value of that component as 32-bit floating point numbers. See [`float`](#float) for more information on the format of floating point numbers.
 
-A `Color3` with the value `INF, 1337, 3.141592653` would appear as follows:
+A `Color3` with the value `INF, 1337, 0.15625` would appear as follows:
 
 ```xml
-<Color3 name="Example">
+<Color3 name="Color3Example">
 	<R>INF</R>
 	<G>1337</G>
-	<B>3.141592653</B>
+	<B>0.15625</B>
 </Color3>
 ```
 
@@ -227,7 +229,7 @@ Roblox encodes this type with the upper 8 bits filled with `FF` (in hexadecimal)
 A `Color3uint8` with the value `96, 64, 32` would appear as follows:
 
 ```xml
-<Color3uint8 name="Example">4284497952</Color3uint8>
+<Color3uint8 name="Color3uint8Example">4284497952</Color3uint8>
 ```
 
 ### ColorSequence
@@ -241,7 +243,7 @@ At this moment, the `Envelope` section of this sequence is unused and SHOULD alw
 A `ColorSequence` with the value `[0, 96, 64, 32] [1, 5, 10, 15]` would appear as follows:
 
 ```xml
-<!--TODO ColorSequence -->
+<ColorSequence name="ColorSequenceExample">0 0.376471 0.25098 0.12549 0 1 0.0196078 0.0392157 0.0588235 0 </ColorSequence>
 ```
 
 ### Content
@@ -252,10 +254,16 @@ If the child element is `url`, then the value of it is the `Content`'s URI. If t
 
 If the child element is either `binary` or `hash`, the contents SHOULD be disregarded and the `Content` should be viewed as empty. These tags MUST NOT be written by encoders.
 
-A `Content` with the value `rbxasset://textures/SpawnLocation.png` would appear as follows:
+A `Content` with the value `rbxasset://textures/face.png` would appear as follows:
 
 ```xml
-<!--TODO Content-->
+<Content name="ContentExample"><url>rbxasset://textures/face.png</url></Content>
+```
+
+Additionally, a `Content` with no value would appear as follows:
+
+```xml
+<Content name="ContentExample"><null></null></Content>
 ```
 
 ### CoordinateFrame
@@ -264,10 +272,23 @@ The `CFrame` data type is represented by a single element named `CoordinateFrame
 
 Despite the canonical name of the data type being `CFrame`, elements of this type MUST be named `CoordinateFrame` to maintain compatibility.
 
-A `CFrame` with the components `INSERT CFRAME` would appear as follows:
+A `CFrame` with the components `0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1` would appear as follows:
 
 ```xml
-<!--TODO CFrame>
+<CoordinateFrame name="CoordinateFrameExample">
+	<X>0</X>
+	<Y>0</Y>
+	<Z>0</Z>
+	<R00>1</R00>
+	<R01>0</R01>
+	<R02>0</R02>
+	<R10>0</R10>
+	<R11>1</R11>
+	<R12>0</R12>
+	<R20>0</R20>
+	<R21>0</R21>
+	<R22>1</R22>
+</CoordinateFrame>
 ```
 
 ### double
@@ -281,7 +302,7 @@ Encoders SHOULD encode `double` values with at least 17 digits of precision but 
 A `double` with the value `0.15625` would appear as follows:
 
 ```xml
-<!--TODO double>
+<double name="DoubleExample">0.15625</double>
 ```
 
 ### Faces
@@ -291,7 +312,9 @@ The `Faces` data type is represented with a single `faces` element that contains
 A `Faces` property with the `Front`, `Left`, and `Top` faces enabled would appear as follows:
 
 ```xml
-<!--TODO Faces>
+<Faces name="FacesExample">
+	<faces>42</faces>
+</Faces>
 ```
 
 ### float
@@ -305,7 +328,7 @@ Encoders SHOULD encode `float` values with at least 9 digits of precision but th
 A `float` with the value `0.15625` would appear as follows:
 
 ```xml
-<float name="Example">0.15625</float>
+<float name="FloatExample">0.15625</float>
 ```
 
 ### Font
@@ -323,12 +346,16 @@ The `Weight` element is a value of an item from the Roblox `FontWeight` enum. Th
 
 The `Style` element is the name of an item from the Roblox `FontStyle` enum. At this time, the only values are `Normal` and `Italic`.
 
-The `CachedFaceId` element will point to a locally cached copy of the `Font`'s source file if it is present. <!--TODO determine if optional>
+The `CachedFaceId` element will point to a locally cached copy of the `Font`'s source file if it is present.
 
 A `Font` with the value `Arial, Italic, Bold` would appear as follows:
 
 ```xml
-<!--TODO Font>
+<Font name="FontExample">
+	<Family><url>rbxasset://fonts/families/Arial.json</url></Family>
+	<Weight>700</Weight>
+	<Style>Italic</Style>
+</Font>
 ```
 
 ### int
@@ -340,7 +367,7 @@ Positive numbers MUST NOT be prefixed with `+`.
 An `int` value of `1337` would appear as follows:
 
 ```xml
-<int name="Example">1337</int>
+<int name="IntExample">1337</int>
 ```
 
 ### int64
@@ -352,7 +379,7 @@ Positive numbers MUST NOT be prefixed with `+`.
 An `int64` value of `-559038737` would appear as follows:
 
 ```xml
-<int64 name="Example">-559038737</int64>
+<int64 name="Int64Example">-559038737</int64>
 ```
 
 ### NumberRange
@@ -364,7 +391,7 @@ Both numbers are formatted as [`float`](#float) values.
 A `NumberRange` value of `0.15625, 1337` would appear as follows:
 
 ```xml
-<NumberRange name="Example">0.15625 1337 </NumberRange>
+<NumberRange name="NumberRangeExample">0.15625 1337 </NumberRange>
 ```
 
 ### NumberSequence
@@ -373,10 +400,10 @@ The `NumberSequence` data type is represented by a series of floating-point numb
 
 `NumberSequence` values MUST have one keypoint with the `Time` field set to `0` and MUST have one keypoint with the `Time` field set to `1`.
 
-A `NumberSequence` with the value `[0, 96, 64] [1, 5, 10]` would appear as follows:
+A `NumberSequence` with the value `[0, 6, 3] [1, 4, 2]` would appear as follows:
 
 ```xml
-<!--TODO NumberSequence -->
+<NumberSequence name="NumberSequenceExample">0 6 3 1 4 2 </NumberSequence>
 ```
 
 ### OptionalCoordinateFrame
@@ -392,13 +419,20 @@ If `CustomPhysics` is `false`, then it will be the only child element present.
 A custom `PhysicalProperties` created with this constructor:
 
 ```lua
-PhysicalProperties.new(0, 1, -1, 0.15625, 1337)
+PhysicalProperties.new(1, 2, 3, 0.15625, 1.25)
 ```
 
 Would appear as follows:
 
 ```xml
-<!--TODO PhysicalProperties-->
+<PhysicalProperties name="PhysicalPropertiesExample">
+	<CustomPhysics>true</CustomPhysics>
+	<Density>1</Density>
+	<Friction>2</Friction>
+	<Elasticity>1</Elasticity>
+	<FrictionWeight>0.15625</FrictionWeight>
+	<ElasticityWeight>1.25</ElasticityWeight>
+</PhysicalProperties>
 ```
 
 ### ProtectedString
@@ -409,8 +443,8 @@ To ease use, `ProtectedString` values SHOULD have their contents written as surr
 
 A `ProtectedString` with the contents `print("Hello, world!")` message would appear as follows:
 
-```
-<!--TODO ProtectedString-->
+```xml
+<ProtectedString name="ProtectedStringExample"><![CDATA[print("Hello world!")]]></ProtectedString>
 ```
 
 ### Ray
@@ -420,17 +454,39 @@ The `Ray` data type is represented as a sequence of two child elements represent
 A `Ray` with the value `[<1, 2, 3>, <-1, -2, -3>]` would appear as follows:
 
 ```xml
-<!--TODO Ray -->
+<Ray name="RayExample">
+	<origin>
+		<X>1</X>
+		<Y>2</Y>
+		<Z>3</Z>
+	</origin>
+	<direction>
+		<X>-1</X>
+		<Y>-2</Y>
+		<Z>-3</Z>
+	</direction>
+</Ray>
 ```
 
 ### Rect2D
 
-The `Rect2D` data type is represented as a sequence of two child elements representing the `Min` nad `Max` components of the value. These child elements are named `min` and `max` and are both [`Vector2`](#vector2) values.
+The `Rect2D` data type (also known as `Rect`) is represented as a sequence of two child elements representing the `Min` nad `Max` components of the value. These child elements are named `min` and `max` and are both [`Vector2`](#vector2) values.
+
+Despite the canonical name of the data type being `Rect`, elements of this type SHOULD be named `Rect` to maintain compatibility.
 
 A `Rect2D` with the value `[<1, 2>, <3, 4>)` would appear as follows:
 
 ```xml
-<!--TODO Rect2D>
+<Rect2D name="Rect2DExample">
+	<min>
+		<X>1</X>
+		<Y>2</Y>
+	</min>
+	<max>
+		<X>3</X>
+		<Y>4</Y>
+	</max>
+</Rect2D>
 ```
 
 ### Ref
@@ -457,19 +513,19 @@ The `SharedString` data type is represented by a string that points to a `Shared
 A `SharedString` value may appear as follows:
 
 ```xml
-<!--TODO SharedString>
+<SharedString name="SharedStringExample">ZGVra29ub3Rfd2FzX2hlcmU=</SharedString>
 ```
 
 ### string
 
-The `string` data type is represented as a literal sequence of characters inside an element. Any leading or trailing whitespace is trimmed from values with this type.
+The `string` data type is represented as a literal sequence of characters inside an element.
 
 Proper care must be taken to escape characters when necessary.
 
 A `string` value `Hello, world!` would appear as follows:
 
 ```xml
-<string name="Example">Hello, world!</string>
+<string name="StringExample">Hello, world!</string>
 ```
 
 ### token
@@ -481,7 +537,7 @@ Despite the canonical name of the data type being `Enum`, elements of this type 
 A `token` representing `Enum.NormalId.Left` would appear as follows:
 
 ```xml
-<token name="Example">3</token>
+<token name="TokenExample">3</token>
 ```
 
 ### UDim
@@ -491,7 +547,7 @@ The `UDim` data type is represented as a sequence of two child elements indicati
 A `UDim` with the value `{0.15625, 1337}` would appear as follows:
 
 ```xml
-<UDim name="Example">
+<UDim name="UDimExample">
 	<S>0.15625</S>
 	<O>1337</O>
 </UDim>
@@ -503,8 +559,13 @@ The `UDim2` data type is represented as a sequence of four child elements indica
 
 A `UDim2` with the value `{0.15625, 1337}, {-123, 456}` would appear as follows:
 
-```
-<!--TODO UDim2-->
+```xml
+<UDim2 name="UDim2Example">
+	<XS>0.15625</XS>
+	<XO>1337</XO>
+	<YS>-123</YS>
+	<YO>456</YO>
+</UDim2>
 ```
 
 ### UniqueId
@@ -522,7 +583,7 @@ The `UniqueId` data type is represented as hexadecimal-encoded sequence of `16` 
 A `UniqueId` may appear as follows:
 
 ```xml
-<!--TODO UniqueId-->
+<UniqueId name="UniqueIdExample">686f6c792062696e676c6521203a33</UniqueId>
 ```
 
 ### Vector2
@@ -532,7 +593,10 @@ The `Vector2` data type is represented as a sequence of two child elements. Thes
 A `Vector2` with the value `<Infinity, 1337>` would appear as follows:
 
 ```xml
-<!--TODO Vector2>
+<Vector2 name="Vector2Example">
+	<X>INF</X>
+	<Y>1337</Y>
+</Vector2>
 ```
 
 ### Vector2int16
@@ -553,7 +617,11 @@ The `Vector3` data type is represented as a sequence of three child elements. Th
 A `Vector3` with the value `<-Infinity, 0.15625, -1337>` would appear as follows:
 
 ```xml
-
+<Vector3 name="Vector3Example">
+	<X>-INF</X>
+	<Y>0.15625</Y>
+	<Z>-1337</Z>
+</Vector3>
 ```
 
 ### Vector3int16
@@ -565,5 +633,9 @@ All three child elements MUST be in the range `-32768` to `32767`, inclusive.
 A `Vector3int16` with the value `<1337, 0, -1337>` would appear as follows:
 
 ```xml
-
+<Vector3int16 name="Vector3int16Example">
+	<X>1337</X>
+	<Y>0</Y>
+	<Z>-1337</Z>
+</Vector3int16>
 ```

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -205,7 +205,29 @@ A `bool` with the value `false` would appear as follows:
 
 ### Color3
 
+The `Color3` data type is represented by three child elements named `R`, `G`, and `B`. These elements contain the value of that component as 32-bit floating point numbers. See [`float`](#float) for more information on the format of floating point numbers.
+
+A `Color3` with the value `INF, 1337, 3.141592653` would appear as follows:
+
+```xml
+<Color3 name="Example">
+	<R>INF</R>
+	<G>1337</G>
+	<B>3.141592653</B>
+</Color3>
+```
+
 ### Color3uint8
+
+The `Color3uint8` data type is represented by a single unsigned 32-bit integer that is the `R`, `G`, and `B` components of the color (as integers in the range 0 to 255) packed into the lower 24 bits of the number. This integer is little-endian and written in the order `G`, `B`, `R`.
+
+Roblox encodes this type with the upper 8 bits filled with `FF` (in hexadecimal). This SHOULD be done by encoders to avoid compatibility issues.
+
+A `Color3uint8` with the value `96, 64, 32` would appear as follows:
+
+```xml
+<Color3uint8 name="Example">4284497952</Color3uint8>
+```
 
 ### ColorSequence
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -32,7 +32,7 @@ This documentation is incomplete. Contributions are welcome.
 	- [int64](#int64)
 	- [NumberRange](#numberrange)
 	- [NumberSequence](#numbersequence)
-	- [OptionalCoordinateFrame](#optionalcoordinateframe)
+	- [Optional](#optional)
 	- [PhysicalProperties](#physicalproperties)
 	- [ProtectedString](#protectedstring)
 	- [Ray](#ray)
@@ -405,7 +405,39 @@ A `NumberSequence` with the value `[0, 6, 3] [1, 4, 2]` would appear as follows:
 <NumberSequence name="NumberSequenceExample">0 6 3 1 4 2 </NumberSequence>
 ```
 
-### OptionalCoordinateFrame
+### Optional
+
+The `Optional<T>` data type represents an optional value of type `T` and is represented by an element with either one or zero child elements. If the value is present, there will be a child element of type `T`. Otherwise, there is no child element.
+
+Elements of this type should be named `Optional` followed by the name of the type. As an example, for `Optional<CoordinateFrame>`, the element should be named `OptionalCoordinateFrame`.
+
+The name of the child element varies depending upon the type `T` is. The following is a list ofcurrently valid types for `T`, along with the name of the child element:
+
+| Type                                  | Child Element Name |
+|:--------------------------------------|:-------------------|
+| [`CoordinateFrame`](#coordinateframe) | `CFrame`           |
+
+An `Optional<CoordinateFrame>` where the value was `0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1` would appear as follows:
+
+```xml
+<OptionalCoordinateFrame name="OptionalExample">
+	<CFrame>
+		<X>0</X>
+		<Y>0</Y>
+		<Z>0</Z>
+		<R00>1</R00>
+		<R01>0</R01>
+		<R02>0</R02>
+		<R10>0</R10>
+		<R11>1</R11>
+		<R12>0</R12>
+		<R20>0</R20>
+		<R21>0</R21>
+		<R22>1</R22>
+	</CFrame>
+</OptionalCoordinateFrame>
+```
+
 
 ### PhysicalProperties
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -241,6 +241,18 @@ A `Color3uint8` with the value `96, 64, 32` would appear as follows:
 
 ### float
 
+The `float` data type (also known as `Float32` or `single`) is represented as a standard 32-bit floating-point number would be. Specifically, it is compatibile with the [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) type. For full details, view the XSD specification, but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `float` values.
+
+Of note, positive infinity is represented as `INF` or `+INF`, negative infinity is represented by `-INF`, and NaN is represented as `NAN`. Encoders MUST use these representations.
+
+Encoders SHOULD encode `float` values with at least 9 digits of precision but they MAY elect to use less depending upon the property and their own needs.
+
+A `float` with the value `0.15625` would appear as follows:
+
+```xml
+<float name="Example">0.15625</float>
+```
+
 ### Font
 
 ### int

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -165,7 +165,13 @@ All properties are encoded as a single element parented under a `Properties` ele
 
 The contents of type elements vary depending upon the type of the property they represent. 
 
-It is RECOMMENDED that the name of type elements correspond to the type that they represent. This ensures that Roblox does not attempt to deserialize them incorrectly and maintains human readability. 
+In some cases, the name of a type element does not accurately correspond to the type that it represents. At the time of writing, these types are:
+
+- `BrickColor` properties are serialized as `int`
+- `CFrame` properties are serialized as `CoordinateFrame`
+- `Enum` properties are serilaized as `token`
+
+If necessary or desired, encoders MAY serialize type elements using any other name, as Roblox does not utilize the actual element name. However, for the compatibility it is RECOMMENDED that Roblox's own names for type elements be used. As a result, decoders SHOULD utilize a reflection system to map type elements to their actual type rather than relying upon the name of the element.
 
 The following attributes are REQUIRED for all property elements, regardless of their type or name:
 
@@ -216,12 +222,12 @@ A `bool` with the value `false` appears as follows:
 
 The `BrickColor` data type is represented by a single 32-bit integer that represents the `Number` of the value.
 
-Roblox encodes this type with the element name `int` but also accepts `BrickColor`. It is preferred that `BrickColor` be used.
+Roblox encodes this type with the element name `int` but as noted previously, using this name for a tag is not a requirement. It may be desirable for encoders to name elements of this type `BrickColor` if the file is intended to be read by humans.
 
-A `BrickColor` with the value `Medium Stone Grey` (whose number is `194`) should appear as follows:
+A `BrickColor` with the value `Medium Stone Grey` (whose number is `194`) MAY appear as follows:
 
 ```xml
-<BrickColor name="BrickColorExample">194</BrickColor>
+<int name="BrickColorExample">194</int>
 ```
 
 ### Color3

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -83,7 +83,7 @@ All other attributes are OPTIONAL. This includes those produced by Roblox Studio
 
 ## Meta
 
-This element represents a single key-value pair of metadata for the file. There MAY be any number of `Meta` elements in a document but they MUST all be under the `roblox` element.
+This element represents a single key-value pair of metadata for the file. There MAY be any number of `Meta` elements in a file but they MUST all be under the `roblox` element.
 
 The following attributes are REQUIRED for this element:
 
@@ -92,6 +92,14 @@ The following attributes are REQUIRED for this element:
 | `name` | The key part of the metadata key-value pair. |
 
 The contents of this element represent the value of the metadata key-value pair.
+
+Currently, Roblox encodes the following `Meta` elements:
+
+| Name                 | Value  |
+|:---------------------|:-------|
+| `ExplicitAutoJoints` | `true` | <!--TODO: Validate that this is always `true`-->
+
+It is RECOMMENDED that every key-value pair from the above table be encoded to maintain compatibility with Roblox Studio.
 
 ## External
 
@@ -103,7 +111,7 @@ The contents of this element represent an unknown purpose.
 
 ## Item
 
-This element describes one `Instance` value. There should be at least one of these in all files, as otherwise they serve no purpose, but Roblox accepts files with no `Item` elements. All `Item` elements MUST be under either the `roblox` element or other `Item` elements.
+This element describes one `Instance` value. All `Item` elements MUST be under either the `roblox` element or other `Item` elements.
 
 The following attributes are REQUIRED for this element:
 
@@ -115,6 +123,8 @@ The following attributes are REQUIRED for this element:
 The value of `referent` MUST be unique for the file. The value of `referent` MUST NOT be `null`. Roblox utilizes the value `null` when serializing [`Ref`](#ref) properties with no value, so it should be considered a reserved value.
 
 Roblox generates referents by prefixing a UUID with `RBX`, but this is not a requirement.
+
+It is suggested that every file have at least `Item` value as otherwise there is no purpose to the file.
 
 ## Properties
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -1,4 +1,5 @@
 # Roblox XML Model Format, Version 4
+
 This is unofficial documentation for Roblox's XML model format. The XML model format is used for places (`.rbxlx` files), models (`.rbxmx` files), Roblox Studio settings, and many objects uploaded to Roblox's asset storage.
 
 The XML model format has generally been replaced by the newer, more efficient [binary model format](binary.md). Some use cases for the XML format still exist, owing to its human readability.
@@ -80,8 +81,6 @@ The following attributes are REQUIRED for this element:
 
 All other attributes are OPTIONAL. This includes those produced by Roblox Studio.
 
-As stated under [File Structure](#file-structure), this element MUST be the beginning and end of the file.
-
 ## Meta
 
 This element represents a single key-value pair of metadata for the file. There MAY be any number of `Meta` elements in a document but they MUST all be under the `roblox` element.
@@ -100,7 +99,7 @@ This element is a legacy feature and currently does nothing. Roblox Studio encod
 
 There are no attributes required for this element.
 
-The contents of this element represent an unknown purpose, as the element does not do anything.
+The contents of this element represent an unknown purpose.
 
 ## Item
 
@@ -115,7 +114,7 @@ The following attributes are REQUIRED for this element:
 
 The value of `referent` MUST be unique for the file. The value of `referent` MUST NOT be `null`. Roblox utilizes the value `null` when serializing [`Ref`](#ref) properties with no value, so it should be considered a reserved value.
 
-Roblox generates referents by prefixing a UUID with `RBX`, but this is not a requirement .
+Roblox generates referents by prefixing a UUID with `RBX`, but this is not a requirement.
 
 ## Properties
 
@@ -172,7 +171,7 @@ The format for each data type is listed below.
 
 The `Axes` data type is represented with a single `axes` element that contains a single integer between `0` and `7`. This integer represents a bitfield of the `Z`, `Y`, and `X` axes packed into the lower 3 bits of it, in that order.
 
-An `Axes` property with only the `X` axis enabled would appear as follows:
+An `Axes` property with only the `X` axis enabled appears as follows:
 
 ```xml
 <Axes name="AxesExample">
@@ -184,7 +183,7 @@ An `Axes` property with only the `X` axis enabled would appear as follows:
 
 The `BinaryString` data type is represented by the contents of the property encoded with Base64.
 
-A `BinaryString` property with the contents `Rojo is cool!` would appear as follows:
+A `BinaryString` property with the contents `Rojo is cool!` appears as follows:
 
 ```xml
 <BinaryString name="BinaryStringExample">Um9qbyBpcyBjb29sIQ==</BinaryString>
@@ -196,7 +195,7 @@ The `bool` data type is represented by a literal string reading either `true` or
 
 Although Roblox accepts variations such as `fAlSe` and `TRUE`, by convention values SHOULD be written in all lowercase.
 
-A `bool` with the value `false` would appear as follows:
+A `bool` with the value `false` appears as follows:
 
 ```xml
 <bool name="BoolExample">false</bool>
@@ -218,7 +217,7 @@ A `BrickColor` with the value `Medium Stone Grey` (whose number is `194`) should
 
 The `Color3` data type is represented by three child elements named `R`, `G`, and `B`. These elements contain the value of that component as written as a [`float`](#float).
 
-A `Color3` with the value `INF, 1337, 0.15625` would appear as follows:
+A `Color3` with the value `INF, 1337, 0.15625` appears as follows:
 
 ```xml
 <Color3 name="Color3Example">
@@ -234,7 +233,7 @@ The `Color3uint8` data type is represented by a single unsigned 32-bit integer t
 
 The upper 8 bits of the value SHOULD be filled with `FF` (in hexadecimal). This is to maintain compatibility with Roblox.
 
-A `Color3uint8` with the value `96, 64, 32` would appear as follows:
+A `Color3uint8` with the value `96, 64, 32` appears as follows:
 
 ```xml
 <Color3uint8 name="Color3uint8Example">4284497952</Color3uint8>
@@ -248,7 +247,7 @@ At this moment, the `Envelope` section of this sequence is unused and should alw
 
 `ColorSequence` values MUST have one keypoint with the `Time` field set to `0` and MUST have one keypoint with the `Time` field set to `1`.
 
-A `ColorSequence` with the value `[0, 96, 64, 32] [1, 5, 10, 15]` would appear as follows:
+A `ColorSequence` with the value `[0, 96, 64, 32] [1, 5, 10, 15]` appears as follows:
 
 ```xml
 <ColorSequence name="ColorSequenceExample">0 0.376471 0.25098 0.12549 0 1 0.0196078 0.0392157 0.0588235 0 </ColorSequence>
@@ -262,7 +261,7 @@ If the child element is `url`, then the value of it is the `Content`'s URI. If t
 
 If the child element is either `binary` or `hash`, the contents SHOULD be disregarded and the `Content` should be viewed as empty. These tags MUST NOT be written by encoders.
 
-A `Content` with the value `rbxasset://textures/face.png` would appear as follows:
+A `Content` with the value `rbxasset://textures/face.png` appears as follows:
 
 ```xml
 <Content name="ContentExample"><url>rbxasset://textures/face.png</url></Content>
@@ -280,7 +279,7 @@ The `CFrame` data type is represented by a single element named `CoordinateFrame
 
 Despite the canonical name of the data type being `CFrame`, elements of this type MUST be named `CoordinateFrame` to maintain compatibility.
 
-A `CFrame` with the components `0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1` would appear as follows:
+A `CFrame` with the components `0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1` appears as follows:
 
 ```xml
 <CoordinateFrame name="CoordinateFrameExample">
@@ -305,9 +304,9 @@ The `double` data type (also known as `Float64`) is represented as a standard 64
 
 Positive infinity is represented as `INF` or `+INF`, negative infinity is represented as `-INF`, and NaN is represented as `NAN`. To be compatible, encoders MUST use these representations, including the all upper casing.
 
-Encoders should encode `double` values with at least 17 significant figures but they may elect to use less depending upon the property and their own needs.
+Encoders should encode `double` values with at least 16 significant figures but they may elect to use less depending upon the property and their own needs.
 
-A `double` with the value `0.15625` would appear as follows:
+A `double` with the value `0.15625` appears as follows:
 
 ```xml
 <double name="DoubleExample">0.15625</double>
@@ -317,7 +316,7 @@ A `double` with the value `0.15625` would appear as follows:
 
 The `Faces` data type is represented with a single `faces` element that contains a single integer between `0` and `63`, inclusive. This integer represents a bitfield of the `Right`, `Top`, `Back`, `Left`, `Bottom`, and `Front` faces packed into the lower 6 bits of it, in that order.
 
-A `Faces` property with the `Front`, `Left`, and `Top` faces enabled would appear as follows:
+A `Faces` property with the `Front`, `Left`, and `Top` faces enabled appears as follows:
 
 ```xml
 <Faces name="FacesExample">
@@ -331,9 +330,9 @@ The `float` data type (also known as `Float32` or `single`) is represented as a 
 
 Positive infinity is represented as `INF` or `+INF`, negative infinity is represented as `-INF`, and NaN is represented as `NAN`. To be compatible, encoders MUST use these representations, including the all upper casing.
 
-Encoders should encode `double` values with at least 9 significant figures but they may elect to use less depending upon the property and their own needs.
+Encoders should encode `float` values with at least 7 significant figures but they may elect to use less depending upon the property and their own needs.
 
-A `float` with the value `0.15625` would appear as follows:
+A `float` with the value `0.15625` appears as follows:
 
 ```xml
 <float name="FloatExample">0.15625</float>
@@ -356,7 +355,7 @@ The `Style` element is the name of an item from the Roblox `FontStyle` enum. At 
 
 The `CachedFaceId` element will point to a locally cached copy of the `Font`'s source file if it is present. This element is OPTIONAL.
 
-A `Font` with the value `Arial, Italic, Bold` would appear as follows:
+A `Font` with the value `Arial, Italic, Bold` appears as follows:
 
 ```xml
 <Font name="FontExample">
@@ -372,7 +371,7 @@ The `int` data type (also known as `Int32`) is represented as a number in the ra
 
 Positive numbers MUST NOT be prefixed with `+`.
 
-An `int` value of `1337` would appear as follows:
+An `int` value of `1337` appears as follows:
 
 ```xml
 <int name="IntExample">1337</int>
@@ -384,7 +383,7 @@ The `int64` data type (also known as `Int64` or `long`) is represented as a numb
 
 Positive numbers MUST NOT be prefixed with `+`.
 
-An `int64` value of `-559038737` would appear as follows:
+An `int64` value of `-559038737` appears as follows:
 
 ```xml
 <int64 name="Int64Example">-559038737</int64>
@@ -396,7 +395,7 @@ The `NumberRange` data type is represented as sequence of two floating-point num
 
 Both numbers are formatted as [`float`](#float) values.
 
-A `NumberRange` value of `0.15625, 1337` would appear as follows:
+A `NumberRange` value of `0.15625, 1337` appears as follows:
 
 ```xml
 <NumberRange name="NumberRangeExample">0.15625 1337 </NumberRange>
@@ -408,7 +407,7 @@ The `NumberSequence` data type is represented by a series of floating-point numb
 
 `NumberSequence` values MUST have one keypoint with the `Time` field set to `0` and MUST have one keypoint with the `Time` field set to `1`.
 
-A `NumberSequence` with the value `[0, 6, 3] [1, 4, 2]` would appear as follows:
+A `NumberSequence` with the value `[0, 6, 3] [1, 4, 2]` appears as follows:
 
 ```xml
 <NumberSequence name="NumberSequenceExample">0 6 3 1 4 2 </NumberSequence>
@@ -426,7 +425,7 @@ The name of the child element varies depending upon the type `T` is. The followi
 |:--------------------------------------|:-------------------|
 | [`CoordinateFrame`](#coordinateframe) | `CFrame`           |
 
-An `Optional<CoordinateFrame>` where the value was `0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1` would appear as follows:
+An `Optional<CoordinateFrame>` where the value was `0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1` appears as follows:
 
 ```xml
 <OptionalCoordinateFrame name="OptionalExample">
@@ -462,7 +461,7 @@ A custom `PhysicalProperties` created with this constructor:
 PhysicalProperties.new(1, 2, 3, 0.15625, 1.25)
 ```
 
-Would appear as follows:
+Appears as follows:
 
 ```xml
 <PhysicalProperties name="PhysicalPropertiesExample">
@@ -481,7 +480,7 @@ The `ProtectedString` data type is represented as a string. This data type MUST 
 
 To ease use, `ProtectedString` values should have their contents written as surrounded by `CDATA`. If this is not possible, then care must be taken to escape characters when necessary.
 
-A `ProtectedString` with the contents `print("Hello, world!")` message would appear as follows:
+A `ProtectedString` with the contents `print("Hello, world!")` message appears as follows:
 
 ```xml
 <ProtectedString name="ProtectedStringExample"><![CDATA[print("Hello world!")]]></ProtectedString>
@@ -491,7 +490,7 @@ A `ProtectedString` with the contents `print("Hello, world!")` message would app
 
 The `Ray` data type is represented as a sequence of two child elements representing the `Origin` and `Direction` components of the value. These child elements are named `origin` and `direction` and are both [`Vector3`](#vector3) values.
 
-A `Ray` with the value `[<1, 2, 3>, <-1, -2, -3>]` would appear as follows:
+A `Ray` with the value `[<1, 2, 3>, <-1, -2, -3>]` appears as follows:
 
 ```xml
 <Ray name="RayExample">
@@ -514,7 +513,7 @@ The `Rect2D` data type (also known as `Rect`) is represented as a sequence of tw
 
 Despite the canonical name of the data type being `Rect`, elements of this type SHOULD be named `Rect2D` to maintain compatibility.
 
-A `Rect2D` with the value `[<1, 2>, <3, 4>)` would appear as follows:
+A `Rect2D` with the value `[<1, 2>, <3, 4>)` appears as follows:
 
 ```xml
 <Rect2D name="Rect2DExample">
@@ -537,7 +536,7 @@ Roblox encodes empty `Ref` values as `null`. Encoders SHOULD also use `null` to 
 
 Although the canonical name of this data type is `Referent`, elements of this type MUST be named `Ref` to ensure compatibility.
 
-A `Ref` value pointing to a random `Item` may appear as follows:
+A `Ref` value pointing to an `Item` with a `referent` of `RBX466F72207262782D646F6D21203A2D29` appears as follows:
 
 ```xml
 <Ref name="Example">RBX466F72207262782D646F6D21203A2D29</Ref>
@@ -552,7 +551,7 @@ The `SharedString` data type is represented by a string that points to a `Shared
 
 The `SharedString` data type is represented by a string that points to a `SharedString` defined elsewhere in the file. Specifically, the contents of elements of this type MUST be equal to the `md5` attribute of a [`SharedString` definition][SharedString-def].
 
-A `SharedString` value may appear as follows:
+A `SharedString` value pointing to the `SharedString` with its `md5` attribute equal to `ZGVra29ub3Rfd2FzX2hlcmU=` appears as follows:
 
 ```xml
 <SharedString name="SharedStringExample">ZGVra29ub3Rfd2FzX2hlcmU=</SharedString>
@@ -564,7 +563,7 @@ The `string` data type is represented as a literal sequence of characters inside
 
 Proper care must be taken to escape characters when necessary.
 
-A `string` value `Hello, world!` would appear as follows:
+A `string` value `Hello, world!` appears as follows:
 
 ```xml
 <string name="StringExample">Hello, world!</string>
@@ -576,7 +575,7 @@ The `token` data type (also known as `Enum`) is represented as a sequence of num
 
 Despite the canonical name of the data type being `Enum`, elements of this type MUST be named `token` to maintain compatibility.
 
-A `token` representing `Enum.NormalId.Left` would appear as follows:
+A `token` representing `Enum.NormalId.Left` (whose value is `3`) appears as follows:
 
 ```xml
 <token name="TokenExample">3</token>
@@ -586,7 +585,7 @@ A `token` representing `Enum.NormalId.Left` would appear as follows:
 
 The `UDim` data type is represented as a sequence of two child elements indicating the `Scale` and `Offset` components of the value. These child elements are named `S` and `O`. The `S` element is a [`float`](#float) and the `O` element is a [`int`](#int).
 
-A `UDim` with the value `{0.15625, 1337}` would appear as follows:
+A `UDim` with the value `{0.15625, 1337}` appears as follows:
 
 ```xml
 <UDim name="UDimExample">
@@ -599,7 +598,7 @@ A `UDim` with the value `{0.15625, 1337}` would appear as follows:
 
 The `UDim2` data type is represented as a sequence of four child elements indicating the `X.Scale`, `X.Offset`, `Y.Scale`, `Y.Offset` components of the value. These elements are named `XS`, `XO`, `YS`, and `YO`. The `XS` and `YS` elements are [`float`](#float) values and the `XO` and `YO` elements are [`int`](#int) values.
 
-A `UDim2` with the value `{0.15625, 1337}, {-123, 456}` would appear as follows:
+A `UDim2` with the value `{0.15625, 1337}, {-123, 456}` appears as follows:
 
 ```xml
 <UDim2 name="UDim2Example">
@@ -622,7 +621,7 @@ The `UniqueId` data type is represented as hexadecimal-encoded sequence of `16` 
 
 **NOTE**: The `Random` component is serialized differently between the XML and [binary](binary.md) format. Specifically, in the XML format it is left-circular rotated by `1` bit. If working with both file formats, care MUST be taken to ensure the `Random` component is the same between formats.
 
-A `UniqueId` may appear as follows:
+A `UniqueId` with random components may appear as follows:
 
 ```xml
 <UniqueId name="UniqueIdExample">686f6c792062696e676c6521203a33</UniqueId>
@@ -632,7 +631,7 @@ A `UniqueId` may appear as follows:
 
 The `Vector2` data type is represented as a sequence of two child elements. These child elements are named `X` and `Y` and represent the respective components of the value. Both of these elements are [`float`](#float) values.
 
-A `Vector2` with the value `<Infinity, 1337>` would appear as follows:
+A `Vector2` with the value `<Infinity, 1337>` appears as follows:
 
 ```xml
 <Vector2 name="Vector2Example">
@@ -645,7 +644,7 @@ A `Vector2` with the value `<Infinity, 1337>` would appear as follows:
 
 The `Vector3` data type is represented as a sequence of three child elements. These child elements are named `X`, `Y`, and `Z` and represent the respective components of the value. All three elements are [`float`](#float) values.
 
-A `Vector3` with the value `<-Infinity, 0.15625, -1337>` would appear as follows:
+A `Vector3` with the value `<-Infinity, 0.15625, -1337>` appears as follows:
 
 ```xml
 <Vector3 name="Vector3Example">
@@ -661,7 +660,7 @@ The `Vector3int16` data type is represented as a sequence of three child element
 
 All three child elements MUST be in the range `-32768` to `32767`, inclusive.
 
-A `Vector3int16` with the value `<1337, 0, -1337>` would appear as follows:
+A `Vector3int16` with the value `<1337, 0, -1337>` appears as follows:
 
 ```xml
 <Vector3int16 name="Vector3int16Example">

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -143,9 +143,12 @@ The value of this element MUST be the SharedString value encoded with Base64.
 
 ## Type Elements
 
-All elements below this point represent a single property on a single `Instance`. They all MUST be under a [`Properties`](#properties) element. There MAY be zero or more of each of these elements under each `Properties` element.
+All properties are encoded as a single element parented under a `Properties` element. Each element represents exactly one property for one `Instance`.
 
-The following attributes are required for all type elements:
+The contents of the element vary depending upon the type of the property it represents. The name of the element SHOULD be the name of the datatype, but Roblox does not require it to be.
+
+The following attributes are required for all property elements, regardless of their type or name:
+
 
 | Name   | Contents                                              |
 |:-------|:------------------------------------------------------|
@@ -153,13 +156,52 @@ The following attributes are required for all type elements:
 
 The `name` of a property does not necessarily reflect its in-engine name, and some properties serialize with unexpected names. Additionally, not every property is deserialized by Roblox.
 
+The format for each data type is listed below.
+
 ### Axes
+
+The `Axes` data type is represented with a single `axes` element that contains a single integer between `0` and `7`. This integer represents a bitfield of the `Z`, `Y`, and `X` axes packed into the lower 3 bits of it, in that order.
+
+An `Axes` property with only the `X` axis enabled would appear as follows:
+
+```xml
+<Axes name="Example"><axes>1</axes></Axes>
+```
 
 ### BinaryString
 
+The `BinaryString` data type is represented by the contents of the property encoded with Base64.
+
+
+A `BinaryString` property with the contents `Rojo is cool!` would appear as follows:
+
+```xml
+<BinaryString name="Example">Um9qbyBpcyBjb29sIQ==</BinaryString>
+```
+
 ### BrickColor
 
+The `BrickColor` data type is represented by a single 32-bit integer that represents the `Number` of the value.
+
+Roblox encodes this type with the element name `int` but by convention, the element SHOULD be named `BrickColor`.
+
+A `BrickColor` with the value `Medium Stone Grey` (whose number is `194`) would appear as follows:
+
+```xml
+<BrickColor name="Example">194</BrickColor>
+```
+
 ### bool
+
+The `bool` data type is represented by a literal string reading either `true` or `false` depending upon the state of the value.
+
+Although Roblox accepts variations such as `fAlSe` and `TRUE`, by convention values SHOULD be written in all lowercase.
+
+A `bool` with the value `false` would appear as follows:
+
+```xml
+<bool name="Example">false</bool>
+```
 
 ### Color3
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -33,8 +33,11 @@ This documentation is incomplete. Contributions are welcome.
 	- [NumberRange](#numberrange)
 	- [NumberSequence](#numbersequence)
 	- [OptionalCoordinateFrame](#optionalcoordinateframe)
-	- [Ref](#ref) (Referent)
+	- [PhysicalProperties](#physicalproperties)
+	- [ProtectedString](#protectedstring)
+	- [Ray](#ray)
 	- [Rect2D](#rect2d)
+	- [Ref](#ref) (Referent)
 	- [SharedString][SharedString-use] (property type)
 	- [string](#string)
 	- [token](#token) (Enum)
@@ -45,7 +48,6 @@ This documentation is incomplete. Contributions are welcome.
 	- [Vector2int16](#vector2int16)
 	- [Vector3](#vector3)
 	- [Vector3int16](#vector3int16)
-
 
 ## File Structure
 Roblox XML files consist of a single `<roblox>` element, which contain a sequence of other elements. The basic layout of the file structure is as follows:
@@ -172,7 +174,6 @@ An `Axes` property with only the `X` axis enabled would appear as follows:
 
 The `BinaryString` data type is represented by the contents of the property encoded with Base64.
 
-
 A `BinaryString` property with the contents `Rojo is cool!` would appear as follows:
 
 ```xml
@@ -231,19 +232,73 @@ A `Color3uint8` with the value `96, 64, 32` would appear as follows:
 
 ### ColorSequence
 
+The `ColorSequence` data type is represented by a series of floating-point numbers seperated by a single space. Every 5 elements in this series represents a single keypoint of the `ColorSequence`. The elements are written in the order `Time`, `Value.R`, `Value.G`, `Value.B`, and `Envelope`.
+
+At this moment, the `Envelope` section of this sequence is unused and SHOULD always be `0`. It MUST be included.
+
+`ColorSequence` values MUST have one keypoint with the `Time` field set to `0` and MUST have one keypoint with the `Time` field set to `1`.
+
+A `ColorSequence` with the value `[0, 96, 64, 32] [1, 5, 10, 15]` would appear as follows:
+
+```xml
+<!--TODO ColorSequence -->
+```
+
 ### Content
+
+The `Content` data type is represented by a single element with one of several child elements. Currently, the name of this child element may be `url` or `null`. Historically, it could be `binary` or `hash`. This child element is not nillable and MUST include an opening and closing tag.
+
+If the child element is `url`, then the value of it is the `Content`'s URI. If the element is `null`, it indicates the `Content` is empty. When the child element is `null`, it MUST be empty. 
+
+If the child element is either `binary` or `hash`, the contents SHOULD be disregarded and the `Content` should be viewed as empty. These tags MUST NOT be written by encoders.
+
+A `Content` with the value `rbxasset://textures/SpawnLocation.png` would appear as follows:
+
+```xml
+<!--TODO Content-->
+```
 
 ### CoordinateFrame
 
+The `CFrame` data type is represented by a single element named `CoordinateFrame` with 12 child elements representing each of the components of the value. In order, these components are: `X`, `Y`, `Z`, `R00`, `R01`, `R02`, `R10`, `R11`, `R12`, `R20`, `R21`, `R22`. Each of these child elements is a [`float`](#float) value.
+
+Despite the canonical name of the data type being `CFrame`, elements of this type MUST be named `CoordinateFrame` to maintain compatibility.
+
+A `CFrame` with the components `INSERT CFRAME` would appear as follows:
+
+```xml
+<!--TODO CFrame>
+```
+
 ### double
+
+The `double` data type (also known as `Float64`) is represented as a standard 64-bit floating point number would be. Specifically, it is represented by the [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) type. For full details, view the XSD specification but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `double` values.
+
+Positive infinity is represented as `INF` or `+INF`, negative infinity is represented as `-INF`, and NaN is represented as `NAN`. To be compatible, encoders MUST use these representations, including the all upper casing.
+
+Encoders SHOULD encode `double` values with at least 17 digits of precision but they MAY elect to use less depending upon the property and their own needs.
+
+A `double` with the value `0.15625` would appear as follows:
+
+```xml
+<!--TODO double>
+```
 
 ### Faces
 
+The `Faces` data type is represented with a single `faces` element that contains a single integer between `0` and `63`, inclusive. This integer represents a bitfield of the `Right`, `Top`, `Back`, `Left`, `Bottom`, and `Front` faces packed into the lower 6 bits of it, in that order.
+
+A `Faces` property with the `Front`, `Left`, and `Top` faces enabled would appear as follows:
+
+```xml
+<!--TODO Faces>
+```
+
 ### float
 
-The `float` data type (also known as `Float32` or `single`) is represented as a standard 32-bit floating-point number would be. Specifically, it is compatibile with the [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) type. For full details, view the XSD specification, but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `float` values.
+The `float` data type (also known as `Float32` or `single`) is represented as a standard 32-bit floating-point number would be. Specifically, it is represented by the [XSD precision decimal](https://www.w3.org/TR/xsd-precisionDecimal/) type. For full details, view the XSD specification, but strings such as `1.0`, `1`, `-0`, and `13e37` are all valid representations of `float` values.
 
-Of note, positive infinity is represented as `INF` or `+INF`, negative infinity is represented by `-INF`, and NaN is represented as `NAN`. Encoders MUST use these representations.
+Positive infinity is represented as `INF` or `+INF`, negative infinity is represented as `-INF`, and NaN is represented as `NAN`. To be compatible, encoders MUST use these representations, including the all upper casing.
 
 Encoders SHOULD encode `float` values with at least 9 digits of precision but they MAY elect to use less depending upon the property and their own needs.
 
@@ -255,24 +310,155 @@ A `float` with the value `0.15625` would appear as follows:
 
 ### Font
 
+The `Font` data type is represented with 4 child elements. These elements and their type is listed as follows:
+
+- `Family` - `Content`
+- `Weight` - `int`
+- `Style` - `String`
+- `CachedFaceId` - `Content`
+
+The `Family` element is a URI to the family definition of the value. This will likely be a local file.
+
+The `Weight` element is a value of an item from the Roblox `FontWeight` enum. This will be a value in between `100` and `900` (inclusive) that is a multiple of `100`.
+
+The `Style` element is the name of an item from the Roblox `FontStyle` enum. At this time, the only values are `Normal` and `Italic`.
+
+The `CachedFaceId` element will point to a locally cached copy of the `Font`'s source file if it is present. <!--TODO determine if optional>
+
+A `Font` with the value `Arial, Italic, Bold` would appear as follows:
+
+```xml
+<!--TODO Font>
+```
+
 ### int
+
+The `int` data type (also known as `Int32`) is represented as a number in the range `-2147483648` to `2147483647`, inclusive. This is the range of a signed 32-bit integer.
+
+Positive numbers MUST NOT be prefixed with `+`.
+
+An `int` value of `1337` would appear as follows:
+
+```xml
+<int name="Example">1337</int>
+```
 
 ### int64
 
+The `int64` data type (also known as `Int64` or `long`) is represented as a number in the range `-9223372036854775808` to `9223372036854775807`, inclusive. This is the range of a 64-bit integer.
+
+Positive numbers MUST NOT be prefixed with `+`.
+
+An `int64` value of `-559038737` would appear as follows:
+
+```xml
+<int64 name="Example">-559038737</int64>
+```
+
 ### NumberRange
+
+The `NumberRange` data type is represented as sequence of two floating-point numbers seperated by a space. These numbers represent the `Min` and `Max` components of the value in that order.
+
+Both numbers are formatted as [`float`](#float) values.
+
+A `NumberRange` value of `0.15625, 1337` would appear as follows:
+
+```xml
+<NumberRange name="Example">0.15625 1337 </NumberRange>
+```
 
 ### NumberSequence
 
+The `NumberSequence` data type is represented by a series of floating-point numbers seperated by a single space. Every 3 elements in this series represents a single keypoint of the `NumberSequence`. The elements are written in the order `Time`, `Value`, and `Envelope`.
+
+`NumberSequence` values MUST have one keypoint with the `Time` field set to `0` and MUST have one keypoint with the `Time` field set to `1`.
+
+A `NumberSequence` with the value `[0, 96, 64] [1, 5, 10]` would appear as follows:
+
+```xml
+<!--TODO NumberSequence -->
+```
+
 ### OptionalCoordinateFrame
+
+### PhysicalProperties
+
+The `PhysicalProperties` data type is represented as a sequence of either one or six child elements. The first child element is named `CustomPhysics` and is a [`bool`](#bool) value indicating whether the data type is custom or not.
+
+If `CustomPhysics` is `true`, then there will be an additional `5` child elements. They are named `Density`, `Friction`, `Elasticity`, `FrictionWeight`, and `ElasticityWeight` and represent the respective components of the value. Each of these child elements is a [`float`](#float) value.
+
+If `CustomPhysics` is `false`, then it will be the only child element present.
+
+A custom `PhysicalProperties` created with this constructor:
+
+```lua
+PhysicalProperties.new(0, 1, -1, 0.15625, 1337)
+```
+
+Would appear as follows:
+
+```xml
+<!--TODO PhysicalProperties-->
+```
+
+### ProtectedString
+
+The `ProtectedString` data type is represented as a string. This data type MUST have its contents maintained exactly. Whitespace MUST be preserved for this type.
+
+To ease use, `ProtectedString` values SHOULD have their contents written as surrounded by `CDATA`. If this is not possible, then care must be taken to escape characters when necessary.
+
+A `ProtectedString` with the contents `print("Hello, world!")` message would appear as follows:
+
+```
+<!--TODO ProtectedString-->
+```
+
+### Ray
+
+The `Ray` data type is represented as a sequence of two child elements representing the `Origin` and `Direction` components of the value. These child elements are named `origin` and `direction` and are both [`Vector3`](#vector3) values.
+
+A `Ray` with the value `[<1, 2, 3>, <-1, -2, -3>]` would appear as follows:
+
+```xml
+<!--TODO Ray -->
+```
+
+### Rect2D
+
+The `Rect2D` data type is represented as a sequence of two child elements representing the `Min` nad `Max` components of the value. These child elements are named `min` and `max` and are both [`Vector2`](#vector2) values.
+
+A `Rect2D` with the value `[<1, 2>, <3, 4>)` would appear as follows:
+
+```xml
+<!--TODO Rect2D>
+```
 
 ### Ref
 
-### Rect2D
+The `Ref` data type (also known as `Referent`) is represented by a literal string that corresponds to the `referent` attribute of an [`Item`](#item) element. The `Item` element that this `referent` belongs to represents the `Instance` pointed to by.
+
+Roblox encodes empty `Ref` values as `null`. Encoders SHOULD also use `null` to refer to an empty `Ref` value when necessary.
+
+Although the canonical name of this data type is `Referent`, elements of this type MUST be named `Ref` to ensure compatibility.
+
+A `Ref` value pointing to a random `Item` may appear as follows:
+
+```xml
+<Ref name="Example">RBX466F72207262782D646F6D21203A2D29</Ref>
+```
 
 ### SharedString
 [SharedString-use]: #sharedstring-1
 
 This element shares a name with a SharedString definition element. That element is documented [here][SharedString-def].
+
+The `SharedString` data type is represented by a string that points to a `SharedString` defined elsewhere in the file. Specifically, the contents of elements of this type should be equal to the `md5` attribute of a [`SharedString` definition][#SharedString-def].
+
+A `SharedString` value may look like this:
+
+```xml
+<!--TODO SharedString>
+```
 
 ### string
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -50,19 +50,23 @@ The XML model format has generally been replaced by the newer, more efficient [b
 	- [Vector3int16](#vector3int16)
 
 ## File Structure
-Roblox XML files consist of a single `<roblox>` element, which contain a sequence of other elements. The basic layout of the file structure is as follows:
 
-- Exactly one `<roblox>` element
-	- Zero or more `<Meta>` elements
-	- Zero or more `<External>` elements
-	- One or more `<Item>` elements
-	- One `<Properties>` element
-		- Zero or more type elements
-	- Zero or more `<Item>` elements (this may nest infinitely)
-	- Zero or one `<SharedStrings>` elements
-		- Zero or more `<SharedString>` elements
+Roblox XML files consist of a single `roblox` element, which contain a sequence of other elements.
 
-**To be accepted by Roblox, files MUST start with `<roblox` and end with `</roblox>`, with no whitespace.**
+Underneath the `roblox` element, there can be the following elements:
+- Zero or more `Meta` elements
+- Zero or more `External` elements
+- Zero or more `Item` elements
+- Zero or one `SharedStrings` elements
+
+Underneath each `Item` element, there can be the following elements:
+- One `Properties` element
+- Zero or more `Item` elements
+
+Underneath the `SharedStrings` element, there can be the following elements:
+- Zero or more [`SharedString` definitions][SharedString-def]
+
+Any trailing or leading whitespace in XML files are ignored by Roblox.
 
 ## roblox
 


### PR DESCRIPTION
Wrote out a spec file for the XML file format since it's long overdue. I would love feedback on this because I'm not 100% convinced on some of the descriptions, but it should hopefully be workable.

Rendered document is [here](https://github.com/Dekkonot/rbx-dom/blob/xml-spec/docs/xml.md).

---

I'd also like feedback on whether or not we should document `Qdir`/`QFont` since they're not really useful to anybody but Roblox. I can definitely see the usefulness of having that information if you were working with settings files, but that seems like an uncommon use case.

The same question applies to more esoteric elements like `MetaBreakpoints` and `ScriptDocs`. I'm leaning towards no, since those are really obscure and are only seen in internal files that aren't used for models or places, but I'd still like people's opinions.