### PR TITLE
Migrate to aftman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,3 @@ Cargo.lock
 /*.rbxm
 /*.rbxmx
 /rbx_dom_lua/*.rbxlx
-
-# Selene-generated Roblox standard library
-/roblox.toml

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,4 @@
+[tools]
+rojo = "rojo-rbx/rojo@7.3.0"
+run-in-roblox = "rojo-rbx/run-in-roblox@0.3.0"
+selene = "Kampfkarren/selene@0.25.0"

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,0 @@
-[tools]
-rojo = { source = "rojo-rbx/rojo", version = "6.0.0-rc.1" }
-run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "0.3.0" }
-selene = { source = "Kampfkarren/selene", version = "0.11.0" }


### PR DESCRIPTION
A quick PR to migrate from foreman to aftman and upgrade the tools. I also removed the `/roblox.toml` from the `.gitignore` since selene doesn't generate it in the project directory anymore.