### PR TITLE
Don't include SecurityCapabilities test in rbx_dom_lua

### DIFF
--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -424,6 +424,15 @@ types = {
 		end,
 	},
 
+	SecurityCapabilities = {
+		fromPod = function(pod)
+			error("SecurityCapabilities is not implemented")
+		end,
+		toPod = function(roblox)
+			error("SecurityCapabilities is not implemented")
+		end
+	},
+
 	SharedString = {
 		fromPod = function(pod)
 			error("SharedString is not supported")

--- a/rbx_reflector/src/cli/values.rs
+++ b/rbx_reflector/src/cli/values.rs
@@ -6,8 +6,8 @@ use rbx_types::{
     Attributes, Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
     ColorSequenceKeypoint, Content, CustomPhysicalProperties, Enum, Faces, Font, MaterialColors,
     Matrix3, NumberRange, NumberSequence, NumberSequenceKeypoint, PhysicalProperties, Ray, Rect,
-    Region3int16, SecurityCapabilities, Tags, TerrainMaterials, UDim, UDim2, Variant, VariantType,
-    Vector2, Vector2int16, Vector3, Vector3int16,
+    Region3int16, Tags, TerrainMaterials, UDim, UDim2, Variant, VariantType, Vector2, Vector2int16,
+    Vector3, Vector3int16,
 };
 use serde::Serialize;
 
@@ -176,10 +176,6 @@ impl ValuesSubcommand {
         values.insert("Vector2int16", Vector2int16::new(-300, 300).into());
         values.insert("Vector3", Vector3::new(-300.0, 0.0, 1500.0).into());
         values.insert("Vector3int16", Vector3int16::new(60, 37, -450).into());
-        values.insert(
-            "SecurityCapabilities",
-            SecurityCapabilities::from_bits(256).into(),
-        );
 
         let entries: BTreeMap<&str, TestEntry> = values
             .into_iter()


### PR DESCRIPTION
With the introduction of SecurityCapabilities in #359, a value was added to the roundtrip test for rbx_dom_lua. This caused tests to begin to fail, as no pod was ever provided. However, in keeping with the theme of "we don't provide pods for values we don't use", we should simply not include a value for this type in tests to begin with.

This PR does exactly that, and allows rbx_dom_lua tests to pass once more.