### PR TITLE
Implement method for cloning multiple instances into external dom

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,6 +1,9 @@
 # rbx_dom_weak Changelog
 
 ## Unreleased Changes
+* Added `WeakDom::clone_multiple_into_external` that allows cloning multiple subtrees all at once into a given `WeakDom`, useful for preserving `Ref` properties that point across cloned subtrees ([#364])
+
+[#364]: https://github.com/rojo-rbx/rbx-dom/pull/364
 
 ## 2.5.0 (2023-08-09)
 * Fix potential stack overflow when creating or inserting into a `WeakDom`. ([#279])

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -282,7 +282,7 @@ impl WeakDom {
         root_ref
     }
 
-    /// Similar to clone_into_external, but clones multiple subtrees all at once. This
+    /// Similar to `clone_into_external`, but clones multiple subtrees all at once. This
     /// method will preserve Ref properties that point across the cloned subtrees.
     pub fn clone_multiple_into_external(&self, referents: &[Ref], dest: &mut WeakDom) -> Vec<Ref> {
         let mut ctx = CloneContext::default();

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -572,7 +572,7 @@ mod test {
         };
 
         let mut other_dom = WeakDom::new(InstanceBuilder::new("DataModel"));
-        let cloned = dom.clone_multiple_into_external(&dom.root().children(), &mut other_dom);
+        let cloned = dom.clone_multiple_into_external(dom.root().children(), &mut other_dom);
 
         assert!(
             other_dom.get_by_ref(cloned[0]).unwrap().parent.is_none(),

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -278,6 +278,25 @@ impl WeakDom {
         root_ref
     }
 
+    /// Ok
+    pub fn clone_multiple_into_external(&self, referents: &[Ref], dest: &mut WeakDom) -> Vec<Ref> {
+        let mut ctx = CloneContext::default();
+        let mut root_refs = Vec::with_capacity(referents.len());
+
+        for referent in referents {
+            let builder = ctx.clone_ref_as_builder(self, *referent);
+            root_refs.push(dest.insert(Ref::none(), builder));
+        }
+
+        while let Some((cloned_parent, uncloned_child)) = ctx.queue.pop_front() {
+            let builder = ctx.clone_ref_as_builder(self, uncloned_child);
+            dest.insert(cloned_parent, builder);
+        }
+
+        ctx.rewrite_refs(dest);
+        root_refs
+    }
+
     fn inner_insert(&mut self, referent: Ref, instance: Instance) {
         self.instances.insert(referent, instance);
 

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -264,6 +264,10 @@ impl WeakDom {
     /// Any Ref properties that point to instances contained in the subtree are
     /// rewritten to point to the cloned instances. Any other Ref properties
     /// would be invalid  in `dest` and are thus rewritten to be `Ref::none()`
+    ///
+    /// This means that if you call this method on multiple different instances, Ref
+    /// properties will not necessarily be preserved in the destination dom. If you're
+    /// cloning multiple instances, prefer `clone_multiple_into_external` instead!
     pub fn clone_into_external(&self, referent: Ref, dest: &mut WeakDom) -> Ref {
         let mut ctx = CloneContext::default();
         let root_builder = ctx.clone_ref_as_builder(self, referent);
@@ -278,7 +282,8 @@ impl WeakDom {
         root_ref
     }
 
-    /// Ok
+    /// Similar to clone_into_external, but clones multiple subtrees all at once. This
+    /// method will preserve Ref properties that point across the cloned subtrees.
     pub fn clone_multiple_into_external(&self, referents: &[Ref], dest: &mut WeakDom) -> Vec<Ref> {
         let mut ctx = CloneContext::default();
         let mut root_refs = Vec::with_capacity(referents.len());

--- a/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_multiple_into_external.snap
+++ b/rbx_dom_weak/src/snapshots/rbx_dom_weak__dom__test__clone_multiple_into_external.snap
@@ -1,0 +1,22 @@
+---
+source: rbx_dom_weak/src/dom.rs
+expression: viewer.view(&other_dom)
+---
+referent: referent-0
+name: DataModel
+class: DataModel
+properties: {}
+children:
+  - referent: referent-1
+    name: Child1
+    class: Part
+    properties:
+      RefProp: referent-2
+    children: []
+  - referent: referent-2
+    name: Child2
+    class: Part
+    properties:
+      RefProp: referent-1
+    children: []
+


### PR DESCRIPTION
Related: filiptibell/lune#110

It is not possible to preserve refs that point across subtrees using `WeakDom::clone_into_external` because a new `CloneContext` is used for each invocation - this new method gives a way to use one `CloneContext` for multiple subtrees!

Not sure about the method name, docs could probably be a little better, etc.