### PR TITLE
Document ZSTD compression and Bytecode data type in binary spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | BinaryString            | `Terrain.MaterialColors`        | ✔ | ➖ | ✔ | ✔ |
 | Bool                    | `Part.Anchored`                 | ✔ | ✔ | ✔ | ✔ |
 | BrickColor              | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |
+| Bytecode                | N/A                             | ❌ | ⛔ | ❌ | ❌ |
 | CFrame                  | `Camera.CFrame`                 | ✔ | ✔ | ✔ | ✔ |
 | Color3                  | `Lighting.Ambient`              | ✔ | ✔ | ✔ | ✔ |
 | Color3uint8             | `Part.BrickColor`               | ✔ | ✔ | ✔ | ✔ |

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -112,7 +112,7 @@ Which of the compression algorithms is used is indicated by the first several by
 - If the first 4 bytes of the block are the literal sequence `28 b5 2f fd`, the block is compressed using the ZSTD algorithm.
 - Otherwise, the block is compressed using the LZ4 algorithm.
 
-When a chunk is compressed using ZSTD, there is also a ZSTD "frame" present following the magic number that must be read by a decompressor. When it is compressed using LZ4, there is no frame and the compressed data begins immediately after the header.
+When a chunk is compressed using ZSTD, there is also a ZSTD frame present following the magic number that must be read by a decompressor. When it is compressed using LZ4, there is no frame and the compressed data begins immediately after the header.
 
 The data contained in **Chunk Data** varies in formatting based on the value of **Chunk Name**. Chunks used by Roblox are documented below:
 

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -624,6 +624,19 @@ When an array of `Int64` values is present, the bytes of the integers are subjec
 
 `SharedString` values are stored as an [Interleaved Array](#byte-interleaving) of `u32` values that represent indices in the [`SSTR`](#sstr-chunk) string array.
 
+### Bytecode
+**Type ID `0x1d`**
+
+`Bytecode` values are stored identically to [`String`](#string) properties but contain precompiled [Luau][Luau] bytecode instructions rather than string data.
+
+This data type is disregarded by Roblox Studio and is only loaded by Roblox clients when cryptographically signed. Given that by design it is impossible to generate these signatures, the signing method is not documented in this spec file. For posterity however, the chunk used by Roblox is named `SIGN`. It is disregarded when loaded by Roblox Studio.
+
+It is highly recommended that implementations do not modify or interpret `Bytecode` data they encounter and instead simply read and write the data as-is.
+
+Implementors should be aware that running unsigned `Bytecode` is **incredibly unsafe** and should not be done unless the source can be validated somehow. Doing so is the equivalent to giving the author of the `Bytecode` unrestricted access to the system it is ran on.
+
+[Luau]: https://github.com/Roblox/luau
+
 ### OptionalCoordinateFrame
 **Type ID `0x1e`**
 

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -47,6 +47,7 @@ This document is based on:
 	- [PhysicalProperties](#physicalproperties)
 	- [Color3uint8](#color3uint8)
 	- [Int64](#int64)
+	- [Bytecode](#bytecode)
 	- [SharedString](#sharedstring)
 	- [OptionalCoordinateFrame](#optionalcoordinateframe)
 	- [UniqueId](#uniqueid)


### PR DESCRIPTION
Roblox added support for ZSTD compression alongside existing LZ4 compression. It's not very intuitive, but I've documented it here. I can provide a link to what I mean when I say `ZSTD frame` if it's deemed necessary but it should be obvious to anybody who's implementing ZSTD compression since it's normal vocabulary for that algorithm.

This also corrects some laziness and documents the `Bytecode` data type! We haven't documented it because it's not very useful to 3rd party users but I figure we should get to it eventually. I'm optimistically assuming we won't ever support it in `rbx_dom_lua` because why would we do that, but I guess I'm open to changing it.

The documentation comes with a warning against running unsigned bytecode. In a perfect world, this would be unnecessary. Unfortunately, [Roblox literally did this](https://github.com/latte-soft/0x1D) so I figure we have an obligation to at least mention that it's dangerous.