### PR TITLE
Add int/float widening support to rbx_xml

### DIFF
--- a/rbx_xml/src/conversion.rs
+++ b/rbx_xml/src/conversion.rs
@@ -27,9 +27,11 @@ impl ConvertVariant for Variant {
         target_type: VariantType,
     ) -> Result<Cow<'_, Self>, String> {
         match (value.borrow(), target_type) {
-            (Variant::Int32(value), VariantType::Int64) => Ok(Cow::Owned((*value as i64).into())),
+            (Variant::Int32(value), VariantType::Int64) => {
+                Ok(Cow::Owned((i64::from(*value)).into()))
+            }
             (Variant::Float32(value), VariantType::Float64) => {
-                Ok(Cow::Owned((*value as f64).into()))
+                Ok(Cow::Owned((f64::from(*value)).into()))
             }
             (Variant::Int32(value), VariantType::BrickColor) => {
                 let narrowed: u16 = (*value).try_into().map_err(|_| {

--- a/rbx_xml/src/conversion.rs
+++ b/rbx_xml/src/conversion.rs
@@ -27,6 +27,8 @@ impl ConvertVariant for Variant {
         target_type: VariantType,
     ) -> Result<Cow<'_, Self>, String> {
         match (value.borrow(), target_type) {
+            // Older files may not have their number types moved to 64-bit yet,
+            // which can cause problems. See issue #301.
             (Variant::Int32(value), VariantType::Int64) => {
                 Ok(Cow::Owned((i64::from(*value)).into()))
             }

--- a/rbx_xml/src/conversion.rs
+++ b/rbx_xml/src/conversion.rs
@@ -27,6 +27,10 @@ impl ConvertVariant for Variant {
         target_type: VariantType,
     ) -> Result<Cow<'_, Self>, String> {
         match (value.borrow(), target_type) {
+            (Variant::Int32(value), VariantType::Int64) => Ok(Cow::Owned((*value as i64).into())),
+            (Variant::Float32(value), VariantType::Float64) => {
+                Ok(Cow::Owned((*value as f64).into()))
+            }
             (Variant::Int32(value), VariantType::BrickColor) => {
                 let narrowed: u16 = (*value).try_into().map_err(|_| {
                     format!("Value {} is not in the range of a valid BrickColor", value)

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -588,6 +588,7 @@ fn deserialize_properties<R: Read>(
                 DataType::Enum(_enum_name) => VariantType::Enum,
                 _ => unimplemented!(),
             };
+            log::trace!("property's read type: {xml_ty:?}, canonical type: {expected_type:?}");
 
             let value = match value.try_convert(expected_type) {
                 Ok(value) => value,

--- a/rbx_xml/src/tests/basic.rs
+++ b/rbx_xml/src/tests/basic.rs
@@ -230,3 +230,36 @@ fn read_unique_id() {
         )))
     );
 }
+
+#[test]
+fn number_widening() {
+    let _ = env_logger::try_init();
+    let document = r#"
+        <roblox version="4">
+            <Item class="IntValue" referent="Test">
+                <Properties>
+                    <int name="Value">194</int>
+                </Properties>
+            </Item>
+            <Item class="NumberValue" referent="Test">
+                <Properties>
+                    <float name="Value">1337</float>
+                </Properties>
+            </Item>
+        </roblox>
+    "#;
+    let tree = crate::from_str_default(document).unwrap();
+
+    let int_value = tree.get_by_ref(tree.root().children()[0]).unwrap();
+    assert_eq!(int_value.class, "IntValue");
+    assert_eq!(
+        int_value.properties.get("Value"),
+        Some(&Variant::Int64(194))
+    );
+    let float_value = tree.get_by_ref(tree.root().children()[1]).unwrap();
+    assert_eq!(float_value.class, "NumberValue");
+    assert_eq!(
+        float_value.properties.get("Value"),
+        Some(&Variant::Float64(1337.0))
+    );
+}


### PR DESCRIPTION
With issue #301, it's became clear we need a way to widen integers and floats from 32-bit to 64-bit since older models may have outdated types for number properties. This PR implements widening for `Int32` and `Float32`, giving them a very simple conversion to `Int64` and `Float64` respectively. This should solve the linked issue in the XML format and prevent it from being a problem for floats as well.

Support in `rbx_binary` is straightforward but the author of that issue has a fix ready to merge, so I'll let them do it. :smile: