### PR TITLE
Prevent UniqueId collisions within WeakDom's API

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -153,6 +153,10 @@ impl WeakDom {
             .get(&referent)
             .unwrap_or_else(|| panic!("cannot destroy an instance that does not exist"));
 
+        if let Some(Variant::UniqueId(unique_id)) = instance.properties.get("UniqueId") {
+            self.unique_ids.remove(unique_id);
+        }
+
         let parent_ref = instance.parent;
         let parent = self.instances.get_mut(&parent_ref).unwrap();
         parent.children.retain(|&child| child != referent);
@@ -162,6 +166,11 @@ impl WeakDom {
 
         while let Some(referent) = to_remove.pop_front() {
             let instance = self.instances.remove(&referent).unwrap();
+
+            if let Some(Variant::UniqueId(unique_id)) = instance.properties.get("UniqueId") {
+                self.unique_ids.remove(unique_id);
+            }
+
             to_remove.extend(instance.children);
         }
     }
@@ -188,6 +197,10 @@ impl WeakDom {
             .remove(&referent)
             .unwrap_or_else(|| panic!("cannot move an instance that does not exist"));
 
+        if let Some(Variant::UniqueId(unique_id)) = instance.properties.get("UniqueId") {
+            self.unique_ids.remove(unique_id);
+        }
+
         // Remove the instance being moved from its parent's list of children.
         // If we care about panic tolerance in the future, doing this first is
         // important to ensure this link is the one severed first.
@@ -208,6 +221,11 @@ impl WeakDom {
         // Transfer all of the descendants of the moving instance breadth-first.
         while let Some(referent) = to_move.pop_front() {
             let instance = self.instances.remove(&referent).unwrap();
+
+            if let Some(Variant::UniqueId(unique_id)) = instance.properties.get("UniqueId") {
+                self.unique_ids.remove(unique_id);
+            }
+
             to_move.extend(instance.children.iter().copied());
             dest.instances.insert(referent, instance);
         }

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -380,10 +380,10 @@ mod test {
         let child = dom.get_by_ref(child_ref).unwrap();
         if let Some(Variant::UniqueId(unique_id)) = child.properties.get("UniqueId") {
             assert_ne!(
-            root_unique_id,
-            *unique_id,
-            "child should have a different UniqueId than the root ({root_unique_id}), but it was the same."
-        )
+                root_unique_id,
+                *unique_id,
+                "child should have a different UniqueId than the root ({root_unique_id}), but it was the same."
+            )
         } else {
             panic!("UniqueId property must exist and contain a Variant::UniqueId")
         };
@@ -410,10 +410,10 @@ mod test {
         let child = dom.get_by_ref(child_ref).unwrap();
         if let Some(Variant::UniqueId(unique_id)) = child.properties.get("UniqueId") {
             assert_ne!(
-            parent_unique_id,
-            *unique_id,
-            "child should have a different UniqueId than the parent ({parent_unique_id}), but it was the same."
-        )
+                parent_unique_id,
+                *unique_id,
+                "child should have a different UniqueId than the parent ({parent_unique_id}), but it was the same."
+            )
         } else {
             panic!("UniqueId property must exist and contain a Variant::UniqueId")
         }
@@ -434,10 +434,10 @@ mod test {
         let child = dom.get_by_ref(child_ref).unwrap();
         if let Some(Variant::UniqueId(unique_id)) = child.properties.get("UniqueId") {
             assert_eq!(
-            desired_unique_id,
-            *unique_id,
-            "if there is no collision, UniqueId should remain the same after passing it to WeakDom::insert."
-        )
+                desired_unique_id,
+                *unique_id,
+                "if there is no collision, UniqueId should remain the same after passing it to WeakDom::insert."
+            )
         } else {
             panic!("UniqueId property must exist and contain a Variant::UniqueId")
         };

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -442,4 +442,37 @@ mod test {
             panic!("UniqueId property must exist and contain a Variant::UniqueId")
         };
     }
+
+    #[test]
+    fn transfer_unique_id_collision() {
+        let desired_unique_id: UniqueId = "0badd00dc0ffee4200133700deadd00d".parse().unwrap();
+
+        let mut dom = WeakDom::new(InstanceBuilder::new("DataModel"));
+        let mut other_dom = WeakDom::new(InstanceBuilder::new("DataModel"));
+        let other_root_ref = other_dom.root_ref();
+
+        let folder_ref = dom.insert(
+            dom.root_ref(),
+            InstanceBuilder::new("Folder")
+                .with_property("UniqueId", Variant::UniqueId(desired_unique_id)),
+        );
+
+        other_dom.insert(
+            other_root_ref,
+            InstanceBuilder::new("Folder")
+                .with_property("UniqueId", Variant::UniqueId(desired_unique_id)),
+        );
+
+        dom.transfer(folder_ref, &mut other_dom, other_root_ref);
+
+        let folder = other_dom.get_by_ref(folder_ref).unwrap();
+        if let Some(Variant::UniqueId(unique_id)) = folder.properties.get("UniqueId") {
+            assert_ne!(
+                desired_unique_id, *unique_id,
+                "WeakDom::transfer caused a UniqueId collision."
+            )
+        } else {
+            panic!("UniqueId property must exist and contain a Variant::UniqueId")
+        };
+    }
 }

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -21,11 +21,9 @@ pub struct WeakDom {
 impl WeakDom {
     /// Construct a new `WeakDom` described by the given [`InstanceBuilder`].
     pub fn new(builder: InstanceBuilder) -> WeakDom {
-        let root_ref = builder.referent;
-
         let mut dom = WeakDom {
             instances: HashMap::new(),
-            root_ref,
+            root_ref: builder.referent,
             unique_ids: HashSet::new(),
         };
 

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -354,4 +354,28 @@ mod test {
             panic!("UniqueId property must exist and contain a Variant::UniqueId")
         };
     }
+
+    #[test]
+    fn unique_id_no_collision() {
+        let desired_unique_id: UniqueId = "0badd00dc0ffee4200133700deadd00d".parse().unwrap();
+        let mut dom = WeakDom::new(InstanceBuilder::new("DataModel"));
+        let root_ref = dom.root().referent;
+
+        let child_ref = dom.insert(
+            root_ref,
+            InstanceBuilder::new("Folder")
+                .with_property("UniqueId", Variant::UniqueId(desired_unique_id)),
+        );
+
+        let child = dom.get_by_ref(child_ref).unwrap();
+        if let Some(Variant::UniqueId(unique_id)) = child.properties.get("UniqueId") {
+            assert_eq!(
+            desired_unique_id,
+            *unique_id,
+            "if there is no collision, UniqueId should remain the same after passing it to WeakDom::insert."
+        )
+        } else {
+            panic!("UniqueId property must exist and contain a Variant::UniqueId")
+        };
+    }
 }

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -391,16 +391,13 @@ mod test {
 
     #[test]
     fn unique_id_collision() {
+        let mut dom = WeakDom::new(InstanceBuilder::new("DataModel"));
+        let root_ref = dom.root().referent;
+
         let unique_id = "0badd00dc0ffee4200133700deadd00d";
         let parent_unique_id: UniqueId = unique_id.parse().unwrap();
         let parent_builder = InstanceBuilder::new("Folder")
             .with_property("UniqueId", Variant::UniqueId(parent_unique_id));
-
-        // Should avoid a collision even if dom was created from a builder containing a
-        // UniqueId prop at the root
-        let mut dom = WeakDom::new(InstanceBuilder::new("DataModel"));
-        let root_ref = dom.root().referent;
-
         let parent_ref = dom.insert(root_ref, parent_builder);
 
         // Try to make a collision!

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -367,11 +367,10 @@ mod test {
         // Should avoid a collision even if dom was created from a builder containing a
         // UniqueId prop at the root
         let mut dom = WeakDom::new(builder);
-        let root_ref = dom.root().referent;
 
         // Try to make a collision!
         let child_ref = dom.insert(
-            root_ref,
+            dom.root_ref(),
             InstanceBuilder::new("Folder").with_property("UniqueId", Variant::UniqueId(unique_id)),
         );
 
@@ -391,10 +390,10 @@ mod test {
     fn unique_id_collision() {
         let mut dom = WeakDom::new(InstanceBuilder::new("DataModel"));
         let unique_id: UniqueId = UniqueId::now().unwrap();
-        let parent_builder =
-            InstanceBuilder::new("Folder").with_property("UniqueId", Variant::UniqueId(unique_id));
-
-        let parent_ref = dom.insert(dom.root_ref(), parent_builder);
+        let parent_ref = dom.insert(
+            dom.root_ref(),
+            InstanceBuilder::new("Folder").with_property("UniqueId", Variant::UniqueId(unique_id)),
+        );
 
         // Try to make a collision!
         let child_ref = dom.insert(
@@ -418,10 +417,9 @@ mod test {
     fn unique_id_no_collision() {
         let unique_id = UniqueId::now().unwrap();
         let mut dom = WeakDom::new(InstanceBuilder::new("DataModel"));
-        let root_ref = dom.root().referent;
 
         let child_ref = dom.insert(
-            root_ref,
+            dom.root_ref(),
             InstanceBuilder::new("Folder").with_property("UniqueId", Variant::UniqueId(unique_id)),
         );
 
@@ -442,7 +440,6 @@ mod test {
         let unique_id = UniqueId::now().unwrap();
         let mut dom = WeakDom::new(InstanceBuilder::new("DataModel"));
         let mut other_dom = WeakDom::new(InstanceBuilder::new("DataModel"));
-        let other_root_ref = other_dom.root_ref();
 
         let folder_ref = dom.insert(
             dom.root_ref(),
@@ -450,10 +447,11 @@ mod test {
         );
 
         other_dom.insert(
-            other_root_ref,
+            other_dom.root_ref(),
             InstanceBuilder::new("Folder").with_property("UniqueId", Variant::UniqueId(unique_id)),
         );
 
+        let other_root_ref = other_dom.root_ref();
         dom.transfer(folder_ref, &mut other_dom, other_root_ref);
 
         let folder = other_dom.get_by_ref(folder_ref).unwrap();

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -23,29 +23,13 @@ impl WeakDom {
     pub fn new(builder: InstanceBuilder) -> WeakDom {
         let root_ref = builder.referent;
 
-        let mut instances = HashMap::new();
-        instances.insert(
-            root_ref,
-            Instance {
-                referent: root_ref,
-                children: Vec::with_capacity(builder.children.len()),
-                parent: Ref::none(),
-                name: builder.name,
-                class: builder.class,
-                properties: builder.properties,
-            },
-        );
-
         let mut dom = WeakDom {
-            instances,
+            instances: HashMap::new(),
             root_ref,
             unique_ids: HashSet::new(),
         };
 
-        for child in builder.children {
-            dom.insert(root_ref, child);
-        }
-
+        dom.insert(Ref::none(), builder);
         dom
     }
 
@@ -136,11 +120,13 @@ impl WeakDom {
                 };
             }
 
-            self.instances
-                .get_mut(&parent)
-                .unwrap_or_else(|| panic!("cannot insert into parent that does not exist"))
-                .children
-                .push(builder.referent);
+            if parent.is_some() {
+                self.instances
+                    .get_mut(&parent)
+                    .unwrap_or_else(|| panic!("cannot insert into parent that does not exist"))
+                    .children
+                    .push(builder.referent);
+            }
 
             for child in builder.children {
                 queue.push_back((builder.referent, child));

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -124,7 +124,10 @@ impl WeakDom {
             panic!("cannot destroy the root instance of a WeakDom");
         }
 
-        let instance = self.remove_maybe_forget_uniqueid(referent);
+        let instance = self
+            .instances
+            .get(&referent)
+            .unwrap_or_else(|| panic!("cannot destroy an instance that does not exist"));
 
         let parent_ref = instance.parent;
         let parent = self.instances.get_mut(&parent_ref).unwrap();

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -94,8 +94,8 @@ impl WeakDom {
             );
 
             // We need to ensure that the value of the Instance.UniqueId property does not
-            // collide with another instance. If we *don't* do this, it's possible to to
-            // use WeakDom::insert to insert UniqueId properties that collide with other
+            // collide with another instance. If we *don't* do this, it's possible to use
+            // WeakDom::insert to insert UniqueId properties that collide with other
             // instances in the dom, violating the invariant that every UniqueId is
             // unique.
 

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -254,7 +254,10 @@ impl WeakDom {
     }
 
     fn remove_maybe_forget_uniqueid(&mut self, referent: Ref) -> Instance {
-        let instance = self.instances.remove(&referent).unwrap();
+        let instance = self
+            .instances
+            .remove(&referent)
+            .unwrap_or_else(|| panic!("cannot remove an instance that does not exist"));
 
         if let Some(Variant::UniqueId(unique_id)) = instance.properties.get("UniqueId") {
             self.unique_ids.remove(unique_id);

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -36,7 +36,7 @@ pub enum UniqueIdError {
 }
 
 /// Represents a UUID with a custom epoch of midnight January 1st 2021.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct UniqueId {
     index: u32,
     time: u32,


### PR DESCRIPTION
Closes #285, using Approach 1 as described in the issue. I ended up having to touch `WeakDom::transfer` as well, because that method could also create collisions.

It feels a bit icky to hard code the property name in these checks, but it's *very* unlikely that we or Roblox will ever want to give it a different name.

This PR additionally changes `WeakDom::insert` to accept a none `Ref` for the parent (previously, it'd just fall over and panic). The reason why is that I wanted to reuse the `UniqueId` checking code in `WeakDom::new` (to uphold the invariant even when the prop is in the root builder), but `WeakDom::insert` did not allow a none parent. The only difference for insertions with none parent vs some parent is whether the parent's list of children is extended, so it's pretty minimal & I think it makes sense.