### PR TITLE
Add `Default` implementation for `WeakDom`

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_dom_weak Changelog
 
 ## Unreleased Changes
+* Implemented `Default` for `WeakDom`, useful when using Serde or creating an empty `WeakDom`
 
 ## 2.6.0 (2023-10-03)
 * Added `WeakDom::clone_multiple_into_external` that allows cloning multiple subtrees all at once into a given `WeakDom`, useful for preserving `Ref` properties that point across cloned subtrees ([#364])

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -346,6 +346,16 @@ impl WeakDom {
     }
 }
 
+impl Default for WeakDom {
+    fn default() -> WeakDom {
+        WeakDom {
+            instances: HashMap::new(),
+            root_ref: Ref::none(),
+            unique_ids: HashSet::new(),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct CloneContext {
     queue: VecDeque<(Ref, Ref)>,


### PR DESCRIPTION
Title basically explains everything. Aside from the fact that it is good practise, `Default` is required e.g. when using `#[serde(skip)]` attribute.