### PR TITLE
Correct binary CFrame docs to say the matrix is in row-major order

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -411,7 +411,7 @@ If the byte is `00`, a `CFrame` looks like this:
 | Field Name  | Format                  | Value                                                                                                        |
 |:------------|:------------------------|:-------------------------------------------------------------------------------------------------------------|
 | ID          | `u8`                    | Always `00` in this case.                                                                                    |
-| Orientation | Array of 9 `f32` values | The rotation matrix of the `CFrame`. It represents the RightVector, UpVector, and LookVector, in that order. |
+| Orientation | Array of 9 `f32` values | The rotation matrix of the `CFrame` in **row-major order**: the XVector, YVector, and ZVector, in that order.|
 | Position    | [`Vector3`](#vector3)   | The position of the `CFrame`.                                                                                |
 
 In this case, the `Orientation` field is stored as nine untransformed [IEEE-754 standard](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) 32-bit floats.

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -408,11 +408,11 @@ The `CFrame` type is more complicated than other types. To save space, there are
 
 If the byte is `00`, a `CFrame` looks like this:
 
-| Field Name  | Format                  | Value                                                                                                        |
-|:------------|:------------------------|:-------------------------------------------------------------------------------------------------------------|
-| ID          | `u8`                    | Always `00` in this case.                                                                                    |
-| Orientation | Array of 9 `f32` values | The rotation matrix of the `CFrame` in **row-major order**: the XVector, YVector, and ZVector, in that order.|
-| Position    | [`Vector3`](#vector3)   | The position of the `CFrame`.                                                                                |
+| Field Name  | Format                  | Value                                                                                                |
+|:------------|:------------------------|:-----------------------------------------------------------------------------------------------------|
+| ID          | `u8`                    | Always `00` in this case.                                                                            |
+| Orientation | Array of 9 `f32` values | The rotation matrix of the `CFrame`. It represents the XVector, YVector, and ZVector, in that order. |
+| Position    | [`Vector3`](#vector3)   | The position of the `CFrame`.                                                                        |
 
 In this case, the `Orientation` field is stored as nine untransformed [IEEE-754 standard](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) 32-bit floats.
 


### PR DESCRIPTION
The docs for the binary format's `CFrame` representation are a bit wrong: the rotation matrix is actually stored in row-major order, and not column-major order as the current docs suggest. This can be verified by reviewing the implementation (which reads the rotation matrix in row-major order), changing rotation matrices in Roblox Studio and inspecting the output, and reviewing other community specifications such as the [RobloxFileSpec](https://www.classy-studios.com/Downloads/RobloxFileSpec.pdf).