### PR TITLE
Make gitignore ignore .vscode and sourcemap.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ Cargo.lock
 /*.rbxm
 /*.rbxmx
 /rbx_dom_lua/*.rbxlx
+
+# Editor-specific folders and files
+/.vscode
+sourcemap.json


### PR DESCRIPTION
I'm getting tired of having to ignore these and they're common in the Roblox development environment.