### PR TITLE
Add name validation to rbx_dom_lua Attributes writer

### DIFF
--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -37,9 +37,24 @@ return {
 			end,
 			write = function(instance, _, value)
 				local existing = instance:GetAttributes()
+				local didAllWritesSucceed = true
 
-				for key, attr in pairs(value) do
-					instance:SetAttribute(key, attr)
+				for attributeName, attributeValue in pairs(value) do
+					local isNameValid =
+						-- For our SetAttribute to succeed, the attribute name must be
+						-- less than or equal to 100 characters...
+						#attributeName <= 100
+						-- ...must only contain alphanumeric characters, periods, hyphens,
+						-- underscores, or forward slashes...
+						and attributeName:match("[^%w%.%-_/]") == nil
+						-- ... and must not use the RBX prefix, which is reserved by Roblox.
+						and attributeName:sub(1, 3) ~= "RBX"
+
+					if isNameValid then
+						instance:SetAttribute(attributeName, attributeValue)
+					else
+						didAllWritesSucceed = false
+					end
 				end
 
 				for key in pairs(existing) do
@@ -48,7 +63,7 @@ return {
 					end
 				end
 
-				return true
+				return didAllWritesSucceed
 			end,
 		},
 		Tags = {


### PR DESCRIPTION
`Instance:SetAttribute` errors when passed invalid attribute names. The name must:
* be less than or equal to 100 characters;
* only contain alphanumeric characters, [and in the near future](https://create.roblox.com/docs/en-us/release-notes/release-notes-592), periods, hyphens, underscores, or forward slashes;
* must not use the RBX prefix, which is reserved by Roblox.

This PR adds validation to rbx_dom_lua's `Attributes` custom writer to guard against these, and if any fail, returns `false` (but will still attempt to set all the attributes). In the future, once Rojo's patch visualizer has more rich display of `Attributes` values, we could return a more detailed error with specific information about which ones failed.

The alternative is throwing the `SetAttribute` into a protected call, but eh..