### PR TITLE
Use generic interleaving methods for `rbx_binary` core

### DIFF
--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -122,8 +122,8 @@ pub trait RbxReadExt: Read {
         let mut read = vec![[0; mem::size_of::<i32>()]; output.len()];
         self.read_interleaved_bytes(&mut read)?;
 
-        for (chunk, n) in read.into_iter().zip(output) {
-            *n = untransform_i32(i32::from_be_bytes(chunk));
+        for (chunk, out) in read.into_iter().zip(output) {
+            *out = untransform_i32(i32::from_be_bytes(chunk));
         }
 
         Ok(())
@@ -134,8 +134,8 @@ pub trait RbxReadExt: Read {
         let mut read = vec![[0; mem::size_of::<u32>()]; output.len()];
         self.read_interleaved_bytes(&mut read)?;
 
-        for (chunk, n) in read.into_iter().zip(output) {
-            *n = u32::from_be_bytes(chunk);
+        for (chunk, out) in read.into_iter().zip(output) {
+            *out = u32::from_be_bytes(chunk);
         }
 
         Ok(())
@@ -147,8 +147,8 @@ pub trait RbxReadExt: Read {
         let mut read = vec![[0; mem::size_of::<u32>()]; output.len()];
         self.read_interleaved_bytes(&mut read)?;
 
-        for (chunk, n) in read.into_iter().zip(output) {
-            *n = f32::from_bits(u32::from_be_bytes(chunk).rotate_right(1));
+        for (chunk, out) in read.into_iter().zip(output) {
+            *out = f32::from_bits(u32::from_be_bytes(chunk).rotate_right(1));
         }
 
         Ok(())
@@ -176,8 +176,8 @@ pub trait RbxReadExt: Read {
         let mut read = vec![[0; mem::size_of::<i64>()]; output.len()];
         self.read_interleaved_bytes(&mut read)?;
 
-        for (chunk, n) in read.into_iter().zip(output) {
-            *n = untransform_i64(i64::from_be_bytes(chunk));
+        for (chunk, out) in read.into_iter().zip(output) {
+            *out = untransform_i64(i64::from_be_bytes(chunk));
         }
 
         Ok(())

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -314,21 +314,24 @@ pub trait RbxWriteExt: Write {
 
 impl<W> RbxWriteExt for W where W: Write {}
 
-/// Applies the integer transformation generally used in property data in the
-/// Roblox binary format.
+/// Applies the 'zigzag' transformation done by Roblox to many `i32` values.
 pub fn transform_i32(value: i32) -> i32 {
     (value << 1) ^ (value >> 31)
 }
 
-/// The inverse of `transform_i32`.
+/// Inverses the 'zigzag' encoding transformation done by Roblox to many
+/// `i32` values.
 pub fn untransform_i32(value: i32) -> i32 {
     ((value as u32) >> 1) as i32 ^ -(value & 1)
 }
 
+/// Applies the 'zigzag' transformation done by Roblox to many `i64` values.
 pub fn transform_i64(value: i64) -> i64 {
     (value << 1) ^ (value >> 63)
 }
 
+/// Inverses the 'zigzag' encoding transformation done by Roblox to many
+/// `i64` values.
 pub fn untransform_i64(value: i64) -> i64 {
     ((value as u64) >> 1) as i64 ^ -(value & 1)
 }


### PR DESCRIPTION
This migrates the various `read_interleaved_XXX_array` and `write_interleaved_XXX_array` functions to use `read_interleaved_bytes` and `write_interleaved_bytes` respectively.

The end result is a lot simpler code and has no cost associated with it (I checked the assembly, both versions give us basically the same instructions). Benchmarking also supports this, as the compilation time on my machine is basically the same before and after once you account for noise.

Also I added documentation to all these functions and the integer transforming functions because I didn't like them sitting there undocumented.