### PR TITLE
Remove erroring SecurityCapabilities lua coder/decoder

### DIFF
--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -412,15 +412,6 @@ types = {
 		end,
 	},
 
-	SecurityCapabilities = {
-		fromPod = function(_pod)
-			error("SecurityCapabilities is not implemented")
-		end,
-		toPod = function(_roblox)
-			error("SecurityCapabilities is not implemented")
-		end,
-	},
-
 	SharedString = {
 		fromPod = function(_pod)
 			error("SharedString is not supported")


### PR DESCRIPTION
It looks like this coder/decoder was introduced in imitation of some other types, but the other types that have erroring implementations either:
* Do not exist on any instance (`Region3`)
* Are special-cased elsewhere downstream (`Ref`)
* Wouldn't work anyway? (`SharedString`, although I think there is a case to be made that `SharedString` should NOT have an erroring lua coder/decoder)

`SecurityCapabilities` exists on *all* instances so an erroring implementation is inappropriate and causes problems for Rojo as per rojo-rbx/rojo#802. I think we can just remove the lua encoder/decoder, like how `UniqueId` simply doesn't have them either.