### PR TITLE
Implement instance cloning methods in WeakDom

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Unreleased Changes
 * Fix potential stack overflow when creating or inserting into a `WeakDom`. ([#279])
 * Added `InstanceBuilder::has_property` for checking if an `InstanceBuilder` defines a given property. ([#283])
+* Added `WeakDom::clone_within` and `WeakDom::clone_into_external` for cloning instances into the same or a different `WeakDom`, respectively. ([#312])
 
 [#279]: https://github.com/rojo-rbx/rbx-dom/pull/279
 [#283]: https://github.com/rojo-rbx/rbx-dom/pull/283
+[#312]: https://github.com/rojo-rbx/rbx-dom/pull/312
 
 ## 2.4.0 (2022-06-05)
 * Added `WeakDom::into_raw` for enabling fast, non-tree-preserving transformations.

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -257,7 +257,7 @@ impl WeakDom {
             self.insert(cloned_parent, builder);
         }
 
-        Self::rewrite_refs(self, &ctx);
+        Self::rewrite_refs(self, ctx);
 
         root_ref
     }
@@ -278,7 +278,7 @@ impl WeakDom {
             dest.insert(cloned_parent, builder);
         }
 
-        Self::rewrite_refs(dest, &ctx);
+        Self::rewrite_refs(dest, ctx);
 
         root_ref
     }
@@ -349,7 +349,7 @@ impl WeakDom {
         builder
     }
 
-    fn rewrite_refs(dom: &mut WeakDom, ctx: &CloneContext) {
+    fn rewrite_refs(dom: &mut WeakDom, ctx: CloneContext) {
         for (_, new_ref) in ctx.ref_rewrites.iter() {
             let instance = dom
                 .get_by_ref_mut(*new_ref)

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -331,7 +331,7 @@ impl CloneContext {
     /// On any instances cloned during the operation, rewrite any Ref properties that
     /// point to instances that were also cloned.
     fn rewrite_refs(self, dest: &mut WeakDom) {
-        let mut existing_dest_refs = HashSet::<Ref>::new();
+        let mut existing_dest_refs = HashSet::new();
 
         for (_, new_ref) in self.ref_rewrites.iter() {
             let instance = dest

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -262,7 +262,8 @@ impl WeakDom {
     /// After the operation, the root of the cloned subtree has no parent.
     ///
     /// Any Ref properties that point to instances contained in the subtree are
-    /// rewritten to point to the cloned instances.
+    /// rewritten to point to the cloned instances. Any other Ref properties
+    /// would be invalid  in `dest` and are thus rewritten to be `Ref::none()`
     pub fn clone_into_external(&self, referent: Ref, dest: &mut WeakDom) -> Ref {
         let mut ctx = CloneContext::default();
         let root_builder = ctx.clone_ref_as_builder(self, referent);

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -328,6 +328,8 @@ struct CloneContext {
 }
 
 impl CloneContext {
+    /// On any instances cloned during the operation, rewrite any Ref properties that
+    /// point to instances that were also cloned.
     fn rewrite_refs(self, dom: &mut WeakDom) {
         for (_, new_ref) in self.ref_rewrites.iter() {
             let instance = dom
@@ -346,8 +348,9 @@ impl CloneContext {
         }
     }
 
-    /// Clones the instance with the given referent and context into a new
-    /// InstanceBuilder.
+    /// Clone the instance with the given `referent` and `source` WeakDom into a new
+    /// InstanceBuilder, and record the mapping of the original referent to the new
+    /// referent.
     ///
     /// This method only clones the instance's class name, name, and properties; it
     /// does not clone any children.

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -249,11 +249,11 @@ impl WeakDom {
     /// rewritten to point to the cloned instances.
     pub fn clone_within(&mut self, referent: Ref) -> Ref {
         let mut ctx = CloneContext::default();
-        let root_builder = self.instancebuilder_from_ref(&mut ctx, referent);
+        let root_builder = self.ref_into_instancebuilder(&mut ctx, referent);
         let root_ref = self.insert(Ref::none(), root_builder);
 
         while let Some((cloned_parent, uncloned_child)) = ctx.queue.pop_front() {
-            let builder = self.instancebuilder_from_ref(&mut ctx, uncloned_child);
+            let builder = self.ref_into_instancebuilder(&mut ctx, uncloned_child);
             self.insert(cloned_parent, builder);
         }
 
@@ -270,11 +270,11 @@ impl WeakDom {
     /// rewritten to point to the cloned instances.
     pub fn clone_into_external(&self, referent: Ref, dest: &mut WeakDom) -> Ref {
         let mut ctx = CloneContext::default();
-        let root_builder = self.instancebuilder_from_ref(&mut ctx, referent);
+        let root_builder = self.ref_into_instancebuilder(&mut ctx, referent);
         let root_ref = dest.insert(Ref::none(), root_builder);
 
         while let Some((cloned_parent, uncloned_child)) = ctx.queue.pop_front() {
-            let builder = self.instancebuilder_from_ref(&mut ctx, uncloned_child);
+            let builder = self.ref_into_instancebuilder(&mut ctx, uncloned_child);
             dest.insert(cloned_parent, builder);
         }
 
@@ -326,7 +326,7 @@ impl WeakDom {
         instance
     }
 
-    fn instancebuilder_from_ref(&self, ctx: &mut CloneContext, referent: Ref) -> InstanceBuilder {
+    fn ref_into_instancebuilder(&self, ctx: &mut CloneContext, referent: Ref) -> InstanceBuilder {
         let (new_ref, builder, children) = {
             let instance = self
                 .get_by_ref(referent)

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -326,24 +326,26 @@ impl WeakDom {
         instance
     }
 
-    fn ref_into_instancebuilder(&self, ctx: &mut CloneContext, referent: Ref) -> InstanceBuilder {
-        let (new_ref, builder, children) = {
-            let instance = self
-                .get_by_ref(referent)
-                .expect("Cannot clone an instance that does not exist");
+    fn ref_into_instancebuilder(
+        &self,
+        ctx: &mut CloneContext,
+        original_ref: Ref,
+    ) -> InstanceBuilder {
+        let instance = self
+            .get_by_ref(original_ref)
+            .expect("Cannot clone an instance that does not exist");
 
-            let builder = InstanceBuilder::new(instance.class.to_string())
-                .with_name(instance.name.to_string())
-                .with_properties(instance.properties.clone());
+        let builder = InstanceBuilder::new(instance.class.to_string())
+            .with_name(instance.name.to_string())
+            .with_properties(instance.properties.clone());
 
-            (builder.referent, builder, instance.children.to_vec())
-        };
+        let new_ref = builder.referent;
 
-        for uncloned_child in children.iter() {
+        for uncloned_child in instance.children.iter() {
             ctx.queue.push_back((new_ref, *uncloned_child))
         }
 
-        ctx.ref_rewrites.insert(referent, new_ref);
+        ctx.ref_rewrites.insert(original_ref, new_ref);
         builder
     }
 

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -356,7 +356,7 @@ impl CloneContext {
             for prop_value in instance.properties.values_mut() {
                 if let Variant::Ref(original_ref) = prop_value {
                     if let Some(new_ref) = self.ref_rewrites.get(original_ref) {
-                        // If the ref points to an instances contained within the
+                        // If the ref points to an instance contained within the
                         // cloned subtree, rewrite it as the corresponding new ref
                         *prop_value = Variant::Ref(*new_ref);
                     } else if !existing_dest_refs.contains(original_ref) {

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -249,11 +249,11 @@ impl WeakDom {
     /// rewritten to point to the cloned instances.
     pub fn clone_within(&mut self, referent: Ref) -> Ref {
         let mut ctx = CloneContext::default();
-        let root_builder = self.ref_into_instancebuilder(&mut ctx, referent);
+        let root_builder = self.clone_ref_as_builder(&mut ctx, referent);
         let root_ref = self.insert(Ref::none(), root_builder);
 
         while let Some((cloned_parent, uncloned_child)) = ctx.queue.pop_front() {
-            let builder = self.ref_into_instancebuilder(&mut ctx, uncloned_child);
+            let builder = self.clone_ref_as_builder(&mut ctx, uncloned_child);
             self.insert(cloned_parent, builder);
         }
 
@@ -270,11 +270,11 @@ impl WeakDom {
     /// rewritten to point to the cloned instances.
     pub fn clone_into_external(&self, referent: Ref, dest: &mut WeakDom) -> Ref {
         let mut ctx = CloneContext::default();
-        let root_builder = self.ref_into_instancebuilder(&mut ctx, referent);
+        let root_builder = self.clone_ref_as_builder(&mut ctx, referent);
         let root_ref = dest.insert(Ref::none(), root_builder);
 
         while let Some((cloned_parent, uncloned_child)) = ctx.queue.pop_front() {
-            let builder = self.ref_into_instancebuilder(&mut ctx, uncloned_child);
+            let builder = self.clone_ref_as_builder(&mut ctx, uncloned_child);
             dest.insert(cloned_parent, builder);
         }
 
@@ -326,11 +326,12 @@ impl WeakDom {
         instance
     }
 
-    fn ref_into_instancebuilder(
-        &self,
-        ctx: &mut CloneContext,
-        original_ref: Ref,
-    ) -> InstanceBuilder {
+    /// Clones the instance with the given referent and context into a new
+    /// InstanceBuilder.
+    ///
+    /// This method only clones the instance's class name, name, and properties; it
+    /// does not clone any children.
+    fn clone_ref_as_builder(&self, ctx: &mut CloneContext, original_ref: Ref) -> InstanceBuilder {
         let instance = self
             .get_by_ref(original_ref)
             .expect("Cannot clone an instance that does not exist");

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -57,7 +57,7 @@ impl<'src> CloneContext<'src> {
         root_ref
     }
 
-    pub fn clone_external(mut self, dest: &mut WeakDom) -> Ref {
+    pub fn clone_into_external(mut self, dest: &mut WeakDom) -> Ref {
         let root_builder = self.instancebuilder_from_ref(self.subtree_root);
         let root_ref = dest.insert(Ref::none(), root_builder);
 
@@ -335,8 +335,8 @@ impl WeakDom {
     }
 
     /// OOoook
-    pub fn clone_external(&mut self, referent: Ref, dest: &mut WeakDom) -> Ref {
-        CloneContext::new(self, referent).clone_external(dest)
+    pub fn clone_into_external(&mut self, referent: Ref, dest: &mut WeakDom) -> Ref {
+        CloneContext::new(self, referent).clone_into_external(dest)
     }
 
     fn inner_insert(&mut self, referent: Ref, instance: Instance) {

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -356,10 +356,10 @@ impl WeakDom {
                 .expect("Cannot rewrite refs on an instance that does not exist");
 
             for prop_value in instance.properties.values_mut() {
-                if let Variant::Ref(old_ref) = prop_value {
+                if let Variant::Ref(original_ref) = prop_value {
                     // We only want to rewrite Refs if they point to instances within the
                     // cloned subtree
-                    if let Some(new_ref) = ctx.ref_rewrites.get(old_ref) {
+                    if let Some(new_ref) = ctx.ref_rewrites.get(original_ref) {
                         *prop_value = Variant::Ref(*new_ref);
                     }
                 }

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -488,16 +488,18 @@ mod test {
     #[test]
     fn clone_into_external() {
         let dom = {
-            let mut child1 = InstanceBuilder::new("Part");
-            let mut child2 = InstanceBuilder::new("Part");
+            let mut child1 = InstanceBuilder::new("Part").with_name("Child1");
+            let mut child2 = InstanceBuilder::new("Part").with_name("Child2");
+            let mut child3 = InstanceBuilder::new("Part").with_name("Child3");
 
             child1 = child1.with_property("RefProp", child2.referent);
             child2 = child2.with_property("RefProp", child1.referent);
+            child3 = child3.with_property("RefProp", Ref::new());
 
             WeakDom::new(
                 InstanceBuilder::new("Folder")
                     .with_name("Root")
-                    .with_children([child1, child2]),
+                    .with_children([child1, child2, child3]),
             )
         };
 
@@ -514,12 +516,13 @@ mod test {
         let mut viewer = DomViewer::new();
 
         // This snapshot is here just to show that the ref props are rewritten after being
-        // cloned into the other dom. It should contain a Folder at the root with two
+        // cloned into the other dom. It should contain a Folder at the root with the three
         // Parts as children
         insta::assert_yaml_snapshot!(viewer.view(&dom));
 
-        // This snapshot should have a clone of the root Folder under the other dom's
-        // DataModel, with the ref properties pointing to the newly cloned parts.
+        // This snapshot should have a clone of the root Folder under the other
+        // dom's DataModel, with Child1's and Child2's ref properties rewritten to point
+        // to the newly cloned instances, and Child3's ref property rewritten to none.
         insta::assert_yaml_snapshot!(viewer.view(&other_dom));
     }
 

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -235,7 +235,8 @@ impl WeakDom {
         dest_parent.children.push(referent);
     }
 
-    /// Clone an instance and all its descendants into the same WeakDom.
+    /// Clone the instance with the given `referent` and all its descendants
+    /// (i.e. the entire subtree) into the same WeakDom.
     ///
     /// After the operation, the root of the cloned subtree has no parent.
     ///
@@ -255,7 +256,8 @@ impl WeakDom {
         root_ref
     }
 
-    /// Clone an instance and all its descendants into a different WeakDom.
+    /// Clone the instance with the given `referent` and all its descendants (i.e. the
+    /// entire subtree) into the given WeakDom.
     ///
     /// After the operation, the root of the cloned subtree has no parent.
     ///

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -241,7 +241,12 @@ impl WeakDom {
         dest_parent.children.push(referent);
     }
 
-    /// Ook
+    /// Clone an instance and all its descendants into the same WeakDom.
+    ///
+    /// After the operation, the root of the cloned subtree has no parent.
+    ///
+    /// Any Ref properties that point to instances contained in the subtree are
+    /// rewritten to point to the cloned instances.
     pub fn clone_within(&mut self, referent: Ref) -> Ref {
         let mut ctx = CloneContext::default();
         let root_builder = self.instancebuilder_from_ref(&mut ctx, referent);
@@ -257,7 +262,12 @@ impl WeakDom {
         root_ref
     }
 
-    /// OOoook
+    /// Clone an instance and all its descendants into a different WeakDom.
+    ///
+    /// After the operation, the root of the cloned subtree has no parent.
+    ///
+    /// Any Ref properties that point to instances contained in the subtree are
+    /// rewritten to point to the cloned instances.
     pub fn clone_into_external(&self, referent: Ref, dest: &mut WeakDom) -> Ref {
         let mut ctx = CloneContext::default();
         let root_builder = self.instancebuilder_from_ref(&mut ctx, referent);

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external-2.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external-2.snap
@@ -1,0 +1,27 @@
+---
+source: rbx_dom_weak/src/dom.rs
+expression: viewer.view(&other_dom)
+---
+referent: referent-3
+name: DataModel
+class: DataModel
+properties: {}
+children:
+  - referent: referent-4
+    name: Root
+    class: Folder
+    properties: {}
+    children:
+      - referent: referent-5
+        name: Part
+        class: Part
+        properties:
+          RefProp: referent-6
+        children: []
+      - referent: referent-6
+        name: Part
+        class: Part
+        properties:
+          RefProp: referent-5
+        children: []
+

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external-2.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external-2.snap
@@ -2,26 +2,32 @@
 source: rbx_dom_weak/src/dom.rs
 expression: viewer.view(&other_dom)
 ---
-referent: referent-3
+referent: referent-4
 name: DataModel
 class: DataModel
 properties: {}
 children:
-  - referent: referent-4
+  - referent: referent-5
     name: Root
     class: Folder
     properties: {}
     children:
-      - referent: referent-5
-        name: Part
+      - referent: referent-6
+        name: Child1
+        class: Part
+        properties:
+          RefProp: referent-7
+        children: []
+      - referent: referent-7
+        name: Child2
         class: Part
         properties:
           RefProp: referent-6
         children: []
-      - referent: referent-6
-        name: Part
+      - referent: referent-8
+        name: Child3
         class: Part
         properties:
-          RefProp: referent-5
+          RefProp: "null"
         children: []
 

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external.snap
@@ -1,0 +1,22 @@
+---
+source: rbx_dom_weak/src/dom.rs
+expression: viewer.view(&dom)
+---
+referent: referent-0
+name: Root
+class: Folder
+properties: {}
+children:
+  - referent: referent-1
+    name: Part
+    class: Part
+    properties:
+      RefProp: referent-2
+    children: []
+  - referent: referent-2
+    name: Part
+    class: Part
+    properties:
+      RefProp: referent-1
+    children: []
+

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_into_external.snap
@@ -8,15 +8,21 @@ class: Folder
 properties: {}
 children:
   - referent: referent-1
-    name: Part
+    name: Child1
     class: Part
     properties:
       RefProp: referent-2
     children: []
   - referent: referent-2
-    name: Part
+    name: Child2
     class: Part
     properties:
       RefProp: referent-1
+    children: []
+  - referent: referent-3
+    name: Child3
+    class: Part
+    properties:
+      RefProp: "[unknown ID]"
     children: []
 

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_within.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_within.snap
@@ -1,0 +1,39 @@
+---
+source: rbx_dom_weak/src/dom.rs
+expression: viewer.view(&dom)
+---
+referent: referent-0
+name: Root
+class: Folder
+properties: {}
+children:
+  - referent: referent-1
+    name: Part
+    class: Part
+    properties:
+      RefProp: referent-2
+    children: []
+  - referent: referent-2
+    name: Part
+    class: Part
+    properties:
+      RefProp: referent-1
+    children: []
+  - referent: referent-3
+    name: Root
+    class: Folder
+    properties: {}
+    children:
+      - referent: referent-4
+        name: Part
+        class: Part
+        properties:
+          RefProp: referent-5
+        children: []
+      - referent: referent-5
+        name: Part
+        class: Part
+        properties:
+          RefProp: referent-4
+        children: []
+

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_within.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_within.snap
@@ -23,7 +23,7 @@ children:
     name: Child1
     class: Part
     properties:
-      RefProp: "null"
+      RefProp: referent-0
     children:
       - referent: referent-4
         name: Child2

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_within.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_within.snap
@@ -8,32 +8,27 @@ class: Folder
 properties: {}
 children:
   - referent: referent-1
-    name: Part
+    name: Child1
     class: Part
     properties:
-      RefProp: referent-2
-    children: []
-  - referent: referent-2
-    name: Part
-    class: Part
-    properties:
-      RefProp: referent-1
-    children: []
+      RefProp: referent-0
+    children:
+      - referent: referent-2
+        name: Child2
+        class: Part
+        properties:
+          RefProp: referent-1
+        children: []
   - referent: referent-3
-    name: Root
-    class: Folder
-    properties: {}
+    name: Child1
+    class: Part
+    properties:
+      RefProp: "null"
     children:
       - referent: referent-4
-        name: Part
+        name: Child2
         class: Part
         properties:
-          RefProp: referent-5
-        children: []
-      - referent: referent-5
-        name: Part
-        class: Part
-        properties:
-          RefProp: referent-4
+          RefProp: referent-3
         children: []
 


### PR DESCRIPTION
Closes #282 by implementing `WeakDom::clone_within` and `WeakDom::clone_into_external`.