### PR TITLE
Implement IntoIterator for &Attributes and Extend for Attributes

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -1,9 +1,15 @@
 # rbx_types Changelog
 
 ## Unreleased Changes
+* Implement `IntoIterator` for `&Attributes`. ([#386])
+* Implement `Extend<(String, Variant)>` for `Attributes`. ([#386])
+
+[#386]: https://github.com/rojo-rbx/rbx-dom/pull/386
 
 ## 1.8.0 (2024-01-16)
 * Add `len` and `is_empty` methods to `Attributes` struct. ([#377])
+
+[#377]: https://github.com/rojo-rbx/rbx-dom/pull/377
 
 ## 1.7.0 (2023-10-03)
 * Implemented `FromStr` for `TerrainMaterials`. ([#354])
@@ -15,7 +21,6 @@
 [#355]: https://github.com/rojo-rbx/rbx-dom/pull/355
 [#358]: https://github.com/rojo-rbx/rbx-dom/pull/358
 [#363]: https://github.com/rojo-rbx/rbx-dom/pull/363
-[#377]: https://github.com/rojo-rbx/rbx-dom/pull/377
 
 ## 1.6.0 (2023-08-09)
 * Added support for `UniqueId` values. ([#271])

--- a/rbx_types/src/attributes/mod.rs
+++ b/rbx_types/src/attributes/mod.rs
@@ -145,7 +145,7 @@ impl Iterator for AttributesIntoIter {
     }
 }
 
-/// A borrowed iterator over the entires of an `Attributes`.
+/// A borrowed iterator over the entries of an `Attributes`.
 /// This is created by [`Attributes::iter`].
 pub struct AttributesIter<'a> {
     iter: btree_map::Iter<'a, String, Variant>,

--- a/rbx_types/src/attributes/mod.rs
+++ b/rbx_types/src/attributes/mod.rs
@@ -75,8 +75,11 @@ impl Attributes {
     }
 
     /// Returns an iterator of borrowed attributes.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Variant)> {
-        self.data.iter()
+    #[inline]
+    pub fn iter(&self) -> AttributesIter<'_> {
+        AttributesIter {
+            iter: self.data.iter(),
+        }
     }
 
     /// Returns the number of attributes.
@@ -92,6 +95,12 @@ impl Attributes {
     }
 }
 
+impl Extend<(String, Variant)> for Attributes {
+    fn extend<T: IntoIterator<Item = (String, Variant)>>(&mut self, iter: T) {
+        self.data.extend(iter)
+    }
+}
+
 impl IntoIterator for Attributes {
     type IntoIter = AttributesIntoIter;
     type Item = (String, Variant);
@@ -99,6 +108,17 @@ impl IntoIterator for Attributes {
     fn into_iter(self) -> Self::IntoIter {
         AttributesIntoIter {
             iter: self.data.into_iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Attributes {
+    type IntoIter = AttributesIter<'a>;
+    type Item = (&'a String, &'a Variant);
+
+    fn into_iter(self) -> Self::IntoIter {
+        AttributesIter {
+            iter: self.data.iter(),
         }
     }
 }
@@ -119,6 +139,20 @@ pub struct AttributesIntoIter {
 
 impl Iterator for AttributesIntoIter {
     type Item = (String, Variant);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+/// A borrowed iterator over the entires of an `Attributes`.
+/// This is created by [`Attributes::iter`].
+pub struct AttributesIter<'a> {
+    iter: btree_map::Iter<'a, String, Variant>,
+}
+
+impl<'a> Iterator for AttributesIter<'a> {
+    type Item = (&'a String, &'a Variant);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()


### PR DESCRIPTION
The original implementation of Attributes had an `iter` method but it did not implement `FromIterator` for `&Attributes`, making it so you couldn't use `for (key, value) in &attributes` and had to use `for (key, value) in attributes.iter()`. This changes that.

Additionally, `Extend` is a nice quality of life trait for containers so it's implemented here.