### PR TITLE
Fix clippy lint in rbx_types

### DIFF
--- a/rbx_types/src/attributes/writer.rs
+++ b/rbx_types/src/attributes/writer.rs
@@ -23,8 +23,6 @@ pub(crate) fn write_attributes<W: Write>(
     writer.write_all(&(map.len() as u32).to_le_bytes())?;
 
     for (name, variant) in map {
-        let variant = variant;
-
         write_string(&mut writer, name)?;
 
         let type_id = type_id::from_variant_type(variant.ty())


### PR DESCRIPTION
This was my fault (I didn't finish the job in PR #370).