### PR TITLE
Allow a database to be specified in both rbx_xml and rbx_binary

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_binary Changelog
 
 ## Unreleased
+* Add the ability to specify a `ReflectionDatabase` to use for serializing and deserializing. This takes the form of `Deserializer::reflection_database` and `Serializer::reflection_database`.
 
 ## 0.7.3 (2023-10-23)
 * Fixed missing fallback default for `SecurityCapabilities` ([#371]).

--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,7 +1,9 @@
 # rbx_binary Changelog
 
 ## Unreleased
-* Add the ability to specify a `ReflectionDatabase` to use for serializing and deserializing. This takes the form of `Deserializer::reflection_database` and `Serializer::reflection_database`.
+* Add the ability to specify a `ReflectionDatabase` to use for serializing and deserializing. This takes the form of `Deserializer::reflection_database` and `Serializer::reflection_database`. ([#375])
+
+[#375]: https://github.com/rojo-rbx/rbx-dom/pull/375
 
 ## 0.7.3 (2023-10-23)
 * Fixed missing fallback default for `SecurityCapabilities` ([#371]).

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -336,18 +336,18 @@ pub fn untransform_i64(value: i64) -> i64 {
     ((value as u64) >> 1) as i64 ^ -(value & 1)
 }
 
-pub struct PropertyDescriptors<'a> {
-    pub canonical: &'a PropertyDescriptor<'a>,
-    pub serialized: Option<&'a PropertyDescriptor<'a>>,
+pub struct PropertyDescriptors<'db> {
+    pub canonical: &'db PropertyDescriptor<'db>,
+    pub serialized: Option<&'db PropertyDescriptor<'db>>,
 }
 
 /// Find both the canonical and serialized property descriptors for a given
 /// class and property name pair. These might be the same descriptor!
-pub fn find_property_descriptors<'a>(
-    database: &'a ReflectionDatabase<'a>,
+pub fn find_property_descriptors<'db>(
+    database: &'db ReflectionDatabase<'db>,
     class_name: &str,
     property_name: &str,
-) -> Option<PropertyDescriptors<'a>> {
+) -> Option<PropertyDescriptors<'db>> {
     let mut class_descriptor = database.classes.get(class_name)?;
 
     // We need to find the canonical property descriptor associated with
@@ -437,11 +437,11 @@ pub fn find_property_descriptors<'a>(
 /// Given the canonical property descriptor for a logical property along with
 /// its serialization, returns the serialized form of the logical property if
 /// this property is serializable.
-fn find_serialized_from_canonical<'a>(
-    class: &'a ClassDescriptor<'a>,
-    canonical: &'a PropertyDescriptor<'a>,
-    serialization: &'a PropertySerialization<'a>,
-) -> Option<&'a PropertyDescriptor<'a>> {
+fn find_serialized_from_canonical<'db>(
+    class: &'db ClassDescriptor<'db>,
+    canonical: &'db PropertyDescriptor<'db>,
+    serialization: &'db PropertySerialization<'db>,
+) -> Option<&'db PropertyDescriptor<'db>> {
     match serialization {
         // This property serializes as-is. This is the happiest path: both the
         // canonical and serialized descriptors are the same!

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -50,6 +50,13 @@ impl<'a> Deserializer<'a> {
         }
     }
 
+    /// Sets what reflection database for the deserializer to use.
+    pub fn reflection_database(self, database: &'a ReflectionDatabase<'a>) -> Self {
+        Self {
+            database: Some(database),
+        }
+    }
+
     /// Deserialize a Roblox binary model or place from the given stream using
     /// this deserializer.
     pub fn deserialize<R: Read>(&self, reader: R) -> Result<WeakDom, Error> {

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -38,6 +38,14 @@ pub use self::error::Error;
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+///
+/// ## Configuration
+///
+/// A custom [`ReflectionDatabase`][ReflectionDatabase] can be specified via
+/// [`reflection_database`][reflection_database].
+///
+/// [ReflectionDatabase]: rbx_reflection::ReflectionDatabase
+/// [reflection_database]: Deserializer#method.reflection_database
 pub struct Deserializer<'db> {
     database: Option<&'db ReflectionDatabase<'db>>,
 }

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -47,23 +47,21 @@ pub use self::error::Error;
 /// [ReflectionDatabase]: rbx_reflection::ReflectionDatabase
 /// [reflection_database]: Deserializer#method.reflection_database
 pub struct Deserializer<'db> {
-    database: Option<&'db ReflectionDatabase<'db>>,
+    database: &'db ReflectionDatabase<'db>,
 }
 
 impl<'db> Deserializer<'db> {
     /// Create a new `Deserializer` with the default settings.
     pub fn new() -> Self {
         Self {
-            database: Some(rbx_reflection_database::get()),
+            database: rbx_reflection_database::get(),
         }
     }
 
     /// Sets what reflection database for the deserializer to use.
     #[inline]
     pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
-        Self {
-            database: Some(database),
-        }
+        Self { database }
     }
 
     /// Deserialize a Roblox binary model or place from the given stream using

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -38,11 +38,11 @@ pub use self::error::Error;
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub struct Deserializer<'a> {
-    database: Option<&'a ReflectionDatabase<'a>>,
+pub struct Deserializer<'db> {
+    database: Option<&'db ReflectionDatabase<'db>>,
 }
 
-impl<'a> Deserializer<'a> {
+impl<'db> Deserializer<'db> {
     /// Create a new `Deserializer` with the default settings.
     pub fn new() -> Self {
         Self {
@@ -51,7 +51,7 @@ impl<'a> Deserializer<'a> {
     }
 
     /// Sets what reflection database for the deserializer to use.
-    pub fn reflection_database(self, database: &'a ReflectionDatabase<'a>) -> Self {
+    pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
         Self {
             database: Some(database),
         }
@@ -88,7 +88,7 @@ impl<'a> Deserializer<'a> {
     }
 }
 
-impl<'a> Default for Deserializer<'a> {
+impl<'db> Default for Deserializer<'db> {
     fn default() -> Self {
         Self::new()
     }

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -51,6 +51,7 @@ impl<'db> Deserializer<'db> {
     }
 
     /// Sets what reflection database for the deserializer to use.
+    #[inline]
     pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
         Self {
             database: Some(database),

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -382,7 +382,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
         }
 
         let property = if let Some(property) = find_canonical_property(
-            self.deserializer.database.unwrap(),
+            self.deserializer.database,
             binary_type,
             &type_info.type_name,
             &prop_name,

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -24,9 +24,9 @@ use crate::{
 
 use super::{error::InnerError, header::FileHeader, Deserializer};
 
-pub(super) struct DeserializerState<'a, R> {
+pub(super) struct DeserializerState<'db, R> {
     /// The user-provided configuration that we should use.
-    deserializer: &'a Deserializer<'a>,
+    deserializer: &'db Deserializer<'db>,
 
     /// The input data encoded as a binary model.
     input: R,
@@ -90,10 +90,10 @@ struct Instance {
 /// contains a migration for some properties Roblox has replaced with
 /// others (like Font, which has been superceded by FontFace).
 #[derive(Debug)]
-struct CanonicalProperty<'a> {
-    name: &'a str,
+struct CanonicalProperty<'db> {
+    name: &'db str,
     ty: VariantType,
-    migration: Option<&'a PropertySerialization<'a>>,
+    migration: Option<&'db PropertySerialization<'db>>,
 }
 
 fn find_canonical_property<'de>(
@@ -210,9 +210,9 @@ fn add_property(instance: &mut Instance, canonical_property: &CanonicalProperty,
     }
 }
 
-impl<'a, R: Read> DeserializerState<'a, R> {
+impl<'db, R: Read> DeserializerState<'db, R> {
     pub(super) fn new(
-        deserializer: &'a Deserializer<'a>,
+        deserializer: &'db Deserializer<'db>,
         mut input: R,
     ) -> Result<Self, InnerError> {
         let tree = WeakDom::new(InstanceBuilder::new("DataModel"));

--- a/rbx_binary/src/serializer/mod.rs
+++ b/rbx_binary/src/serializer/mod.rs
@@ -28,8 +28,16 @@ pub use self::error::Error;
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+///
+/// ## Configuration
+///
+/// A custom [`ReflectionDatabase`][ReflectionDatabase] can be specified via
+/// [`reflection_database`][reflection_database].
+///
+/// [ReflectionDatabase]: rbx_reflection::ReflectionDatabase
+/// [reflection_database]: Serializer#method.reflection_database
+//
 // future settings:
-// * reflection_database: Option<ReflectionDatabase> = default
 // * recursive: bool = true
 #[non_exhaustive]
 pub struct Serializer<'db> {

--- a/rbx_binary/src/serializer/mod.rs
+++ b/rbx_binary/src/serializer/mod.rs
@@ -45,6 +45,7 @@ impl<'db> Serializer<'db> {
     }
 
     /// Sets what reflection database for the serializer to use.
+    #[inline]
     pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
         Self {
             database: Some(database),

--- a/rbx_binary/src/serializer/mod.rs
+++ b/rbx_binary/src/serializer/mod.rs
@@ -32,11 +32,11 @@ pub use self::error::Error;
 // * reflection_database: Option<ReflectionDatabase> = default
 // * recursive: bool = true
 #[non_exhaustive]
-pub struct Serializer<'a> {
-    database: Option<&'a ReflectionDatabase<'a>>,
+pub struct Serializer<'db> {
+    database: Option<&'db ReflectionDatabase<'db>>,
 }
 
-impl<'a> Serializer<'a> {
+impl<'db> Serializer<'db> {
     /// Create a new `Serializer` with the default settings.
     pub fn new() -> Self {
         Serializer {
@@ -45,7 +45,7 @@ impl<'a> Serializer<'a> {
     }
 
     /// Sets what reflection database for the serializer to use.
-    pub fn reflection_database(self, database: &'a ReflectionDatabase<'a>) -> Self {
+    pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
         Self {
             database: Some(database),
         }
@@ -72,7 +72,7 @@ impl<'a> Serializer<'a> {
     }
 }
 
-impl<'a> Default for Serializer<'a> {
+impl<'db> Default for Serializer<'db> {
     fn default() -> Self {
         Self::new()
     }

--- a/rbx_binary/src/serializer/mod.rs
+++ b/rbx_binary/src/serializer/mod.rs
@@ -41,23 +41,21 @@ pub use self::error::Error;
 // * recursive: bool = true
 #[non_exhaustive]
 pub struct Serializer<'db> {
-    database: Option<&'db ReflectionDatabase<'db>>,
+    database: &'db ReflectionDatabase<'db>,
 }
 
 impl<'db> Serializer<'db> {
     /// Create a new `Serializer` with the default settings.
     pub fn new() -> Self {
         Serializer {
-            database: Some(rbx_reflection_database::get()),
+            database: rbx_reflection_database::get(),
         }
     }
 
     /// Sets what reflection database for the serializer to use.
     #[inline]
     pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
-        Self {
-            database: Some(database),
-        }
+        Self { database }
     }
 
     /// Serialize a Roblox binary model or place into the given stream using

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -289,7 +289,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
     pub fn collect_type_info(&mut self, instance: &'dom Instance) -> Result<(), InnerError> {
         let type_info = self
             .type_infos
-            .get_or_create(self.serializer.database.unwrap(), &instance.class);
+            .get_or_create(self.serializer.database, &instance.class);
         type_info.instances.push(instance);
 
         for (prop_name, prop_value) in &instance.properties {
@@ -322,7 +322,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
             let serialized_ty;
             let mut migration = None;
 
-            let database = self.serializer.database.unwrap();
+            let database = self.serializer.database;
             match find_property_descriptors(database, &instance.class, prop_name) {
                 Some(descriptors) => {
                     // For any properties that do not serialize, we can skip

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -27,6 +27,7 @@ use crate::{
         find_property_descriptors, RbxWriteExt, FILE_MAGIC_HEADER, FILE_SIGNATURE, FILE_VERSION,
     },
     types::Type,
+    Serializer,
 };
 
 use super::error::InnerError;
@@ -36,7 +37,9 @@ static FILE_FOOTER: &[u8] = b"</roblox>";
 /// Represents all of the state during a single serialization session. A new
 /// `BinarySerializer` object should be created every time we want to serialize
 /// a binary model file.
-pub(super) struct SerializerState<'dom, W> {
+pub(super) struct SerializerState<'dom, 'a, W> {
+    serializer: &'a Serializer<'a>,
+
     /// The dom containing all of the instances that we're serializing.
     dom: &'dom WeakDom,
 
@@ -53,7 +56,7 @@ pub(super) struct SerializerState<'dom, W> {
 
     /// All of the types of instance discovered by our serializer that we'll be
     /// writing into the output.
-    type_infos: TypeInfos<'dom>,
+    type_infos: TypeInfos<'dom, 'a>,
 
     /// All of the SharedStrings in the DOM, in the order they'll be written
     // in.
@@ -67,7 +70,7 @@ pub(super) struct SerializerState<'dom, W> {
 /// An instance class that our serializer knows about. We should have one struct
 /// per unique ClassName.
 #[derive(Debug)]
-struct TypeInfo<'dom> {
+struct TypeInfo<'dom, 'a> {
     /// The ID that this serializer will use to refer to this type of instance.
     type_id: u32,
 
@@ -85,16 +88,16 @@ struct TypeInfo<'dom> {
     ///
     /// Stored in a sorted map to try to ensure that we write out properties in
     /// a deterministic order.
-    properties: BTreeMap<Cow<'static, str>, PropInfo>,
+    properties: BTreeMap<Cow<'a, str>, PropInfo<'a>>,
 
     /// A reference to the type's class descriptor from rbx_reflection, if this
     /// is a known class.
-    class_descriptor: Option<&'static ClassDescriptor<'static>>,
+    class_descriptor: Option<&'a ClassDescriptor<'a>>,
 
     /// A set containing the properties that we have seen so far in the file and
     /// processed. This helps us avoid traversing the reflection database
     /// multiple times if there are many copies of the same kind of instance.
-    properties_visited: HashSet<(Cow<'static, str>, VariantType)>,
+    properties_visited: HashSet<(Cow<'a, str>, VariantType)>,
 }
 
 /// A property on a specific class that our serializer knows about.
@@ -104,7 +107,7 @@ struct TypeInfo<'dom> {
 /// `BasePart.size` are present in the same document, they should share a
 /// `PropInfo` as they are the same logical property.
 #[derive(Debug)]
-struct PropInfo {
+struct PropInfo<'a> {
     /// The binary format type ID that will be use to serialize this property.
     /// This type is related to the type of the serialized form of the logical
     /// property, but is not 1:1.
@@ -117,7 +120,7 @@ struct PropInfo {
     /// The serialized name for this property. This is the name that is actually
     /// written as part of the PROP chunk and may not line up with the canonical
     /// name for the property.
-    serialized_name: Cow<'static, str>,
+    serialized_name: Cow<'a, str>,
 
     /// A set containing the names of all aliases discovered while preparing to
     /// serialize this property. Ideally, this set will remain empty (and not
@@ -136,32 +139,32 @@ struct PropInfo {
     ///
     /// Default values are first populated from the reflection database, if
     /// present, followed by an educated guess based on the type of the value.
-    default_value: Cow<'static, Variant>,
+    default_value: Cow<'a, Variant>,
 
     /// If a logical property has a migration associated with it (i.e. BrickColor ->
     /// Color, Font -> FontFace), this field contains Some(PropertyMigration). Otherwise,
     /// it is None.
-    migration: Option<&'static PropertyMigration>,
+    migration: Option<&'a PropertyMigration>,
 }
 
 /// Contains all of the `TypeInfo` objects known to the serializer so far. This
 /// struct was broken out to help encapsulate the behavior here and to ease
 /// self-borrowing issues from BinarySerializer getting too large.
 #[derive(Debug)]
-struct TypeInfos<'dom> {
+struct TypeInfos<'dom, 'a> {
     /// A map containing one entry for each unique ClassName discovered in the
     /// DOM.
     ///
     /// These are stored sorted so that we naturally iterate over them in order
     /// and improve our chances of being deterministic.
-    values: BTreeMap<String, TypeInfo<'dom>>,
+    values: BTreeMap<String, TypeInfo<'dom, 'a>>,
 
     /// The next type ID that should be assigned if a type is discovered and
     /// added to the serializer.
     next_type_id: u32,
 }
 
-impl<'dom> TypeInfos<'dom> {
+impl<'dom, 'a> TypeInfos<'dom, 'a> {
     fn new() -> Self {
         Self {
             values: BTreeMap::new(),
@@ -171,7 +174,7 @@ impl<'dom> TypeInfos<'dom> {
 
     /// Finds the type info from the given ClassName if it exists, or creates
     /// one and returns a reference to it if not.
-    fn get_or_create(&mut self, class: &str) -> &mut TypeInfo<'dom> {
+    fn get_or_create(&mut self, class: &str) -> &mut TypeInfo<'dom, 'a> {
         if !self.values.contains_key(class) {
             let type_id = self.next_type_id;
             self.next_type_id += 1;
@@ -224,9 +227,10 @@ impl<'dom> TypeInfos<'dom> {
     }
 }
 
-impl<'dom, W: Write> SerializerState<'dom, W> {
-    pub fn new(dom: &'dom WeakDom, output: W) -> Self {
+impl<'dom, 'a, W: Write> SerializerState<'dom, 'a, W> {
+    pub fn new(serializer: &'a Serializer<'a>, dom: &'dom WeakDom, output: W) -> Self {
         SerializerState {
+            serializer,
             dom,
             output,
             relevant_instances: Vec::new(),
@@ -311,7 +315,7 @@ impl<'dom, W: Write> SerializerState<'dom, W> {
             let serialized_ty;
             let mut migration = None;
 
-            let database = rbx_reflection_database::get();
+            let database = self.serializer.database.unwrap();
             match find_property_descriptors(database, &instance.class, prop_name) {
                 Some(descriptors) => {
                     // For any properties that do not serialize, we can skip

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,7 +1,9 @@
 # rbx_xml Changelog
 
 ## Unreleased
-* Add the ability to specify a `ReflectionDatabase` to use for serializing and deserializing. This takes the form of `DecodeOptions::reflection_database` and `EncodeOptions::reflection_database`.
+* Add the ability to specify a `ReflectionDatabase` to use for serializing and deserializing. This takes the form of `DecodeOptions::reflection_database` and `EncodeOptions::reflection_database`. ([#375])
+
+[#375]: https://github.com/rojo-rbx/rbx-dom/pull/375
 
 ## 0.13.2 (2023-10-03)
 * Added support for `SecurityCapabilities` values. ([#359])

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* Add the ability to specify a `ReflectionDatabase` to use for serializing and deserializing. This takes the form of `DecodeOptions::reflection_database` and `EncodeOptions::reflection_database`.
 
 ## 0.13.2 (2023-10-03)
 * Added support for `SecurityCapabilities` values. ([#359])

--- a/rbx_xml/src/core.rs
+++ b/rbx_xml/src/core.rs
@@ -39,31 +39,31 @@ pub trait XmlType: Sized {
     }
 }
 
-pub fn find_canonical_property_descriptor<'a>(
+pub fn find_canonical_property_descriptor<'db>(
     class_name: &str,
     property_name: &str,
-    database: &'a ReflectionDatabase<'a>,
-) -> Option<&'a PropertyDescriptor<'a>> {
+    database: &'db ReflectionDatabase<'db>,
+) -> Option<&'db PropertyDescriptor<'db>> {
     find_property_descriptors(class_name, property_name, database)
         .map(|(canonical, _serialized)| canonical)
 }
 
-pub fn find_serialized_property_descriptor<'a>(
+pub fn find_serialized_property_descriptor<'db>(
     class_name: &str,
     property_name: &str,
-    database: &'a ReflectionDatabase<'a>,
-) -> Option<&'a PropertyDescriptor<'a>> {
+    database: &'db ReflectionDatabase<'db>,
+) -> Option<&'db PropertyDescriptor<'db>> {
     find_property_descriptors(class_name, property_name, database)
         .map(|(_canonical, serialized)| serialized)
 }
 
 /// Find both the canonical and serialized property descriptors for a given
 /// class and property name pair. These might be the same descriptor!
-fn find_property_descriptors<'a>(
+fn find_property_descriptors<'db>(
     class_name: &str,
     property_name: &str,
-    database: &'a ReflectionDatabase<'a>,
-) -> Option<(&'a PropertyDescriptor<'a>, &'a PropertyDescriptor<'a>)> {
+    database: &'db ReflectionDatabase<'db>,
+) -> Option<(&'db PropertyDescriptor<'db>, &'db PropertyDescriptor<'db>)> {
     let class_descriptor = database.classes.get(class_name)?;
 
     let mut current_class_descriptor = class_descriptor;

--- a/rbx_xml/src/core.rs
+++ b/rbx_xml/src/core.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use rbx_reflection::{PropertyDescriptor, PropertyKind, PropertySerialization};
+use rbx_reflection::{PropertyDescriptor, PropertyKind, PropertySerialization, ReflectionDatabase};
 
 use crate::{
     deserializer_core::XmlEventReader,
@@ -39,30 +39,32 @@ pub trait XmlType: Sized {
     }
 }
 
-pub fn find_canonical_property_descriptor(
+pub fn find_canonical_property_descriptor<'a>(
     class_name: &str,
     property_name: &str,
-) -> Option<&'static PropertyDescriptor<'static>> {
-    find_property_descriptors(class_name, property_name).map(|(canonical, _serialized)| canonical)
+    database: &'a ReflectionDatabase<'a>,
+) -> Option<&'a PropertyDescriptor<'a>> {
+    find_property_descriptors(class_name, property_name, database)
+        .map(|(canonical, _serialized)| canonical)
 }
 
-pub fn find_serialized_property_descriptor(
+pub fn find_serialized_property_descriptor<'a>(
     class_name: &str,
     property_name: &str,
-) -> Option<&'static PropertyDescriptor<'static>> {
-    find_property_descriptors(class_name, property_name).map(|(_canonical, serialized)| serialized)
+    database: &'a ReflectionDatabase<'a>,
+) -> Option<&'a PropertyDescriptor<'a>> {
+    find_property_descriptors(class_name, property_name, database)
+        .map(|(_canonical, serialized)| serialized)
 }
 
 /// Find both the canonical and serialized property descriptors for a given
 /// class and property name pair. These might be the same descriptor!
-fn find_property_descriptors(
+fn find_property_descriptors<'a>(
     class_name: &str,
     property_name: &str,
-) -> Option<(
-    &'static PropertyDescriptor<'static>,
-    &'static PropertyDescriptor<'static>,
-)> {
-    let class_descriptor = rbx_reflection_database::get().classes.get(class_name)?;
+    database: &'a ReflectionDatabase<'a>,
+) -> Option<(&'a PropertyDescriptor<'a>, &'a PropertyDescriptor<'a>)> {
+    let class_descriptor = database.classes.get(class_name)?;
 
     let mut current_class_descriptor = class_descriptor;
 
@@ -133,7 +135,7 @@ fn find_property_descriptors(
             // If a property descriptor isn't found in our class, check
             // our superclass.
 
-            current_class_descriptor = rbx_reflection_database::get()
+            current_class_descriptor = database
                 .classes
                 .get(superclass_name)
                 .expect("Superclass in reflection database didn't exist");

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -69,12 +69,12 @@ pub enum DecodePropertyBehavior {
 
 /// Options available for deserializing an XML-format model or place.
 #[derive(Debug, Clone)]
-pub struct DecodeOptions<'a> {
+pub struct DecodeOptions<'db> {
     property_behavior: DecodePropertyBehavior,
-    database: &'a ReflectionDatabase<'a>,
+    database: &'db ReflectionDatabase<'db>,
 }
 
-impl<'a> DecodeOptions<'a> {
+impl<'db> DecodeOptions<'db> {
     /// Constructs a `DecodeOptions` with all values set to their defaults.
     #[inline]
     pub fn new() -> Self {
@@ -97,7 +97,7 @@ impl<'a> DecodeOptions<'a> {
     /// Determines what reflection database rbx_xml will use to deserialize
     /// properties.
     #[inline]
-    pub fn reflection_database(self, database: &'a ReflectionDatabase<'a>) -> Self {
+    pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
         DecodeOptions { database, ..self }
     }
 
@@ -108,17 +108,17 @@ impl<'a> DecodeOptions<'a> {
     }
 }
 
-impl<'a> Default for DecodeOptions<'a> {
-    fn default() -> DecodeOptions<'a> {
+impl<'db> Default for DecodeOptions<'db> {
+    fn default() -> DecodeOptions<'db> {
         DecodeOptions::new()
     }
 }
 
 /// The state needed to deserialize an XML model into an `WeakDom`.
-pub struct ParseState<'dom, 'a> {
+pub struct ParseState<'dom, 'db> {
     tree: &'dom mut WeakDom,
 
-    options: DecodeOptions<'a>,
+    options: DecodeOptions<'db>,
 
     /// Metadata deserialized from 'Meta' fields in the file.
     /// Known fields are:
@@ -163,8 +163,8 @@ struct SharedStringRewrite {
     shared_string_hash: String,
 }
 
-impl<'dom, 'a> ParseState<'dom, 'a> {
-    fn new(tree: &'dom mut WeakDom, options: DecodeOptions<'a>) -> ParseState<'dom, 'a> {
+impl<'dom, 'db> ParseState<'dom, 'db> {
+    fn new(tree: &'dom mut WeakDom, options: DecodeOptions<'db>) -> ParseState<'dom, 'db> {
         ParseState {
             tree,
             options,

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -97,10 +97,6 @@
 //! The non-default reader and writer functions accept these as their `options`
 //! argument.
 //!
-//! rbx_xml exposes no useful configuration yet, but there are methods that
-//! accept [`DecodeOptions`][DecodeOptions] and
-//! [`EncodeOptions`][EncodeOptions] that will be useful when it does.
-//!
 //! [DecodeOptions]: struct.DecodeOptions.html
 //! [EncodeOptions]: struct.EncodeOptions.html
 //! [from_str]: fn.from_str.html

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -89,6 +89,14 @@
 //! ```
 //!
 //! ## Configuration
+//! rbx_xml exposes a few configuration options at the moment in the form of
+//! [`DecodeOptions`][DecodeOptions] and [`EncodeOptions`][EncodeOptions].
+//! For information on the configuration, see the documentation for those
+//! structs.
+//!
+//! The non-default reader and writer functions accept these as their `options`
+//! argument.
+//!
 //! rbx_xml exposes no useful configuration yet, but there are methods that
 //! accept [`DecodeOptions`][DecodeOptions] and
 //! [`EncodeOptions`][EncodeOptions] that will be useful when it does.

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -8,7 +8,7 @@ use rbx_dom_weak::{
     types::{Ref, SharedString, SharedStringHash, Variant, VariantType},
     WeakDom,
 };
-use rbx_reflection::{DataType, PropertyKind, PropertySerialization};
+use rbx_reflection::{DataType, PropertyKind, PropertySerialization, ReflectionDatabase};
 
 use crate::{
     conversion::ConvertVariant,
@@ -74,16 +74,18 @@ pub enum EncodePropertyBehavior {
 
 /// Options available for serializing an XML-format model or place.
 #[derive(Debug, Clone)]
-pub struct EncodeOptions {
+pub struct EncodeOptions<'a> {
     property_behavior: EncodePropertyBehavior,
+    database: &'a ReflectionDatabase<'a>,
 }
 
-impl EncodeOptions {
+impl<'a> EncodeOptions<'a> {
     /// Constructs a `EncodeOptions` with all values set to their defaults.
     #[inline]
     pub fn new() -> Self {
         EncodeOptions {
             property_behavior: EncodePropertyBehavior::IgnoreUnknown,
+            database: rbx_reflection_database::get(),
         }
     }
 
@@ -91,7 +93,17 @@ impl EncodeOptions {
     /// ones.
     #[inline]
     pub fn property_behavior(self, property_behavior: EncodePropertyBehavior) -> Self {
-        EncodeOptions { property_behavior }
+        EncodeOptions {
+            property_behavior,
+            ..self
+        }
+    }
+
+    /// Determines what reflection database rbx_xml will use to serialize
+    /// properties.
+    #[inline]
+    pub fn reflection_database(self, database: &'a ReflectionDatabase<'a>) -> Self {
+        EncodeOptions { database, ..self }
     }
 
     pub(crate) fn use_reflection(&self) -> bool {
@@ -99,14 +111,14 @@ impl EncodeOptions {
     }
 }
 
-impl Default for EncodeOptions {
-    fn default() -> EncodeOptions {
+impl<'a> Default for EncodeOptions<'a> {
+    fn default() -> EncodeOptions<'a> {
         EncodeOptions::new()
     }
 }
 
-pub struct EmitState {
-    options: EncodeOptions,
+pub struct EmitState<'a> {
+    options: EncodeOptions<'a>,
 
     /// A map of IDs written so far to the generated referent that they use.
     /// This map is used to correctly emit Ref properties.
@@ -120,8 +132,8 @@ pub struct EmitState {
     shared_strings_to_emit: BTreeMap<SharedStringHash, SharedString>,
 }
 
-impl EmitState {
-    pub fn new(options: EncodeOptions) -> EmitState {
+impl<'a> EmitState<'a> {
+    pub fn new(options: EncodeOptions<'a>) -> EmitState<'a> {
         EmitState {
             options,
             referent_map: HashMap::new(),
@@ -183,7 +195,11 @@ fn serialize_instance<'a, W: Write>(
 
     for (property_name, value) in property_buffer.drain(..) {
         let maybe_serialized_descriptor = if state.options.use_reflection() {
-            find_serialized_property_descriptor(&instance.class, property_name)
+            find_serialized_property_descriptor(
+                &instance.class,
+                property_name,
+                state.options.database,
+            )
         } else {
             None
         };

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -74,12 +74,12 @@ pub enum EncodePropertyBehavior {
 
 /// Options available for serializing an XML-format model or place.
 #[derive(Debug, Clone)]
-pub struct EncodeOptions<'a> {
+pub struct EncodeOptions<'db> {
     property_behavior: EncodePropertyBehavior,
-    database: &'a ReflectionDatabase<'a>,
+    database: &'db ReflectionDatabase<'db>,
 }
 
-impl<'a> EncodeOptions<'a> {
+impl<'db> EncodeOptions<'db> {
     /// Constructs a `EncodeOptions` with all values set to their defaults.
     #[inline]
     pub fn new() -> Self {
@@ -102,7 +102,7 @@ impl<'a> EncodeOptions<'a> {
     /// Determines what reflection database rbx_xml will use to serialize
     /// properties.
     #[inline]
-    pub fn reflection_database(self, database: &'a ReflectionDatabase<'a>) -> Self {
+    pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
         EncodeOptions { database, ..self }
     }
 
@@ -111,14 +111,14 @@ impl<'a> EncodeOptions<'a> {
     }
 }
 
-impl<'a> Default for EncodeOptions<'a> {
-    fn default() -> EncodeOptions<'a> {
+impl<'db> Default for EncodeOptions<'db> {
+    fn default() -> EncodeOptions<'db> {
         EncodeOptions::new()
     }
 }
 
-pub struct EmitState<'a> {
-    options: EncodeOptions<'a>,
+pub struct EmitState<'db> {
+    options: EncodeOptions<'db>,
 
     /// A map of IDs written so far to the generated referent that they use.
     /// This map is used to correctly emit Ref properties.
@@ -132,8 +132,8 @@ pub struct EmitState<'a> {
     shared_strings_to_emit: BTreeMap<SharedStringHash, SharedString>,
 }
 
-impl<'a> EmitState<'a> {
-    pub fn new(options: EncodeOptions<'a>) -> EmitState<'a> {
+impl<'db> EmitState<'db> {
+    pub fn new(options: EncodeOptions<'db>) -> EmitState<'db> {
         EmitState {
             options,
             referent_map: HashMap::new(),
@@ -163,12 +163,12 @@ impl<'a> EmitState<'a> {
 ///
 /// `property_buffer` is a Vec that can be reused between calls to
 /// serialize_instance to make sorting properties more efficient.
-fn serialize_instance<'a, W: Write>(
+fn serialize_instance<'dom, W: Write>(
     writer: &mut XmlEventWriter<W>,
     state: &mut EmitState,
-    tree: &'a WeakDom,
+    tree: &'dom WeakDom,
     id: Ref,
-    property_buffer: &mut Vec<(&'a String, &'a Variant)>,
+    property_buffer: &mut Vec<(&'dom String, &'dom Variant)>,
 ) -> Result<(), NewEncodeError> {
     let instance = tree.get_by_ref(id).unwrap();
     let mapped_id = state.map_id(id);


### PR DESCRIPTION
This allows the reflection database to be specified for serializing/deserializing in `rbx_binary` and `rbx_xml`. It does this by having the structs for these crates store a reflection database rather than using `rbx_reflection_database` inline. This doesn't change how the crates are used normally since they use the bundled database by default, but it provides the opportunity for tools like Rojo to specify their own database.

I took some liberties here also, and cleaned up the name of lifetimes a bit. Specifically, I've changed it so that all lifetimes that refer to a reflection database use a `'db` lifetime and all lifetimes that refer to a `WeakDom` use a `'dom` lifetime. This is to avoid confusion because `'a` is not specific or helpful.