### PR TITLE
Implement FromStr for TerrainMaterials

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased Changes
 
+* Implement `FromStr` for `TerrainMaterials`. ([#354])
+
+[#354]: https://github.com/rojo-rbx/rbx-dom/pull/354
+
 ## 1.6.0 (2023-08-09)
 * Added support for `UniqueId` values. ([#271])
 * Changed `BinaryString`'s non-human readable serde implementation to be identical to `Vec<u8>`. ([#276])

--- a/rbx_types/src/material_colors.rs
+++ b/rbx_types/src/material_colors.rs
@@ -142,13 +142,13 @@ macro_rules! material_colors {
         }
 
         impl FromStr for TerrainMaterials {
-            type Err = MaterialColorsError;
+            type Err = CrateError;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {$(
                     stringify!($name) => Ok(Self::$name),
                 )*
-                    _ => Err(MaterialColorsError::UnknownMaterial(s.to_string())),
+                    _ => Err(MaterialColorsError::UnknownMaterial(s.to_string()).into()),
                 }
             }
         }

--- a/rbx_types/src/material_colors.rs
+++ b/rbx_types/src/material_colors.rs
@@ -88,7 +88,7 @@ where
     }
 }
 
-/// An error that can occur when deserializing MaterialColors.
+/// An error that can occur when deserializing or working with MaterialColors and TerrainMaterials.
 #[derive(Debug, Error)]
 pub enum MaterialColorsError {
     /// The `MaterialColors` blob was the wrong number of bytes.


### PR DESCRIPTION
Closes #353.

This also modifies `MaterialColorsError` to be a generalized error for both `MaterialColors` and `TerrainColors`. This is technically a breaking change because the enum is publicly exposed, but I don't think it will seriously impact anyone beyond adding a new variant to the enum.