### PR TITLE
Use in-progress db for rbx_reflector default place decode

### DIFF
--- a/rbx_reflector/src/defaults.rs
+++ b/rbx_reflector/src/defaults.rs
@@ -18,7 +18,8 @@ pub fn apply_defaults(
     let file = BufReader::new(File::open(defaults_place).context("Could not find defaults place")?);
 
     let decode_options = rbx_xml::DecodeOptions::new()
-        .property_behavior(rbx_xml::DecodePropertyBehavior::IgnoreUnknown);
+        .property_behavior(rbx_xml::DecodePropertyBehavior::IgnoreUnknown)
+        .reflection_database(database);
 
     let tree =
         rbx_xml::from_reader(file, decode_options).context("Could not decode defaults place")?;


### PR DESCRIPTION
Closes #345

Because of #375, it's possible to continue using `DecodePropertyBehavior::IgnoreUnknown` and simply swap to the in-progress database via `DecodeOptions::reflection_database`