### PR TITLE
Return pod in MaterialColors Lua encoder

### DIFF
--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -282,6 +282,7 @@ types = {
 					math.round(math.clamp(color.B, 0, 1) * 255)
 				}
 			end
+			return pod
 		end,
 	},
 


### PR DESCRIPTION
Right now, rbx_dom_lua's round trip test fails on MaterialColors:
```
ken@DESKTOP-NIUUROA:~/projects/rbx-dom/rbx_dom_lua$ ./test
Building project 'rbx_dom_lua test place'
Built project to TestPlace.rbxlx
Test results:
[-] RbxDom
   [-] EncodedValue
      [-] round trip MaterialColors
0 passed, 1 failed, 34 skipped
1 test nodes reported failures.
Errors reported by tests:

TestService: ReplicatedStorage.RbxDom.EncodedValue.spec:63: Round-trip results did not match.
Expected:
{"MaterialColors":{"Grass":[106,127,63],"Rock":[102,108,111],"Basalt":[30,30,37],"Sand":[143,126,95],"Sandstone":[137,90,71],"Brick":[138,86,62],"Cobblestone":[132,123,90],"Glacier":[101,176,234],"Ground":[102,92,59],"Snow":[195,199,218],"WoodPlanks":[139,109,79],"Limestone":[206,173,148],"Slate":[63,127,107],"Salt":[198,189,181],"Pavement":[148,148,140],"CrackedLava":[232,156,74],"Mud":[58,46,36],"Concrete":[127,102,63],"LeafyGrass":[115,132,74],"Asphalt":[115,123,107],"Ice":[129,194,224]}}
Actual:
[]
ReplicatedStorage.TestEZ.TestRunner:91
ReplicatedStorage.RbxDom.EncodedValue.spec:63
ReplicatedStorage.TestEZ.TestRunner:90 function runPlanNode
ReplicatedStorage.TestEZ.TestRunner:113 function runPlanNode
ReplicatedStorage.TestEZ.TestRunner:113 function runPlanNode
ReplicatedStorage.TestEZ.TestRunner:38 function runPlan
ReplicatedStorage.TestEZ.TestBootstrap:101 function run
user_run_in_roblox-50312.rbxmx.run-in-roblox-plugin.Main:2
user_run_in_roblox-50312.rbxmx.run-in-roblox-plugin:79
```
This is occurring because the MaterialColors toPod implementation does not return the result:
https://github.com/rojo-rbx/rbx-dom/blob/9d2418d834dd5e47dc2927a5860ba339942414ef/rbx_dom_lua/src/EncodedValue.lua#L276-L285