### PR TITLE
RollOff Patch

### DIFF
--- a/patches/sound.yml
+++ b/patches/sound.yml
@@ -6,3 +6,17 @@ Change:
         As: xmlRead_MaxDistance_3
     xmlRead_MaxDistance_3:
       AliasFor: MaxDistance
+
+    RollOffMinDistance:
+      Serialization:
+        Type: SerializesAs
+        As: EmitterSize
+    EmitterSize:
+      AliasFor: RollOffMinDistance
+    
+    RollOffMaxDistance:
+      Serialization:
+        Type: SerializesAs
+        As: xmlRead_MaxDistance_3
+    xmlRead_MaxDistance_3:
+      AliasFor: RollOffMaxDistance


### PR DESCRIPTION
closes #320 and https://github.com/rojo-rbx/rojo/issues/742

- `RollOffMinDistance` serialize as `EmitterSize`
- `RollOffMaxDistance` serialize as `xmlRead_MaxDistance_3`