### PR TITLE
Don't panic in WeakDom methods if parent is none

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -161,8 +161,11 @@ impl WeakDom {
         // Remove the instance being moved from its parent's list of children.
         // If we care about panic tolerance in the future, doing this first is
         // important to ensure this link is the one severed first.
-        let parent = self.instances.get_mut(&instance.parent).unwrap();
-        parent.children.retain(|&child| child != referent);
+        let parent_ref = instance.parent;
+        if parent_ref.is_some() {
+            let parent = self.instances.get_mut(&parent_ref).unwrap();
+            parent.children.retain(|&child| child != referent);
+        }
 
         // We'll start tracking all of the instances that we're moving in a
         // queue. We're about to move the moving instance, so we need to do this

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -125,8 +125,10 @@ impl WeakDom {
             .unwrap_or_else(|| panic!("cannot destroy an instance that does not exist"));
 
         let parent_ref = instance.parent;
-        let parent = self.instances.get_mut(&parent_ref).unwrap();
-        parent.children.retain(|&child| child != referent);
+        if parent_ref.is_some() {
+            let parent = self.instances.get_mut(&parent_ref).unwrap();
+            parent.children.retain(|&child| child != referent);
+        }
 
         let mut to_remove = VecDeque::new();
         to_remove.push_back(referent);

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -221,8 +221,10 @@ impl WeakDom {
         instance.parent = dest_parent_ref;
 
         // Remove the instance's referent from its parent's list of children.
-        let parent = self.instances.get_mut(&parent_ref).unwrap();
-        parent.children.retain(|&child| child != referent);
+        if parent_ref.is_some() {
+            let parent = self.instances.get_mut(&parent_ref).unwrap();
+            parent.children.retain(|&child| child != referent);
+        }
 
         // Add the instance's referent to its new parent's list of children.
         let dest_parent = self


### PR DESCRIPTION
There are a few methods that currently panic if an instance's parent ref is none: `WeakDom::destroy`, `WeakDom::transfer`, and `WeakDom::transfer_within`. None parents are allowed after #288, so this PR adds checks to these methods to avoid panics.