### PR TITLE
Fix formatting of property name in `UniqueId` coverage table entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | String                  | `Instance.Name`                 | ✔ | ✔ | ✔ | ✔ |
 | UDim                    | `UIListLayout.Padding`          | ✔ | ✔ | ✔ | ✔ |
 | UDim2                   | `Frame.Size`                    | ✔ | ✔ | ✔ | ✔ |
-| UniqueId                | `Instance.UniqueId              | ✔ | ❌ | ✔ | ✔ |
+| UniqueId                | `Instance.UniqueId`             | ✔ | ❌ | ✔ | ✔ |
 | Vector2                 | `ImageLabel.ImageRectSize`      | ✔ | ✔ | ✔ | ✔ |
 | Vector2int16            | N/A                             | ✔ | ✔ | ✔ | ❌ |
 | Vector3                 | `Part.Size`                     | ✔ | ✔ | ✔ | ✔ |


### PR DESCRIPTION
Fixes an itty-bitty mistake we didn't notice during the `UniqueId` addition