### PR TITLE
Remove LPGhatguy as codeowner, add Dekkonot as main codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,1 @@
-* @LPGhatguy
-
-docs/ @LPGhatguy @Dekkonot @Kampfkarren
-test-files/ @LPGhatguy @Dekkonot @Kampfkarren
-patches/ @LPGhatguy @Kampfkarren
+* @Dekkonot


### PR DESCRIPTION
Given LPG's decision to exit the Roblox ecosystem, it makes very little sense for him to be requested as a reviewer for every PR that opens in this repository. I'm acting as the maintainer so it makes sense for me to at least be requested on every PR.

I could merge this without any comment but I feel like getting explicit approval would be good.