### PR TITLE
Add int/float widening from 32 to 64 bits for rbx_binary

### DIFF
--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -489,6 +489,9 @@ impl<'a, R: Read> DeserializerState<'a, R> {
                         add_property(instance, &property, value.into());
                     }
                 }
+                // This branch allows values serialized as Int32 to be converted to Int64 when we expect a Int64
+                // Basically, we convert Int32 to Int64 when we expect a Int64 but read a Int32
+                // See: #301
                 VariantType::Int64 => {
                     let mut values = vec![0; type_info.referents.len()];
                     chunk.read_interleaved_i32_array(&mut values)?;

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -489,6 +489,15 @@ impl<'a, R: Read> DeserializerState<'a, R> {
                         add_property(instance, &property, value.into());
                     }
                 }
+                VariantType::Int64 => {
+                    let mut values = vec![0; type_info.referents.len()];
+                    chunk.read_interleaved_i32_array(&mut values)?;
+
+                    for (value, referent) in values.into_iter().zip(&type_info.referents) {
+                        let instance = self.instances_by_ref.get_mut(referent).unwrap();
+                        add_property(instance, &property, (value as i64).into());
+                    }
+                }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
                         type_name: type_info.type_name.clone(),

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -498,7 +498,8 @@ impl<'a, R: Read> DeserializerState<'a, R> {
 
                     for (value, referent) in values.into_iter().zip(&type_info.referents) {
                         let instance = self.instances_by_ref.get_mut(referent).unwrap();
-                        add_property(instance, &property, (value as i64).into());
+                        let value_converted = i64::from(value);
+                        add_property(instance, &property, value_converted.into());
                     }
                 }
                 invalid_type => {


### PR DESCRIPTION
This PR supports widening ints & floats from 32 bits to 64 bits.

Basically, if we deserialize a property we expect to be 64 bits and it's actually 32 bits, we can safely convert over.

This fixes issues where Roblox previously had values serialized as 32 bits, but then they got upgraded to 64 bits later on. This only really occurs in older files, but it's a good blanket fix to have regardless.

There might be a better solution with migrations but I'm not as familiar with that; we can always remove this change if that gets figured out. I don't think this will break anything, unless Roblox goes from 64 back to 32 for a value and rbx_dom doesn't update in time, though that doesn't seem very likely. It's more likely that this will automatically migrate a value if Roblox changes something from 32 bits to 64.

This fixes #301, and rbx_xml's fix is tracked in #303.

Let me know if there's anything else I need to change! I wanted to make a test for this, but I couldn't figure out how to get a binary file in the wrong format other than my repo file, and it looks like the file resolutions paths are broken on my cursed Cygwin setup, so I couldn't run any tests. Hopefully this is good!