### PR TITLE
Update READMEs of crates to remove outdated info

### DIFF
--- a/rbx_binary/README.md
+++ b/rbx_binary/README.md
@@ -7,4 +7,13 @@ More details about this crate are available on [the rbx-dom GitHub](https://gith
 Implementation of Roblox's binary model formats, rbxm and rbxl, for the rbx-dom ecosystem.
 
 ## Coverage
-rbx_binary aims to support all property types from rbx_dom_weak, but it currently lags behind rbx_xml due to implementation complexity.
+
+rbx_binary supports all property types from [`rbx_types`](https://crates.io/crates/rbx_types). It currently embeds a reflection database which contains a list of classes, properties, their types, and other information. In the event that this database is outdated, some issues may come up.
+
+These are mostly harmless, but they may include:
+	- Properties being serialized under the wrong name
+	- Properties having the incorrect default
+
+Additionally, data types newer than the current release of rbx_binary cannot be (de)serialized.
+
+In all of these cases, an update is needed for this crate.

--- a/rbx_types/README.md
+++ b/rbx_types/README.md
@@ -11,6 +11,6 @@ rbx_types contains value types, which are generally evergreen and are added infr
 - `Vector3`, Roblox's 3D vector type
 - `NumberSequence`, a series of numbers on a timeline
 - `BinaryString`, an opaque buffer of binary data
-- In the future, more specialized types like `Tags`, a list of `CollectionService` tags
+- More specialized data types representing specific `BinaryString` blobs
 
 rbx_types will _not_ contain instance types. New instances are added to the platform all the time and have more complicated semantics.

--- a/rbx_xml/README.md
+++ b/rbx_xml/README.md
@@ -7,6 +7,13 @@ More details about this crate are available on [the rbx-dom GitHub](https://gith
 Implementation of Roblox's XML model formats, rbxmx and rbxlx for the rbx-dom ecosystem.
 
 ## Coverage
-rbx_xml aims to support all property types from rbx_dom_weak.
 
-Some properties serialize with different names in XML than the names exposed via Roblox's API dump or via the Lua API. In those cases, rbx_xml keeps a mapping that needs to be kept up to date. These cases are pretty uncommon, so that table is small.
+rbx_xml supports all property types from [`rbx_types`](https://crates.io/crates/rbx_types). It currently embeds a reflection database which contains a list of classes, properties, their types, and other information. In the event that this database is outdated, some issues may come up.
+
+These are mostly harmless, but they may include:
+	- Properties being serialized under the wrong name
+	- Properties having the incorrect default
+
+Additionally, data types newer than the current release of rbx_xml cannot be (de)serialized.
+
+In all of these cases, an update is needed for this crate.


### PR DESCRIPTION
`rbx_types`, `rbx_binary`, and `rbx_xml` all have outdated information in their README so I think we should fix that.