### PR TITLE
Fix write_interleaved_bytes so that it actually writes interleaved

### DIFF
--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -269,9 +269,9 @@ pub trait RbxWriteExt: Write {
     fn write_interleaved_bytes<const N: usize>(&mut self, values: &[[u8; N]]) -> io::Result<()> {
         let len = values.len();
         let mut blob = vec![0; len * N];
-        for (x, bytes) in values.iter().enumerate() {
-            for (y, byte) in bytes.iter().enumerate() {
-                blob[y + x * N] = *byte;
+        for (i, bytes) in values.iter().enumerate() {
+            for (j, byte) in bytes.iter().enumerate() {
+                blob[i + len * j] = *byte;
             }
         }
         self.write_all(&blob)?;

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -117,7 +117,7 @@ pub trait RbxReadExt: Read {
     }
 
     fn read_interleaved_i32_array(&mut self, output: &mut [i32]) -> io::Result<()> {
-        let mut buffer = vec![0; output.len() * mem::size_of::<i32>()];
+        let mut buffer = vec![0; mem::size_of_val(output)];
         self.read_exact(&mut buffer)?;
 
         for i in 0..output.len() {
@@ -133,7 +133,7 @@ pub trait RbxReadExt: Read {
     }
 
     fn read_interleaved_u32_array(&mut self, output: &mut [u32]) -> io::Result<()> {
-        let mut buffer = vec![0; output.len() * mem::size_of::<u32>()];
+        let mut buffer = vec![0; mem::size_of_val(output)];
         self.read_exact(&mut buffer)?;
 
         for i in 0..output.len() {
@@ -151,7 +151,7 @@ pub trait RbxReadExt: Read {
     }
 
     fn read_interleaved_f32_array(&mut self, output: &mut [f32]) -> io::Result<()> {
-        let mut buf = vec![0; output.len() * mem::size_of::<f32>()];
+        let mut buf = vec![0; mem::size_of_val(output)];
         self.read_exact(&mut buf)?;
 
         for i in 0..output.len() {
@@ -179,7 +179,7 @@ pub trait RbxReadExt: Read {
     }
 
     fn read_interleaved_i64_array(&mut self, output: &mut [i64]) -> io::Result<()> {
-        let mut buf = vec![0; output.len() * mem::size_of::<i64>()];
+        let mut buf = vec![0; mem::size_of_val(output)];
         self.read_exact(&mut buf)?;
 
         for i in 0..output.len() {

--- a/rbx_binary/src/tests/core_read_write.rs
+++ b/rbx_binary/src/tests/core_read_write.rs
@@ -1,0 +1,69 @@
+use crate::core::{RbxReadExt, RbxWriteExt};
+
+#[test]
+fn read_interleaved_bytes() {
+    #[rustfmt::skip]
+    let mut input: &[u8] = &[
+        00, 00, 00,
+        01, 01, 01,
+        02, 02, 02,
+        03, 03, 03,
+        04, 04, 04,
+        05, 05, 05,
+        06, 06, 06,
+        07, 07, 07,
+        08, 08, 08,
+        09, 09, 09,
+        10, 10, 10,
+        11, 11, 11,
+        12, 12, 12,
+        13, 13, 13,
+        14, 14, 14,
+        15, 15, 15,
+    ];
+
+    let expected = &[
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    ];
+
+    let mut result = vec![[0; 16]; expected.len()];
+    input.read_interleaved_bytes::<16>(&mut result).unwrap();
+
+    assert_eq!(result, expected)
+}
+
+#[test]
+fn write_interleaved_bytes() {
+    let mut input: &[[u8; 16]] = &[
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    ];
+
+    #[rustfmt::skip]
+    let expected = &[
+            00, 00, 00,
+            01, 01, 01,
+            02, 02, 02,
+            03, 03, 03,
+            04, 04, 04,
+            05, 05, 05,
+            06, 06, 06,
+            07, 07, 07,
+            08, 08, 08,
+            09, 09, 09,
+            10, 10, 10,
+            11, 11, 11,
+            12, 12, 12,
+            13, 13, 13,
+            14, 14, 14,
+            15, 15, 15,
+        ];
+
+    let mut result = Vec::new();
+    result.write_interleaved_bytes::<16>(&mut input).unwrap();
+
+    assert_eq!(result, expected)
+}

--- a/rbx_binary/src/tests/core_read_write.rs
+++ b/rbx_binary/src/tests/core_read_write.rs
@@ -4,16 +4,16 @@ use crate::core::{RbxReadExt, RbxWriteExt};
 fn read_interleaved_bytes() {
     #[rustfmt::skip]
     let mut input: &[u8] = &[
-        00, 00, 00,
-        01, 01, 01,
-        02, 02, 02,
-        03, 03, 03,
-        04, 04, 04,
-        05, 05, 05,
-        06, 06, 06,
-        07, 07, 07,
-        08, 08, 08,
-        09, 09, 09,
+        0, 0, 0,
+        1, 1, 1,
+        2, 2, 2,
+        3, 3, 3,
+        4, 4, 4,
+        5, 5, 5,
+        6, 6, 6,
+        7, 7, 7,
+        8, 8, 8,
+        9, 9, 9,
         10, 10, 10,
         11, 11, 11,
         12, 12, 12,
@@ -36,7 +36,7 @@ fn read_interleaved_bytes() {
 
 #[test]
 fn write_interleaved_bytes() {
-    let mut input: &[[u8; 16]] = &[
+    let input: &[[u8; 16]] = &[
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
@@ -44,16 +44,16 @@ fn write_interleaved_bytes() {
 
     #[rustfmt::skip]
     let expected = &[
-            00, 00, 00,
-            01, 01, 01,
-            02, 02, 02,
-            03, 03, 03,
-            04, 04, 04,
-            05, 05, 05,
-            06, 06, 06,
-            07, 07, 07,
-            08, 08, 08,
-            09, 09, 09,
+            0, 0, 0,
+            1, 1, 1,
+            2, 2, 2,
+            3, 3, 3,
+            4, 4, 4,
+            5, 5, 5,
+            6, 6, 6,
+            7, 7, 7,
+            8, 8, 8,
+            9, 9, 9,
             10, 10, 10,
             11, 11, 11,
             12, 12, 12,
@@ -63,7 +63,7 @@ fn write_interleaved_bytes() {
         ];
 
     let mut result = Vec::new();
-    result.write_interleaved_bytes::<16>(&mut input).unwrap();
+    result.write_interleaved_bytes::<16>(input).unwrap();
 
     assert_eq!(result, expected)
 }

--- a/rbx_binary/src/tests/mod.rs
+++ b/rbx_binary/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod core_read_write;
 mod models;
 mod places;
 mod serializer;


### PR DESCRIPTION
write_interleaved_bytes fails right now because it's just writing the bytes in their original sequence (see the results [here](https://github.com/rojo-rbx/rbx-dom/actions/runs/5296791237/jobs/9588138111))! This PR aims to close #286 by tweaking write_interleaved_bytes' implementation to interleave the bytes as it should. 