### PR TITLE
Add fallback default for SecurityCapabilities

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_binary Changelog
 
 ## Unreleased
+* Fixed missing fallback default for `SecurityCapabilities` ([#371]).
 
 ## 0.7.2 (2023-10-03)
 * Added support for `SecurityCapabilities` values. ([#361])

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -10,8 +10,9 @@ use rbx_dom_weak::{
     types::{
         Attributes, Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
         ColorSequenceKeypoint, Content, Enum, Faces, Font, MaterialColors, Matrix3, NumberRange,
-        NumberSequence, NumberSequenceKeypoint, PhysicalProperties, Ray, Rect, Ref, SharedString,
-        Tags, UDim, UDim2, UniqueId, Variant, VariantType, Vector2, Vector3, Vector3int16,
+        NumberSequence, NumberSequenceKeypoint, PhysicalProperties, Ray, Rect, Ref,
+        SecurityCapabilities, SharedString, Tags, UDim, UDim2, UniqueId, Variant, VariantType,
+        Vector2, Vector3, Vector3int16,
     },
     Instance, WeakDom,
 };
@@ -1360,6 +1361,9 @@ impl<'dom, W: Write> SerializerState<'dom, W> {
             VariantType::UniqueId => Variant::UniqueId(UniqueId::nil()),
             VariantType::Font => Variant::Font(Font::default()),
             VariantType::MaterialColors => Variant::MaterialColors(MaterialColors::new()),
+            VariantType::SecurityCapabilities => {
+                Variant::SecurityCapabilities(SecurityCapabilities::default())
+            }
             _ => return None,
         })
     }


### PR DESCRIPTION
In #361, we forgot to add the fallback default for `SecurityCapabilities`. This means when some instances are missing `Instance.Capabilities` (these are instances that were saved before `SecurityCapabilities` existed), and other instances *do* have this property, the binary serializer errors out. This PR adds the fallback default so this doesn't happen.