### PR TITLE
Make SSTR chunk deterministic

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 * Added support for `Font` values. ([#248])
+* Fixed the nondeterministic output of SSTR chunk when multiple shared strings are present. ([#254])
 
 [#248]: https://github.com/rojo-rbx/rbx-dom/pull/248
+[#254]: https://github.com/rojo-rbx/rbx-dom/pull/254
 
 ## 0.6.6 (2022-06-29)
 * Fixed unserialized properties getting deserialized, like `BasePart.MaterialVariant`. ([#230])

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -40,6 +40,7 @@ binary_tests! {
     ref_adjacent,
     ref_child,
     ref_parent,
+    sharedstring,
     tags,
     three_brickcolorvalues,
     three_color3values,

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__sharedstring__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__sharedstring__decoded.snap
@@ -1,0 +1,1433 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Parts
+  class: Model
+  properties:
+    Attributes:
+      Attributes: {}
+    LevelOfDetail:
+      Enum: 0
+    ModelMeshCFrame:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Vector3:
+        - 0
+        - 0
+        - 0
+    ModelStreamingMode:
+      Enum: 0
+    NeedsPivotMigration:
+      Bool: false
+    PrimaryPart: "null"
+    ScaleFactor:
+      Float32: 1
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    WorldPivotData:
+      OptionalCFrame:
+        position:
+          - -0.69070053
+          - 1.3813775
+          - -0.8003998
+        orientation:
+          - - -0.10631021
+            - 0.0024746137
+            - -0.99433017
+          - - -0.021991055
+            - -0.99975836
+            - -0.00013692312
+          - - -0.9940901
+            - 0.021851815
+            - 0.10633871
+  children:
+    - referent: referent-1
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -0.09659165
+              - 1.517803
+              - -0.83597946
+            orientation:
+              - - 0.10630996
+                - -0.0024746126
+                - -0.9943304
+              - - 0.021991052
+                - 0.999758
+                - -0.0001369233
+              - - 0.99409056
+                - -0.02185182
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 1.0000002
+            - 18
+            - 31.000004
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.3600072
+            - 0.6200124
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-2
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.2853186
+              - 1.5163233
+              - -0.769176
+            orientation:
+              - - -0.106310226
+                - -0.0024746126
+                - 0.99433064
+              - - -0.02199106
+                - 0.999758
+                - 0.00013691811
+              - - -0.9940908
+                - -0.02185182
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 1.0000002
+            - 18
+            - 31.000004
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000714
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-3
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: ""
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0.16903359
+              - 1.3672578
+              - -0.89124817
+            orientation:
+              - - 0.10630996
+                - 0.002474614
+                - 0.99433064
+              - - 0.021991052
+                - -0.99975836
+                - 0.00013691811
+              - - 0.99409056
+                - 0.02185183
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 248
+            - 248
+            - 248
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 4.8
+            - 2.0098171
+            - 2.0169144
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 1088
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 36
+          hash: a8e881ce93449542139935bd0ec3f0a77725c368b5a699b2b87077d9fd842a64
+        PhysicalConfigData:
+          len: 19694
+          hash: c0f5b001cda7f15fa5f109b9872cecc30fcc0ce5d83a101d95a77f4ee7cfb221
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.096
+            - 0.05
+            - 0.05
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: false
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-4
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -0.102969766
+              - 1.5164837
+              - -0.8956378
+            orientation:
+              - - 0.10630996
+                - -0.0024746126
+                - -0.9943304
+              - - 0.021991052
+                - 0.999758
+                - -0.0001369233
+              - - 0.99409056
+                - -0.02185182
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 1.0000002
+            - 18
+            - 31.000004
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.3600072
+            - 0.6200124
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-5
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.2789422
+              - 1.5176423
+              - -0.70953286
+            orientation:
+              - - -0.106310226
+                - -0.0024746126
+                - 0.99433064
+              - - -0.02199106
+                - 0.999758
+                - 0.00013691811
+              - - -0.9940908
+                - -0.02185182
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 1.0000002
+            - 18
+            - 31.000004
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000714
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-6
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.2813833
+              - 1.2170323
+              - -0.7327989
+            orientation:
+              - - -0.106310226
+                - 0.002474614
+                - -0.9943304
+              - - -0.02199106
+                - -0.99975836
+                - -0.0001369233
+              - - -0.9940908
+                - 0.02185183
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 1.0000002
+            - 18
+            - 31.000004
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000717
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-7
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: ""
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.5503206
+              - 1.3669466
+              - -0.7073545
+            orientation:
+              - - -0.106310226
+                - 0.002474614
+                - -0.9943304
+              - - -0.02199106
+                - -0.99975836
+                - -0.0001369233
+              - - -0.9940908
+                - 0.02185183
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 248
+            - 248
+            - 248
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 4.800001
+            - 2.0047607
+            - 2.0113258
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 1088
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 36
+          hash: 9262df03156e7ba931096479dc69773b7674d01299e9a832118c53cc21f388ed
+        PhysicalConfigData:
+          len: 16278
+          hash: ab812b4f1546543445cb10ee2ae8a71c7993a54932de7b1f7a60612a8a027dfa
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.2
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.09600002
+            - 0.05
+            - 0.05
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: false
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-8
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -0.099030495
+              - 1.2171957
+              - -0.85926116
+            orientation:
+              - - 0.10630996
+                - 0.002474614
+                - 0.99433064
+              - - 0.021991052
+                - -0.99975836
+                - 0.00013691811
+              - - 0.99409056
+                - 0.02185183
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData:
+          BinaryString: ""
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FormFactor:
+          Enum: 3
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        InitialSize:
+          Vector3:
+            - 1.0000002
+            - 18
+            - 31.000004
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MaterialVariantSerialized:
+          BinaryString: ""
+        MeshData:
+          BinaryString: ""
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PhysicsData:
+          BinaryString: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000717
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__sharedstring__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__sharedstring__encoded.snap
@@ -1,0 +1,1251 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 2
+num_instances: 9
+chunks:
+  - Sstr:
+      version: 0
+      entries:
+        - len: 36
+          hash: 9262df03156e7ba931096479dc69773b7674d01299e9a832118c53cc21f388ed
+        - len: 36
+          hash: a8e881ce93449542139935bd0ec3f0a77725c368b5a699b2b87077d9fd842a64
+        - len: 16278
+          hash: ab812b4f1546543445cb10ee2ae8a71c7993a54932de7b1f7a60612a8a027dfa
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        - len: 19694
+          hash: c0f5b001cda7f15fa5f109b9872cecc30fcc0ce5d83a101d95a77f4ee7cfb221
+        - len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+  - Inst:
+      type_id: 0
+      type_name: Model
+      object_format: 0
+      referents:
+        - 0
+  - Inst:
+      type_id: 1
+      type_name: UnionOperation
+      object_format: 0
+      referents:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 3
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelStreamingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Parts
+  - Prop:
+      type_id: 0
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: ScaleFactor
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - position:
+            - -0.69070053
+            - 1.3813775
+            - -0.8003998
+          orientation:
+            - - -0.10631021
+              - 0.0024746137
+              - -0.99433017
+            - - -0.021991055
+              - -0.99975836
+              - -0.00013692312
+            - - -0.9940901
+              - 0.021851815
+              - 0.10633871
+  - Prop:
+      type_id: 1
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: AssetId
+      prop_type: String
+      values:
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - ""
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - ""
+        - "https://www.roblox.com//asset/?id=2892119179"
+  - Prop:
+      type_id: 1
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - -0.09659165
+            - 1.517803
+            - -0.83597946
+          orientation:
+            - - 0.10630996
+              - -0.0024746126
+              - -0.9943304
+            - - 0.021991052
+              - 0.999758
+              - -0.0001369233
+            - - 0.99409056
+              - -0.02185182
+              - 0.1063388
+        - position:
+            - -1.2853186
+            - 1.5163233
+            - -0.769176
+          orientation:
+            - - -0.106310226
+              - -0.0024746126
+              - 0.99433064
+            - - -0.02199106
+              - 0.999758
+              - 0.00013691811
+            - - -0.9940908
+              - -0.02185182
+              - -0.10633907
+        - position:
+            - 0.16903359
+            - 1.3672578
+            - -0.89124817
+          orientation:
+            - - 0.10630996
+              - 0.002474614
+              - 0.99433064
+            - - 0.021991052
+              - -0.99975836
+              - 0.00013691811
+            - - 0.99409056
+              - 0.02185183
+              - -0.10633907
+        - position:
+            - -0.102969766
+            - 1.5164837
+            - -0.8956378
+          orientation:
+            - - 0.10630996
+              - -0.0024746126
+              - -0.9943304
+            - - 0.021991052
+              - 0.999758
+              - -0.0001369233
+            - - 0.99409056
+              - -0.02185182
+              - 0.1063388
+        - position:
+            - -1.2789422
+            - 1.5176423
+            - -0.70953286
+          orientation:
+            - - -0.106310226
+              - -0.0024746126
+              - 0.99433064
+            - - -0.02199106
+              - 0.999758
+              - 0.00013691811
+            - - -0.9940908
+              - -0.02185182
+              - -0.10633907
+        - position:
+            - -1.2813833
+            - 1.2170323
+            - -0.7327989
+          orientation:
+            - - -0.106310226
+              - 0.002474614
+              - -0.9943304
+            - - -0.02199106
+              - -0.99975836
+              - -0.0001369233
+            - - -0.9940908
+              - 0.02185183
+              - 0.1063388
+        - position:
+            - -1.5503206
+            - 1.3669466
+            - -0.7073545
+          orientation:
+            - - -0.106310226
+              - 0.002474614
+              - -0.9943304
+            - - -0.02199106
+              - -0.99975836
+              - -0.0001369233
+            - - -0.9940908
+              - 0.02185183
+              - 0.1063388
+        - position:
+            - -0.099030495
+            - 1.2171957
+            - -0.85926116
+          orientation:
+            - - 0.10630996
+              - 0.002474614
+              - 0.99433064
+            - - 0.021991052
+              - -0.99975836
+              - 0.00013691811
+            - - 0.99409056
+              - 0.02185183
+              - -0.10633907
+  - Prop:
+      type_id: 1
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: ChildData
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: ChildData2
+      prop_type: SharedString
+      values:
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+  - Prop:
+      type_id: 1
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+  - Prop:
+      type_id: 1
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 159
+          - 161
+          - 172
+        - - 159
+          - 161
+          - 172
+        - - 248
+          - 248
+          - 248
+        - - 159
+          - 161
+          - 172
+        - - 159
+          - 161
+          - 172
+        - - 159
+          - 161
+          - 172
+        - - 248
+          - 248
+          - 248
+        - - 159
+          - 161
+          - 172
+  - Prop:
+      type_id: 1
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+  - Prop:
+      type_id: 1
+      prop_name: FormFactor
+      prop_type: Enum
+      values:
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+  - Prop:
+      type_id: 1
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: InitialSize
+      prop_type: Vector3
+      values:
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 4.8
+          - 2.0098171
+          - 2.0169144
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 4.800001
+          - 2.0047607
+          - 2.0113258
+        - - 1.0000002
+          - 18
+          - 31.000004
+  - Prop:
+      type_id: 1
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 272
+        - 272
+        - 1088
+        - 272
+        - 272
+        - 272
+        - 1088
+        - 272
+  - Prop:
+      type_id: 1
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: MeshData
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: MeshData2
+      prop_type: SharedString
+      values:
+        - 3
+        - 3
+        - 1
+        - 3
+        - 3
+        - 3
+        - 0
+        - 3
+  - Prop:
+      type_id: 1
+      prop_name: Name
+      prop_type: String
+      values:
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+  - Prop:
+      type_id: 1
+      prop_name: PhysicalConfigData
+      prop_type: SharedString
+      values:
+        - 5
+        - 5
+        - 4
+        - 5
+        - 5
+        - 5
+        - 2
+        - 5
+  - Prop:
+      type_id: 1
+      prop_name: PhysicsData
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 1
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0.1
+        - 0.1
+        - 0
+        - 0.1
+        - 0.1
+        - 0.1
+        - 0.2
+        - 0.1
+  - Prop:
+      type_id: 1
+      prop_name: RenderFidelity
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+  - Prop:
+      type_id: 1
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 1
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 0.05
+          - 0.3600072
+          - 0.6200124
+        - - 0.05
+          - 0.36000714
+          - 0.62001246
+        - - 0.096
+          - 0.05
+          - 0.05
+        - - 0.05
+          - 0.3600072
+          - 0.6200124
+        - - 0.05
+          - 0.36000714
+          - 0.62001246
+        - - 0.05
+          - 0.36000717
+          - 0.62001246
+        - - 0.09600002
+          - 0.05
+          - 0.05
+        - - 0.05
+          - 0.36000717
+          - 0.62001246
+  - Prop:
+      type_id: 1
+      prop_name: SmoothingAngle
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+  - Prop:
+      type_id: 1
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: UsePartColor
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - false
+        - true
+        - true
+        - true
+        - false
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - 0
+        - - 2
+          - 0
+        - - 3
+          - 0
+        - - 4
+          - 0
+        - - 5
+          - 0
+        - - 6
+          - 0
+        - - 7
+          - 0
+        - - 8
+          - 0
+  - End
+

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__sharedstring__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__sharedstring__input.snap
@@ -1,0 +1,1255 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 2
+num_instances: 9
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Sstr:
+      version: 0
+      entries:
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        - len: 36
+          hash: a8e881ce93449542139935bd0ec3f0a77725c368b5a699b2b87077d9fd842a64
+        - len: 36
+          hash: 9262df03156e7ba931096479dc69773b7674d01299e9a832118c53cc21f388ed
+        - len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        - len: 19694
+          hash: c0f5b001cda7f15fa5f109b9872cecc30fcc0ce5d83a101d95a77f4ee7cfb221
+        - len: 16278
+          hash: ab812b4f1546543445cb10ee2ae8a71c7993a54932de7b1f7a60612a8a027dfa
+  - Inst:
+      type_id: 0
+      type_name: Model
+      object_format: 0
+      referents:
+        - 0
+  - Inst:
+      type_id: 1
+      type_name: UnionOperation
+      object_format: 0
+      referents:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 0
+      prop_name: ModelStreamingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Parts
+  - Prop:
+      type_id: 0
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: ScaleFactor
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - position:
+            - -0.69070053
+            - 1.3813775
+            - -0.8003998
+          orientation:
+            - - -0.10631021
+              - 0.0024746137
+              - -0.99433017
+            - - -0.021991055
+              - -0.99975836
+              - -0.00013692312
+            - - -0.9940901
+              - 0.021851815
+              - 0.10633871
+  - Prop:
+      type_id: 1
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: AssetId
+      prop_type: String
+      values:
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - ""
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - "https://www.roblox.com//asset/?id=2892119179"
+        - ""
+        - "https://www.roblox.com//asset/?id=2892119179"
+  - Prop:
+      type_id: 1
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - -0.09659165
+            - 1.517803
+            - -0.83597946
+          orientation:
+            - - 0.10630996
+              - -0.0024746126
+              - -0.9943304
+            - - 0.021991052
+              - 0.999758
+              - -0.0001369233
+            - - 0.99409056
+              - -0.02185182
+              - 0.1063388
+        - position:
+            - -1.2853186
+            - 1.5163233
+            - -0.769176
+          orientation:
+            - - -0.106310226
+              - -0.0024746126
+              - 0.99433064
+            - - -0.02199106
+              - 0.999758
+              - 0.00013691811
+            - - -0.9940908
+              - -0.02185182
+              - -0.10633907
+        - position:
+            - 0.16903359
+            - 1.3672578
+            - -0.89124817
+          orientation:
+            - - 0.10630996
+              - 0.002474614
+              - 0.99433064
+            - - 0.021991052
+              - -0.99975836
+              - 0.00013691811
+            - - 0.99409056
+              - 0.02185183
+              - -0.10633907
+        - position:
+            - -0.102969766
+            - 1.5164837
+            - -0.8956378
+          orientation:
+            - - 0.10630996
+              - -0.0024746126
+              - -0.9943304
+            - - 0.021991052
+              - 0.999758
+              - -0.0001369233
+            - - 0.99409056
+              - -0.02185182
+              - 0.1063388
+        - position:
+            - -1.2789422
+            - 1.5176423
+            - -0.70953286
+          orientation:
+            - - -0.106310226
+              - -0.0024746126
+              - 0.99433064
+            - - -0.02199106
+              - 0.999758
+              - 0.00013691811
+            - - -0.9940908
+              - -0.02185182
+              - -0.10633907
+        - position:
+            - -1.2813833
+            - 1.2170323
+            - -0.7327989
+          orientation:
+            - - -0.106310226
+              - 0.002474614
+              - -0.9943304
+            - - -0.02199106
+              - -0.99975836
+              - -0.0001369233
+            - - -0.9940908
+              - 0.02185183
+              - 0.1063388
+        - position:
+            - -1.5503206
+            - 1.3669466
+            - -0.7073545
+          orientation:
+            - - -0.106310226
+              - 0.002474614
+              - -0.9943304
+            - - -0.02199106
+              - -0.99975836
+              - -0.0001369233
+            - - -0.9940908
+              - 0.02185183
+              - 0.1063388
+        - position:
+            - -0.099030495
+            - 1.2171957
+            - -0.85926116
+          orientation:
+            - - 0.10630996
+              - 0.002474614
+              - 0.99433064
+            - - 0.021991052
+              - -0.99975836
+              - 0.00013691811
+            - - 0.99409056
+              - 0.02185183
+              - -0.10633907
+  - Prop:
+      type_id: 1
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: ChildData
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: ChildData2
+      prop_type: SharedString
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+  - Prop:
+      type_id: 1
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 159
+          - 161
+          - 172
+        - - 159
+          - 161
+          - 172
+        - - 248
+          - 248
+          - 248
+        - - 159
+          - 161
+          - 172
+        - - 159
+          - 161
+          - 172
+        - - 159
+          - 161
+          - 172
+        - - 248
+          - 248
+          - 248
+        - - 159
+          - 161
+          - 172
+  - Prop:
+      type_id: 1
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+        - Default
+  - Prop:
+      type_id: 1
+      prop_name: FormFactor
+      prop_type: Enum
+      values:
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+        - 3
+  - Prop:
+      type_id: 1
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: InitialSize
+      prop_type: Vector3
+      values:
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 4.8
+          - 2.0098171
+          - 2.0169144
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 1.0000002
+          - 18
+          - 31.000004
+        - - 4.800001
+          - 2.0047607
+          - 2.0113258
+        - - 1.0000002
+          - 18
+          - 31.000004
+  - Prop:
+      type_id: 1
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 272
+        - 272
+        - 1088
+        - 272
+        - 272
+        - 272
+        - 1088
+        - 272
+  - Prop:
+      type_id: 1
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: MeshData
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: MeshData2
+      prop_type: SharedString
+      values:
+        - 0
+        - 0
+        - 1
+        - 0
+        - 0
+        - 0
+        - 2
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Name
+      prop_type: String
+      values:
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+        - Union
+  - Prop:
+      type_id: 1
+      prop_name: PhysicalConfigData
+      prop_type: SharedString
+      values:
+        - 3
+        - 3
+        - 4
+        - 3
+        - 3
+        - 3
+        - 5
+        - 3
+  - Prop:
+      type_id: 1
+      prop_name: PhysicsData
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 1
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0.1
+        - 0.1
+        - 0
+        - 0.1
+        - 0.1
+        - 0.1
+        - 0.2
+        - 0.1
+  - Prop:
+      type_id: 1
+      prop_name: RenderFidelity
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+        - 1
+  - Prop:
+      type_id: 1
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 1
+      prop_name: SmoothingAngle
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+        - -1
+  - Prop:
+      type_id: 1
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 1
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 1
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+        - 10
+  - Prop:
+      type_id: 1
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: UsePartColor
+      prop_type: Bool
+      values:
+        - true
+        - true
+        - false
+        - true
+        - true
+        - true
+        - false
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 1
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 0.05
+          - 0.3600072
+          - 0.6200124
+        - - 0.05
+          - 0.36000714
+          - 0.62001246
+        - - 0.096
+          - 0.05
+          - 0.05
+        - - 0.05
+          - 0.3600072
+          - 0.6200124
+        - - 0.05
+          - 0.36000714
+          - 0.62001246
+        - - 0.05
+          - 0.36000717
+          - 0.62001246
+        - - 0.09600002
+          - 0.05
+          - 0.05
+        - - 0.05
+          - 0.36000717
+          - 0.62001246
+  - Prnt:
+      version: 0
+      links:
+        - - 1
+          - 0
+        - - 2
+          - 0
+        - - 3
+          - 0
+        - - 4
+          - 0
+        - - 5
+          - 0
+        - - 6
+          - 0
+        - - 7
+          - 0
+        - - 8
+          - 0
+        - - 0
+          - -1
+  - End
+

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__unions__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__unions__encoded.snap
@@ -8,10 +8,10 @@ chunks:
   - Sstr:
       version: 0
       entries:
-        - len: 1803
-          hash: db0e2bce2a871addfc49da3894a9b0c8ef97b3b83c962717ece20aa97635fee3
         - len: 1367
           hash: cc62d7045ec238081b7ebbd97ce5ce7dc15166e688168c307247089135718bdb
+        - len: 1803
+          hash: db0e2bce2a871addfc49da3894a9b0c8ef97b3b83c962717ece20aa97635fee3
   - Inst:
       type_id: 0
       type_name: UnionOperation
@@ -348,9 +348,9 @@ chunks:
       prop_name: PhysicalConfigData
       prop_type: SharedString
       values:
-        - 0
-        - 0
         - 1
+        - 1
+        - 0
   - Prop:
       type_id: 0
       prop_name: PhysicsData

--- a/rbx_xml/tests/snapshots/test_files__sharedstring.snap
+++ b/rbx_xml/tests/snapshots/test_files__sharedstring.snap
@@ -1,0 +1,1272 @@
+---
+source: rbx_xml/tests/test-files.rs
+expression: viewer.view_children(&dom)
+---
+- referent: referent-0
+  name: Parts
+  class: Model
+  properties:
+    Attributes:
+      Attributes: {}
+    LevelOfDetail:
+      Enum: 0
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelStreamingMode:
+      Enum: 0
+    PrimaryPart: "null"
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+  children:
+    - referent: referent-1
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -0.09659165
+              - 1.517803
+              - -0.83597946
+            orientation:
+              - - 0.10630996
+                - -0.0024746126
+                - -0.9943304
+              - - 0.021991052
+                - 0.999758
+                - -0.0001369233
+              - - 0.99409056
+                - -0.02185182
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.3600072
+            - 0.6200124
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-2
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.2853186
+              - 1.5163233
+              - -0.769176
+            orientation:
+              - - -0.106310226
+                - -0.0024746126
+                - 0.99433064
+              - - -0.02199106
+                - 0.999758
+                - 0.00013691811
+              - - -0.9940908
+                - -0.02185182
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000714
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-3
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: ""
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0.16903359
+              - 1.3672578
+              - -0.89124817
+            orientation:
+              - - 0.10630996
+                - 0.002474614
+                - 0.99433064
+              - - 0.021991052
+                - -0.99975836
+                - 0.00013691811
+              - - 0.99409056
+                - 0.02185183
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 248
+            - 248
+            - 248
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 1088
+        MeshData2:
+          len: 36
+          hash: a8e881ce93449542139935bd0ec3f0a77725c368b5a699b2b87077d9fd842a64
+        PhysicalConfigData:
+          len: 19694
+          hash: c0f5b001cda7f15fa5f109b9872cecc30fcc0ce5d83a101d95a77f4ee7cfb221
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.096
+            - 0.05
+            - 0.05
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: false
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-4
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -0.102969766
+              - 1.5164837
+              - -0.8956378
+            orientation:
+              - - 0.10630996
+                - -0.0024746126
+                - -0.9943304
+              - - 0.021991052
+                - 0.999758
+                - -0.0001369233
+              - - 0.99409056
+                - -0.02185182
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.3600072
+            - 0.6200124
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-5
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.2789422
+              - 1.5176423
+              - -0.70953286
+            orientation:
+              - - -0.106310226
+                - -0.0024746126
+                - 0.99433064
+              - - -0.02199106
+                - 0.999758
+                - 0.00013691811
+              - - -0.9940908
+                - -0.02185182
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000714
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-6
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.2813833
+              - 1.2170323
+              - -0.7327989
+            orientation:
+              - - -0.106310226
+                - 0.002474614
+                - -0.9943304
+              - - -0.02199106
+                - -0.99975836
+                - -0.0001369233
+              - - -0.9940908
+                - 0.02185183
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000717
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-7
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: ""
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -1.5503206
+              - 1.3669466
+              - -0.7073545
+            orientation:
+              - - -0.106310226
+                - 0.002474614
+                - -0.9943304
+              - - -0.02199106
+                - -0.99975836
+                - -0.0001369233
+              - - -0.9940908
+                - 0.02185183
+                - 0.1063388
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 248
+            - 248
+            - 248
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 1088
+        MeshData2:
+          len: 36
+          hash: 9262df03156e7ba931096479dc69773b7674d01299e9a832118c53cc21f388ed
+        PhysicalConfigData:
+          len: 16278
+          hash: ab812b4f1546543445cb10ee2ae8a71c7993a54932de7b1f7a60612a8a027dfa
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.2
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.09600002
+            - 0.05
+            - 0.05
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: false
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+    - referent: referent-8
+      name: Union
+      class: UnionOperation
+      properties:
+        Anchored:
+          Bool: false
+        AssetId:
+          Content: "https://www.roblox.com//asset/?id=2892119179"
+        Attributes:
+          Attributes: {}
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 10
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 10
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - -0.099030495
+              - 1.2171957
+              - -0.85926116
+            orientation:
+              - - 0.10630996
+                - 0.002474614
+                - 0.99433064
+              - - 0.021991052
+                - -0.99975836
+                - 0.00013691811
+              - - 0.99409056
+                - 0.02185183
+                - -0.10633907
+        CanCollide:
+          Bool: false
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        CastShadow:
+          Bool: true
+        ChildData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 159
+            - 161
+            - 172
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 10
+        FrontSurfaceInput:
+          Enum: 0
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 10
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 272
+        MeshData2:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicalConfigData:
+          len: 8350
+          hash: fb095154e907fd5daaca93bae5bf68ca6400ee1c213e897c65cbf95c65fb4463
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0.1
+        RenderFidelity:
+          Enum: 1
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 10
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Size:
+          Vector3:
+            - 0.05
+            - 0.36000717
+            - 0.62001246
+        SmoothingAngle:
+          Float32: 0
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 10
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UsePartColor:
+          Bool: true
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children: []
+

--- a/rbx_xml/tests/test-files.rs
+++ b/rbx_xml/tests/test-files.rs
@@ -34,6 +34,7 @@ test_models! {
     tags: "models/tags",
     body_movers: "models/body-movers",
     union: "models/unions",
+    sharedstring: "models/sharedstring",
 
     unknown_type: "edge-cases/xml-unknown-type",
 }


### PR DESCRIPTION
Currently, the SSTR chunk is non-deterministic, where the ordering of the SharedStrings inside the array can change on each run.

We make this deterministic by sorting the shared strings array (based on its hash), and then assigning IDs afterwards.

Dependent on the test files introduced in https://github.com/rojo-rbx/rbx-test-files/pull/16