### PR TITLE
Add gen-reflection equivalent for windows

### DIFF
--- a/gen-reflection.bat
+++ b/gen-reflection.bat
@@ -1,0 +1,8 @@
+@ECHO OFF
+
+IF "%1" EQU "--dry-run" (
+    cargo run --bin rbx_reflector -- generate --patches patches
+) ELSE (
+    cargo run --bin rbx_reflector -- generate rbx_reflection_database/database.msgpack rbx_dom_lua/src/database.json --patches patches
+    cargo run --bin rbx_reflector -- values rbx_dom_lua/src/allValues.json
+)


### PR DESCRIPTION
Though it is heresy to admit it, I do run windows on my machine and have been manually typing out the command to generate the reflection database. I think it'd be cool if I didn't have to do that anymore.

It's functionally identical to the bash script, just for batch.