### PR TITLE
Make `rbx_binary` use nil UniqueId for default value

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1269,7 +1269,7 @@ impl<'dom, W: Write> SerializerState<'dom, W> {
             VariantType::Tags => Variant::Tags(Tags::new()),
             VariantType::Content => Variant::Content(Content::new()),
             VariantType::Attributes => Variant::Attributes(Attributes::new()),
-            VariantType::UniqueId => Variant::UniqueId(UniqueId::now().unwrap()),
+            VariantType::UniqueId => Variant::UniqueId(UniqueId::non_unique()),
             VariantType::Font => Variant::Font(Font::default()),
             _ => return None,
         })

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1269,7 +1269,7 @@ impl<'dom, W: Write> SerializerState<'dom, W> {
             VariantType::Tags => Variant::Tags(Tags::new()),
             VariantType::Content => Variant::Content(Content::new()),
             VariantType::Attributes => Variant::Attributes(Attributes::new()),
-            VariantType::UniqueId => Variant::UniqueId(UniqueId::non_unique()),
+            VariantType::UniqueId => Variant::UniqueId(UniqueId::nil()),
             VariantType::Font => Variant::Font(Font::default()),
             _ => return None,
         })

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -46,6 +46,8 @@ pub struct UniqueId {
 static INDEX: AtomicU32 = AtomicU32::new(0);
 
 impl UniqueId {
+    /// Returns a non-unique `UniqueId` that has every field set to `0`.
+    /// This value may appear multiple times in a Roblox file safely.
     pub fn non_unique() -> Self {
         Self {
             index: 0,
@@ -54,6 +56,8 @@ impl UniqueId {
         }
     }
 
+    /// Returns a new `UniqueId` with each component set to the passed
+    /// values.
     pub fn new(index: u32, time: u32, random: i64) -> Self {
         Self {
             index,
@@ -62,6 +66,7 @@ impl UniqueId {
         }
     }
 
+    /// Returns a new UniqueId.
     pub fn now() -> Result<Self, UniqueIdError> {
         let time = SystemTime::now()
             .duration_since(*EPOCH)
@@ -76,24 +81,38 @@ impl UniqueId {
         })
     }
 
+    /// Returns whether this `UniqueId` represents a value that **must** be
+    /// unique across all Instances in a Roblox file.
     pub fn is_unique(&self) -> bool {
         // Note that because only one field needs to be non-zero, we use
         // || here
         self.time != 0 || self.index != 0 || self.random != 0
     }
 
+    /// Returns whether this `UniqueId` represents the non-unique
+    /// `UniqueId` value.
     pub fn is_non_unique(&self) -> bool {
         !self.is_unique()
     }
 
+    /// The 'time' portion of the UniqueId. This is the number of seconds since
+    /// 1 January 2021.
+    ///
+    /// Pending system time errors, this value will always be above `0`.
     pub fn time(&self) -> u32 {
         self.time
     }
 
+    /// The 'index' portion of the UniqueId.
+    ///
+    /// This value may be any number in the range `[0, u32::MAX]`.
     pub fn index(&self) -> u32 {
         self.index
     }
 
+    /// The 'random' portion of the `UniqueId`.
+    ///
+    /// This value may be any number in the range `[0, i64::MAX]`.
     pub fn random(&self) -> i64 {
         self.random
     }

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -84,7 +84,7 @@ impl UniqueId {
     /// Returns whether this `UniqueId` is 'nil' or not. That is, whether
     /// every field of the UniqueId is set to `0`.
     pub fn is_nil(&self) -> bool {
-        self.time != 0 && self.index != 0 && self.random != 0
+        self.time == 0 && self.index == 0 && self.random == 0
     }
 
     /// The 'time' portion of the UniqueId. This is the number of seconds since

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -46,9 +46,9 @@ pub struct UniqueId {
 static INDEX: AtomicU32 = AtomicU32::new(0);
 
 impl UniqueId {
-    /// Returns a non-unique `UniqueId` that has every field set to `0`.
+    /// Returns a 'nil' `UniqueId` that has every field set to `0`.
     /// This value may appear multiple times in a Roblox file safely.
-    pub fn non_unique() -> Self {
+    pub fn nil() -> Self {
         Self {
             index: 0,
             time: 0,
@@ -81,18 +81,10 @@ impl UniqueId {
         })
     }
 
-    /// Returns whether this `UniqueId` represents a value that **must** be
-    /// unique across all Instances in a Roblox file.
-    pub fn is_unique(&self) -> bool {
-        // Note that because only one field needs to be non-zero, we use
-        // || here
-        self.time != 0 || self.index != 0 || self.random != 0
-    }
-
-    /// Returns whether this `UniqueId` represents the non-unique
-    /// `UniqueId` value.
-    pub fn is_non_unique(&self) -> bool {
-        !self.is_unique()
+    /// Returns whether this `UniqueId` is 'nil' or not. That is, whether
+    /// every field of the UniqueId is set to `0`.
+    pub fn is_nil(&self) -> bool {
+        self.time != 0 && self.index != 0 && self.random != 0
     }
 
     /// The 'time' portion of the UniqueId. This is the number of seconds since

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -46,6 +46,14 @@ pub struct UniqueId {
 static INDEX: AtomicU32 = AtomicU32::new(0);
 
 impl UniqueId {
+    pub fn non_unique() -> Self {
+        Self {
+            index: 0,
+            time: 0,
+            random: 0,
+        }
+    }
+
     pub fn new(index: u32, time: u32, random: i64) -> Self {
         Self {
             index,
@@ -66,6 +74,16 @@ impl UniqueId {
             // but is also always positive.
             random: thread_rng().gen_range(0..i64::MAX),
         })
+    }
+
+    pub fn is_unique(&self) -> bool {
+        // Note that because only one field needs to be non-zero, we use
+        // || here
+        self.time != 0 || self.index != 0 || self.random != 0
+    }
+
+    pub fn is_non_unique(&self) -> bool {
+        !self.is_unique()
     }
 
     pub fn time(&self) -> u32 {


### PR DESCRIPTION
Fully resolves #324 by making `UniqueId`'s default a null value, which may appears many times in a file.

Due to #327, it shouldn't affect anyone, but it's more 'correct' behavior anyway, so it's what we should be doing.

Tested in a version where `UniqueId` serializes using the following code:
```rs
use std::fs::File;

use rbx_dom_weak::{types::UniqueId, InstanceBuilder, WeakDom};

fn main() {
    let dom = WeakDom::new(
        InstanceBuilder::new("Workspace").with_children([
            InstanceBuilder::new("Folder")
                .with_property("UniqueId", UniqueId::now().unwrap())
                .with_name("UniqueId set"),
            InstanceBuilder::new("Folder"),
            InstanceBuilder::new("Folder"),
            InstanceBuilder::new("Folder"),
        ]),
    );

    rbx_binary::to_writer(File::create("out.rbxl").unwrap(), &dom, &[dom.root_ref()]).unwrap()
}
```