### PR TITLE
Remove pinned version from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, "1.63.0"]
+        rust_version: [stable]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: ["1.64.0"]
+        rust_version: [stable]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ rbx-dom is a collection of cross-platform libraries that enables any software to
 
 Documentation about the project is hosted at [dom.rojo.space](https://dom.rojo.space).
 
+At this moment, we do not specify a MSRV for any project in rbx-dom. If you need to build one of these libraries with an outdated version of Rust, please open an issue explaining what blockers there are to you updating Cargo, what version you would need us to support, and why.
+
 ## [rbx_dom_weak](rbx_dom_weak)
 [![rbx_dom_weak on crates.io](https://img.shields.io/crates/v/rbx_dom_weak.svg)](https://crates.io/crates/rbx_dom_weak)
 [![rbx_dom_weak docs](https://img.shields.io/badge/docs-docs.rs-orange.svg)](https://docs.rs/rbx_dom_weak)

--- a/generate_reflection/src/main.rs
+++ b/generate_reflection/src/main.rs
@@ -52,11 +52,11 @@ fn run(options: Options) -> anyhow::Result<()> {
 
     if let Some(path) = &options.json_path {
         let encoded = serde_json::to_string_pretty(&database)?;
-        fs::write(&path, encoded)?;
+        fs::write(path, encoded)?;
     }
 
     if let Some(path) = &options.values_path {
-        fs::write(&path, values::encode()?)?;
+        fs::write(path, values::encode()?)?;
     }
 
     Ok(())

--- a/rbx_types/src/attributes/writer.rs
+++ b/rbx_types/src/attributes/writer.rs
@@ -25,7 +25,7 @@ pub(crate) fn write_attributes<W: Write>(
     for (name, variant) in map {
         let variant = variant.borrow();
 
-        write_string(&mut writer, &name)?;
+        write_string(&mut writer, name)?;
 
         let type_id = type_id::from_variant_type(variant.ty())
             .ok_or_else(|| AttributeError::UnsupportedVariantType(variant.ty()))?;

--- a/rbx_types/src/font.rs
+++ b/rbx_types/src/font.rs
@@ -1,21 +1,16 @@
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FontWeight {
     Thin,
     ExtraLight,
     Light,
+    #[default]
     Regular,
     Medium,
     SemiBold,
     Bold,
     ExtraBold,
     Heavy,
-}
-
-impl Default for FontWeight {
-    fn default() -> Self {
-        FontWeight::Regular
-    }
 }
 
 impl FontWeight {
@@ -48,17 +43,12 @@ impl FontWeight {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FontStyle {
+    #[default]
     Normal,
     Italic,
-}
-
-impl Default for FontStyle {
-    fn default() -> Self {
-        FontStyle::Normal
-    }
 }
 
 impl FontStyle {

--- a/rbx_xml/src/deserializer_core.rs
+++ b/rbx_xml/src/deserializer_core.rs
@@ -233,7 +233,7 @@ impl<R: Read> XmlEventReader<R> {
             .filter(|c| !c.is_whitespace())
             .collect();
 
-        base64::decode(&contents).map_err(|e| self.error(e))
+        base64::decode(contents).map_err(|e| self.error(e))
     }
 
     /// Reads a tag completely and returns its text content. This is intended

--- a/rbx_xml/src/types/tags.rs
+++ b/rbx_xml/src/types/tags.rs
@@ -17,7 +17,7 @@ pub fn write_tags<W: Write>(
     let encoded = value.encode();
 
     writer.write(XmlWriteEvent::start_element(XML_TAG_NAME).attr("name", property_name))?;
-    writer.write_string(&base64::encode(&encoded))?;
+    writer.write_string(&base64::encode(encoded))?;
     writer.write(XmlWriteEvent::end_element())?;
 
     Ok(())


### PR DESCRIPTION
We don't actually get any benefit from pinning our CI version beyond knowing our MSRV. This is because we aren't keeping lock files in the repository and we've historically just bumped the pinned version until it works.

To prevent this from ever becoming a problem again, we should simply not pin our versions. This has a consequences for Clippy because it means that our CI may suddenly fail in the future, but honestly Clippy lints should be fixed anyway so I don't think that's a bad thing.