### PR TITLE
Don't serialize migrated properties

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -16,7 +16,7 @@ use rbx_dom_weak::{
     Instance, WeakDom,
 };
 
-use rbx_reflection::{ClassDescriptor, ClassTag, DataType};
+use rbx_reflection::{ClassDescriptor, ClassTag, DataType, PropertyKind, PropertySerialization};
 
 use crate::{
     chunk::{ChunkBuilder, ChunkCompression},
@@ -304,7 +304,16 @@ impl<'dom, W: Write> SerializerState<'dom, W> {
                     // For any properties that do not serialize, we can skip
                     // adding them to the set of type_infos.
                     let serialized = match descriptors.serialized {
-                        Some(descriptor) => descriptor,
+                        Some(descriptor) => {
+                            if let PropertyKind::Canonical {
+                                serialization: PropertySerialization::Migrate(_),
+                            } = descriptor.kind
+                            {
+                                continue;
+                            } else {
+                                descriptor
+                            }
+                        }
                         None => continue,
                     };
 

--- a/rbx_xml/src/core.rs
+++ b/rbx_xml/src/core.rs
@@ -50,7 +50,16 @@ pub fn find_serialized_property_descriptor(
     class_name: &str,
     property_name: &str,
 ) -> Option<&'static PropertyDescriptor<'static>> {
-    find_property_descriptors(class_name, property_name).map(|(_canonical, serialized)| serialized)
+    find_property_descriptors(class_name, property_name).map_or(None, |(_canonical, serialized)| {
+        if let PropertyKind::Canonical {
+            serialization: PropertySerialization::Migrate(_),
+        } = serialized.kind
+        {
+            None
+        } else {
+            Some(serialized)
+        }
+    })
 }
 
 /// Find both the canonical and serialized property descriptors for a given

--- a/rbx_xml/src/core.rs
+++ b/rbx_xml/src/core.rs
@@ -50,7 +50,7 @@ pub fn find_serialized_property_descriptor(
     class_name: &str,
     property_name: &str,
 ) -> Option<&'static PropertyDescriptor<'static>> {
-    find_property_descriptors(class_name, property_name).map_or(None, |(_canonical, serialized)| {
+    find_property_descriptors(class_name, property_name).and_then(|(_canonical, serialized)| {
         if let PropertyKind::Canonical {
             serialization: PropertySerialization::Migrate(_),
         } = serialized.kind


### PR DESCRIPTION
Closes #329.

This PR prevents rbx_xml and rbx_binary from serializing migrated properties. As stated in the linked issue, it's only possible for migrated properties to end up in the dom by specifically inserting them, but I think it's best to avoid any inconsistencies here.