### PR TITLE
Fix saying CFrame components are XVector, YVector, and ZVector

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -408,11 +408,11 @@ The `CFrame` type is more complicated than other types. To save space, there are
 
 If the byte is `00`, a `CFrame` looks like this:
 
-| Field Name  | Format                  | Value                                                                                                |
-|:------------|:------------------------|:-----------------------------------------------------------------------------------------------------|
-| ID          | `u8`                    | Always `00` in this case.                                                                            |
-| Orientation | Array of 9 `f32` values | The rotation matrix of the `CFrame`. It represents the XVector, YVector, and ZVector, in that order. |
-| Position    | [`Vector3`](#vector3)   | The position of the `CFrame`.                                                                        |
+| Field Name  | Format                  | Value                                                                                                              |
+|:------------|:------------------------|:-------------------------------------------------------------------------------------------------------------------|
+| ID          | `u8`                    | Always `00` in this case.                                                                                          |
+| Orientation | Array of 9 `f32` values | The rotation matrix of the `CFrame`. Contains the components `R00 R01 R02 R10 R11 R12 R20 R21 R22`, in that order. |
+| Position    | [`Vector3`](#vector3)   | The position of the `CFrame`.                                                                                      |
 
 In this case, the `Orientation` field is stored as nine untransformed [IEEE-754 standard](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) 32-bit floats.
 


### PR DESCRIPTION
It turns out that the Roblox documentation was totally wrong and I was misled into writing that `CFrame` stores the `XVector`, `YVector`, and `ZVector` (these properties are NOT the rows of the matrix - [Roblox docs have recently been updated to reflect this](https://create.roblox.com/docs/en-us/reference/engine/datatypes/CFrame)). This PR simply writes the components of the rotation matrix in row-major order in our docs for binary `CFrame`.