### PR TITLE
Fix potential stack overflow with WeakDom::insert

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_dom_weak Changelog
 
 ## Unreleased Changes
+* Fix potential stack overflow when creating or inserting into a `WeakDom`
 
 ## 2.4.0 (2022-06-05)
 * Added `WeakDom::into_raw` for enabling fast, non-tree-preserving transformations.


### PR DESCRIPTION
Downstream in https://github.com/filiptibell/lune/issues/48, a potential stack overflow was discovered with the implementation of `WeakDom::insert`. This was because we recursively traverse the tree of any `InstanceBuilder` inserted into a Dom.

This PR swaps us over to use a queue instead of recursion, which resolves the stack overflow. it results in slightly more memory use overall (we're allocating a queue now, so there is a memory overhead) but it shouldn't be noticeable for normal uses.