### PR TITLE
Dont expose `MaterialColorsError` and `UniqueIdError`

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # rbx_types Changelog
 
 ## Unreleased Changes
+* `MaterialColorsError` and `UniqueIdError` are no longer publicly exposed. ([#355])
+
+[#355]: https://github.com/rojo-rbx/rbx-dom/pull/355
 
 ## 1.6.0 (2023-08-09)
 * Added support for `UniqueId` values. ([#271])

--- a/rbx_types/src/error.rs
+++ b/rbx_types/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{AttributeError, MaterialColorsError, Matrix3Error};
+use crate::{AttributeError, MaterialColorsError, Matrix3Error, UniqueIdError};
 
 /// Represents an error that occurred when using a fallible method.
 #[derive(Debug, Error)]
@@ -33,6 +33,14 @@ impl From<MaterialColorsError> for Error {
     }
 }
 
+impl From<UniqueIdError> for Error {
+    fn from(source: UniqueIdError) -> Self {
+        Self {
+            source: Box::new(source.into()),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 enum InnerError {
     #[error(transparent)]
@@ -43,4 +51,7 @@ enum InnerError {
 
     #[error(transparent)]
     MaterialColors(#[from] MaterialColorsError),
+
+    #[error(transparent)]
+    UniqueId(#[from] UniqueIdError),
 }

--- a/rbx_types/src/material_colors.rs
+++ b/rbx_types/src/material_colors.rs
@@ -90,7 +90,7 @@ where
 
 /// An error that can occur when deserializing MaterialColors.
 #[derive(Debug, Error)]
-pub enum MaterialColorsError {
+pub(crate) enum MaterialColorsError {
     /// The `MaterialColors` blob was the wrong number of bytes.
     #[error(
         "MaterialColors blob was the wrong length (expected it to be 69 bytes, it was {0} bytes)"

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -94,10 +94,6 @@ pub(crate) enum DecodeErrorKind {
         actual_type: VariantType,
         message: String,
     },
-    InvalidPropertyData {
-        property_type: &'static str,
-        error: String,
-    },
 }
 
 impl fmt::Display for DecodeErrorKind {

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -142,13 +142,6 @@ impl fmt::Display for DecodeErrorKind {
                  When trying to convert, this error occured: {}",
                 class_name, property_name, expected_type, actual_type, message
             ),
-            InvalidPropertyData {
-                property_type,
-                error,
-            } => write!(
-                output,
-                "Could not decode property of type {property_type} because: {error}"
-            ),
         }
     }
 }

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -74,6 +74,7 @@ pub(crate) enum DecodeErrorKind {
     ParseInt(std::num::ParseIntError),
     DecodeBase64(base64::DecodeError),
     MigrationError(rbx_reflection::MigrationError),
+    TypeError(rbx_dom_weak::types::Error),
 
     // Errors specific to rbx_xml
     WrongDocVersion(String),
@@ -109,6 +110,7 @@ impl fmt::Display for DecodeErrorKind {
             ParseInt(err) => write!(output, "{}", err),
             DecodeBase64(err) => write!(output, "{}", err),
             MigrationError(err) => write!(output, "{}", err),
+            TypeError(err) => write!(output, "{}", err),
 
             WrongDocVersion(version) => {
                 write!(output, "Invalid version '{}', expected version 4", version)

--- a/rbx_xml/src/types/unique_id.rs
+++ b/rbx_xml/src/types/unique_id.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use rbx_dom_weak::types::{UniqueId, UniqueIdError};
+use rbx_dom_weak::types::UniqueId;
 
 use crate::{
     core::XmlType,
@@ -15,19 +15,12 @@ impl XmlType for UniqueId {
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
         let content = reader.read_characters()?;
 
-        content.parse().map_err(|e| reader.error(e))
+        content
+            .parse()
+            .map_err(|e| reader.error(DecodeErrorKind::TypeError(e)))
     }
 
     fn write_xml<W: Write>(&self, writer: &mut XmlEventWriter<W>) -> Result<(), EncodeError> {
         writer.write_value(&self.to_string())
-    }
-}
-
-impl From<UniqueIdError> for DecodeErrorKind {
-    fn from(value: UniqueIdError) -> Self {
-        DecodeErrorKind::InvalidPropertyData {
-            property_type: "UniqueId",
-            error: value.to_string(),
-        }
     }
 }


### PR DESCRIPTION
At the moment, the error types for `UniqueId` and `MaterialColors` are exposed. This means that every change to their structure is breaking, including adding variants.

We should use the `Error` type defined by `rbx_types` instead. This PR changes it to do that. Additionally, it cleans up an implementation in `rbx_xml` that relied upon this type being exposed but that's not user facing so it is not noted in the changelog.