### PR TITLE
Fix support for empty Font tags in rbx_xml

### DIFF
--- a/rbx_xml/Cargo.toml
+++ b/rbx_xml/Cargo.toml
@@ -21,4 +21,4 @@ xml-rs = "0.8.4"
 
 [dev-dependencies]
 env_logger = "0.9.0"
-insta = "1.14.1"
+insta = { version = "1.14.1", features = ["yaml"] }

--- a/rbx_xml/src/types/font.rs
+++ b/rbx_xml/src/types/font.rs
@@ -106,7 +106,7 @@ impl XmlType for Font {
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
         // Patchwork fix for older Roblox files that were written with invalid
         // `Font` tags
-        if let XmlReadEvent::EndElement { name: _ } = reader.expect_peek()? {
+        if let XmlReadEvent::EndElement { .. } = reader.expect_peek()? {
             return Ok(Font::default());
         }
 

--- a/rbx_xml/src/types/font.rs
+++ b/rbx_xml/src/types/font.rs
@@ -104,6 +104,12 @@ impl XmlType for Font {
     }
 
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
+        // Patchwork fix for older Roblox files that were written with invalid
+        // `Font` tags
+        if let XmlReadEvent::EndElement { name: _ } = reader.expect_peek()? {
+            return Ok(Font::default());
+        }
+
         let family = read_content(reader, "Family")?;
 
         let weight: u16 = reader.read_value_in_tag("Weight")?;

--- a/rbx_xml/tests/snapshots/test_files__empty_font.snap
+++ b/rbx_xml/tests/snapshots/test_files__empty_font.snap
@@ -1,0 +1,128 @@
+---
+source: rbx_xml/tests/test-files.rs
+expression: viewer.view_children(&dom)
+---
+- referent: referent-0
+  name: Bold Denk
+  class: TextLabel
+  properties:
+    Active:
+      Bool: false
+    AnchorPoint:
+      Vector2:
+        - 0
+        - 0
+    Attributes:
+      Attributes: {}
+    AutoLocalize:
+      Bool: true
+    AutomaticSize:
+      Enum: 0
+    BackgroundColor3:
+      Color3:
+        - 0.6392157
+        - 0.63529414
+        - 0.64705884
+    BackgroundTransparency:
+      Float32: 0
+    BorderColor3:
+      Color3:
+        - 0.10588236
+        - 0.16470589
+        - 0.20784315
+    BorderMode:
+      Enum: 0
+    BorderSizePixel:
+      Int32: 1
+    ClipsDescendants:
+      Bool: false
+    Draggable:
+      Bool: false
+    FontFace:
+      Font:
+        family: "rbxasset://fonts/families/SourceSansPro.json"
+        weight: Regular
+        style: Normal
+        cachedFaceId: ~
+    LayoutOrder:
+      Int32: 0
+    LineHeight:
+      Float32: 1
+    MaxVisibleGraphemes:
+      Int32: -1
+    NextSelectionDown: "null"
+    NextSelectionLeft: "null"
+    NextSelectionRight: "null"
+    NextSelectionUp: "null"
+    Position:
+      UDim2:
+        - - 0
+          - 0
+        - - 0
+          - 0
+    RichText:
+      Bool: false
+    RootLocalizationTable: "null"
+    Rotation:
+      Float32: 0
+    Selectable:
+      Bool: false
+    SelectionBehaviorDown:
+      Enum: 0
+    SelectionBehaviorLeft:
+      Enum: 0
+    SelectionBehaviorRight:
+      Enum: 0
+    SelectionBehaviorUp:
+      Enum: 0
+    SelectionGroup:
+      Bool: false
+    SelectionImageObject: "null"
+    SelectionOrder:
+      Int32: 0
+    Size:
+      UDim2:
+        - - 0
+          - 0
+        - - 0
+          - 0
+    SizeConstraint:
+      Enum: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Text:
+      String: Example
+    TextColor3:
+      Color3:
+        - 0.10588236
+        - 0.16470589
+        - 0.20784315
+    TextScaled:
+      Bool: false
+    TextSize:
+      Float32: 8
+    TextStrokeColor3:
+      Color3:
+        - 0
+        - 0
+        - 0
+    TextStrokeTransparency:
+      Float32: 1
+    TextTransparency:
+      Float32: 0
+    TextTruncate:
+      Enum: 0
+    TextWrapped:
+      Bool: false
+    TextXAlignment:
+      Enum: 2
+    TextYAlignment:
+      Enum: 1
+    Visible:
+      Bool: true
+    ZIndex:
+      Int32: 1
+  children: []
+

--- a/rbx_xml/tests/snapshots/test_files__font.snap
+++ b/rbx_xml/tests/snapshots/test_files__font.snap
@@ -1,0 +1,251 @@
+---
+source: rbx_xml/tests/test-files.rs
+expression: viewer.view_children(&dom)
+---
+- referent: referent-0
+  name: Bold Denk
+  class: TextLabel
+  properties:
+    Active:
+      Bool: false
+    AnchorPoint:
+      Vector2:
+        - 0
+        - 0
+    Attributes:
+      Attributes: {}
+    AutoLocalize:
+      Bool: true
+    AutomaticSize:
+      Enum: 0
+    BackgroundColor3:
+      Color3:
+        - 0.6392157
+        - 0.63529414
+        - 0.64705884
+    BackgroundTransparency:
+      Float32: 0
+    BorderColor3:
+      Color3:
+        - 0.10588236
+        - 0.16470589
+        - 0.20784315
+    BorderMode:
+      Enum: 0
+    BorderSizePixel:
+      Int32: 1
+    ClipsDescendants:
+      Bool: false
+    Draggable:
+      Bool: false
+    FontFace:
+      Font:
+        family: "rbxasset://fonts/families/DenkOne.json"
+        weight: Bold
+        style: Normal
+        cachedFaceId: ~
+    LayoutOrder:
+      Int32: 0
+    LineHeight:
+      Float32: 1
+    MaxVisibleGraphemes:
+      Int32: -1
+    NextSelectionDown: "null"
+    NextSelectionLeft: "null"
+    NextSelectionRight: "null"
+    NextSelectionUp: "null"
+    Position:
+      UDim2:
+        - - 0
+          - 0
+        - - 0
+          - 0
+    RichText:
+      Bool: false
+    RootLocalizationTable: "null"
+    Rotation:
+      Float32: 0
+    Selectable:
+      Bool: false
+    SelectionBehaviorDown:
+      Enum: 0
+    SelectionBehaviorLeft:
+      Enum: 0
+    SelectionBehaviorRight:
+      Enum: 0
+    SelectionBehaviorUp:
+      Enum: 0
+    SelectionGroup:
+      Bool: false
+    SelectionImageObject: "null"
+    SelectionOrder:
+      Int32: 0
+    Size:
+      UDim2:
+        - - 0
+          - 0
+        - - 0
+          - 0
+    SizeConstraint:
+      Enum: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Text:
+      String: Example
+    TextColor3:
+      Color3:
+        - 0.10588236
+        - 0.16470589
+        - 0.20784315
+    TextScaled:
+      Bool: false
+    TextSize:
+      Float32: 8
+    TextStrokeColor3:
+      Color3:
+        - 0
+        - 0
+        - 0
+    TextStrokeTransparency:
+      Float32: 1
+    TextTransparency:
+      Float32: 0
+    TextTruncate:
+      Enum: 0
+    TextWrapped:
+      Bool: false
+    TextXAlignment:
+      Enum: 2
+    TextYAlignment:
+      Enum: 1
+    Visible:
+      Bool: true
+    ZIndex:
+      Int32: 1
+  children: []
+- referent: referent-1
+  name: Italic Merriweather
+  class: TextLabel
+  properties:
+    Active:
+      Bool: false
+    AnchorPoint:
+      Vector2:
+        - 0
+        - 0
+    Attributes:
+      Attributes: {}
+    AutoLocalize:
+      Bool: true
+    AutomaticSize:
+      Enum: 0
+    BackgroundColor3:
+      Color3:
+        - 0.6392157
+        - 0.63529414
+        - 0.64705884
+    BackgroundTransparency:
+      Float32: 0
+    BorderColor3:
+      Color3:
+        - 0.10588236
+        - 0.16470589
+        - 0.20784315
+    BorderMode:
+      Enum: 0
+    BorderSizePixel:
+      Int32: 1
+    ClipsDescendants:
+      Bool: false
+    Draggable:
+      Bool: false
+    FontFace:
+      Font:
+        family: "rbxasset://fonts/families/Merriweather.json"
+        weight: Regular
+        style: Italic
+        cachedFaceId: ~
+    LayoutOrder:
+      Int32: 0
+    LineHeight:
+      Float32: 1
+    MaxVisibleGraphemes:
+      Int32: -1
+    NextSelectionDown: "null"
+    NextSelectionLeft: "null"
+    NextSelectionRight: "null"
+    NextSelectionUp: "null"
+    Position:
+      UDim2:
+        - - 0
+          - 0
+        - - 0
+          - 0
+    RichText:
+      Bool: false
+    RootLocalizationTable: "null"
+    Rotation:
+      Float32: 0
+    Selectable:
+      Bool: false
+    SelectionBehaviorDown:
+      Enum: 0
+    SelectionBehaviorLeft:
+      Enum: 0
+    SelectionBehaviorRight:
+      Enum: 0
+    SelectionBehaviorUp:
+      Enum: 0
+    SelectionGroup:
+      Bool: false
+    SelectionImageObject: "null"
+    SelectionOrder:
+      Int32: 0
+    Size:
+      UDim2:
+        - - 0
+          - 0
+        - - 0
+          - 0
+    SizeConstraint:
+      Enum: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Text:
+      String: Example
+    TextColor3:
+      Color3:
+        - 0.10588236
+        - 0.16470589
+        - 0.20784315
+    TextScaled:
+      Bool: false
+    TextSize:
+      Float32: 8
+    TextStrokeColor3:
+      Color3:
+        - 0
+        - 0
+        - 0
+    TextStrokeTransparency:
+      Float32: 1
+    TextTransparency:
+      Float32: 0
+    TextTruncate:
+      Enum: 0
+    TextWrapped:
+      Bool: false
+    TextXAlignment:
+      Enum: 2
+    TextYAlignment:
+      Enum: 1
+    Visible:
+      Bool: true
+    ZIndex:
+      Int32: 1
+  children: []
+

--- a/rbx_xml/tests/test-files.rs
+++ b/rbx_xml/tests/test-files.rs
@@ -35,6 +35,8 @@ test_models! {
     body_movers: "models/body-movers",
     union: "models/unions",
     sharedstring: "models/sharedstring",
+    font: "models/font",
 
     unknown_type: "edge-cases/xml-unknown-type",
+    empty_font: "edge-cases/empty-font",
 }


### PR DESCRIPTION
In the past, Roblox serialized `Font` properties as empty tags. Although they've stopped doing that, there are still models in the wild with that format for tags. This adds support for empty Font tags by just returning the default value for `Font` when the tag is empty.

Relies on https://github.com/rojo-rbx/rbx-test-files/pull/19.