### PR TITLE
Fix useless conversion lints, use Rust 2021 feature resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
 	"generate_reflection",
 	"rbx_binary",

--- a/rbx_dom_weak/src/instance.rs
+++ b/rbx_dom_weak/src/instance.rs
@@ -156,7 +156,7 @@ impl InstanceBuilder {
     where
         I: IntoIterator<Item = InstanceBuilder>,
     {
-        self.children.extend(children.into_iter());
+        self.children.extend(children);
         self
     }
 
@@ -167,7 +167,7 @@ impl InstanceBuilder {
     where
         I: IntoIterator<Item = InstanceBuilder>,
     {
-        self.children.extend(children.into_iter());
+        self.children.extend(children);
     }
 }
 


### PR DESCRIPTION
This PR Fixes a couple clippy lints that recently cropped up - we were calling `into_iter` unnecessarily in some `InstanceBuilder` methods

I also noticed a warning about the Rust 2021 feature resolver, so I set `workspace.resolver = "2"` to silence it. It looks to work just fine and I can't see any significant drawbacks - see https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html for details