### PR TITLE
In compatibility doc, fix BrickColor concern and add section on strings with ]]>

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -32,9 +32,9 @@ Issues of this category would impact the usage of `rbx-xml` if Roblox makes a br
 
 ### BrickColor Properties
 
-Roblox and `rbx-xml` serialize BrickColor properties using an element named `int`. When using a reflection database, this is fine because those properties get converted to BrickColor during deserialization. However, if the database used by `rbx-xml` is out of date, it won't know to do this, so any new BrickColor properties will be deserialized as integers.
+Due to how Roblox and `rbx-xml` serialize `BrickColor` properties, they may be deserialized as `Int32` values by `rbx-xml`. This will happen when no reflection database is used and may happen when an outdated one is used.
 
-This is not expected to be a problem, as Roblox will translate the properties just fine when deserializing files, but it may be inconvenient for end users.
+To fix this problem, an up-to-date reflection database should be used. The `rbx-xml` deserializer must know that the correct type of a property is `BrickColor` to correctly deserialize it, and a database will contain the types of every property. In the event that using an updated database does not work though, a [patch may need to be made](patching-database.md) that changes the type of the property to `BrickColor`.
 
 ### Strings that contain `]]>`
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -32,9 +32,15 @@ Issues of this category would impact the usage of `rbx-xml` if Roblox makes a br
 
 ### BrickColor Properties
 
-To improve readability by humans, `rbx-xml` serializes `BrickColor` properties using the element name `BrickColor`. This datatype is serialized as `int` by Roblox Studio. Since Roblox does not care about the name of the element for properties in the XML format, this has no consequences and is an easy win for readability.
+Roblox and `rbx-xml` serialize BrickColor properties using an element named `int`. When using a reflection database, this is fine because those properties get converted to BrickColor during deserialization. However, if the database used by `rbx-xml` is out of date, it won't know to do this, so any new BrickColor properties will be deserialized as integers.
 
-If Roblox were to suddenly start reading the name of property elements though, the element name for `BrickColor` properties would have to change to `int`.
+This is not expected to be a problem, as Roblox will translate the properties just fine when deserializing files, but it may be inconvenient for end users.
+
+### Strings that contain `]]>`
+
+String properties that contain leading or trailing whitespace characters are serialized using `CDATA` to preserve it. However, the sequence `]]>` is used to end `CDATA` values. If that sequence is present in a string property that also has trailing whitespace, it will serialize incorrectly as a result.
+
+This is an easy problem to fix but due to the performance concerns of traversing every string property serialized for the sequence `]]>`, the current implementation does not. It's unlikely that a string will both have whitespace padding and contain the sequence `]]>` though, so it's considered low priority to fix.
 
 ### Empty Property Elements
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -38,7 +38,7 @@ This is not expected to be a problem, as Roblox will translate the properties ju
 
 ### Strings that contain `]]>`
 
-String properties that contain leading or trailing whitespace characters are serialized using `CDATA` to preserve it. However, the sequence `]]>` is used to end `CDATA` values. If that sequence is present in a string property that also has trailing whitespace, it will serialize incorrectly as a result.
+String properties that contain leading or trailing whitespace characters are serialized using `CDATA` to preserve the whitespace. However, the sequence `]]>` is used to end `CDATA` sections. This means that when a string property contains leading or trailing whitespace, and also contains `]]>`, the property will serialize incorrectly.
 
 This is an easy problem to fix but due to the performance concerns of traversing every string property serialized for the sequence `]]>`, the current implementation does not. It's unlikely that a string will both have whitespace padding and contain the sequence `]]>` though, so it's considered low priority to fix.
 


### PR DESCRIPTION
Turns out I was just outright wrong about BrickColor properties and for some reason didn't think to check (in my defense, I checked the other things I listed, I just forgot BrickColor for some reason).

Also, I forgot that serializing string properties might break under a specific scenario. Not something I plan to fix, but worth noting.