### PR TITLE
Break rbx_reflector file watcher receive loop after modify events

### DIFF
--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -89,7 +89,8 @@ fn save_place_in_studio(path: &PathBuf) -> anyhow::Result<StudioInfo> {
     println!("Please save the opened place in Roblox Studio (ctrl+s).");
 
     loop {
-        if rx.recv()??.kind.is_create() {
+        let event = rx.recv()??;
+        if event.kind.is_create() || event.kind.is_modify() {
             break;
         }
     }


### PR DESCRIPTION
On macOS, the file watcher emits a modify event after saving the defaults place in Roblox Studio, making it impossible to successfully use rbx_reflector. This PR fixes this by changing the event receive loop in rbx_reflector's defaults place command so that it also checks for modify events. 