### PR TITLE
Make Blockquotes more reasonably sized in doc site

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -39,3 +39,9 @@ code {
     padding: 2px;
     background: none;
 }
+
+// Make blockquotes a bit more reasonably sized
+// (previously: 1.6em, now the same size as H3)
+blockquote {
+  font-size: 18px
+}


### PR DESCRIPTION
At the moment, block quotes are quite frankly unreasonably large on the doc site. This patches the CSS for it to make their text equivalent to an H3 instead of being larger than H2.

For reference, this is how it looks right now:
![image](https://user-images.githubusercontent.com/4625546/235475133-97eb4ca7-ef21-48b1-9fe1-0e4b35a878a2.png)
And this is how it looks after the change:
![image](https://user-images.githubusercontent.com/4625546/235475191-92a99353-24d6-4fb9-bfc4-0c18c10694ed.png)
