### PR TITLE
Update License year and copyright holder

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Lucien Greathouse
+Copyright (c) 2023 The Rojo Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Since we are prepping for a new release, it makes sense for us to change this; all subsequent versions of rbx-dom starting from the next release will be licensed to the Rojo authors rather than specifically LPG.