### PR TITLE
Document Enum attributes in spec document

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -17,6 +17,7 @@ This document describes the Attribute binary format. In this format there is no 
     - [Vector2](#vector2)
     - [Vector3](#vector3)
     - [CFrame](#cframe)
+	- [EnumItem](#EnumItem)
     - [NumberSequence](#numbersequence)
     - [ColorSequence](#colorsequence)
     - [NumberRange](#numberrange)
@@ -179,6 +180,18 @@ A rotation is considered "axis-aligned" if it's in increments of 90 degrees arou
 A `CFrame` with the value `CFrame.new(1, 2, 3) * CFrame.Angles(0, 45, 0)` looks like this when serialized: `00 00 80 3f 00 00 00 40 00 00 40 40 00 f3 04 35 3f 00 00 00 00 f3 04 35 3f 00 00 00 00 00 00 80 3f 00 00 00 00 f3 04 35 bf 00 00 00 00 f3 04 35 3f`.
 
 Demonstrating the axis-aligned rotation matrix case, a `CFrame` with the value `CFrame.new(1, 2, 3)` looks like this: `00 00 80 3f 00 00 00 40 00 00 40 40 02`.
+
+### EnumItem
+**Type ID `0x15`**
+
+The `EnumItem` type is composed of two parts: 
+
+| Field Name | Format              | Value                                                  |
+|:-----------|:--------------------|:-------------------------------------------------------|
+| Enum Name  | [`String`](#string) | The name of the [`Enum`][Enum_Type] of this `EnumItem` |
+| Value      | `u32`               | The `Value` field of the `EnumItem`                    |
+
+[Enum_Type]: https://create.roblox.com/docs/reference/engine/datatypes/Enum
 
 ### NumberSequence
 **Type ID `0x17`**

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -263,12 +263,12 @@ A Rect with the value `10, 20, 30, 40` would look like this: `00 00 20 41 00 00 
 
 The `Font` type is a struct composed of a `u16`, `u8` and two `String`s
 
-| Field Name   | Format                | Value                                  |
-|:-------------|:----------------------|:---------------------------------------|
-| Weight       | `u16`                 | The weight of the font                 |
-| Style        | `u8`                  | The style of the font                  |
-| Family       | [String](#string)     | The font family content URI            |
-| CachedFaceId | [String](#string)     | The cached content URI of the TTF file |
+| Field Name   | Format                  | Value                                  |
+|:-------------|:------------------------|:---------------------------------------|
+| Weight       | `u16`                   | The weight of the font                 |
+| Style        | `u8`                    | The style of the font                  |
+| Family       | [`String`](#string)     | The font family content URI            |
+| CachedFaceId | [`String`](#string)     | The cached content URI of the TTF file |
 
 The `Weight` and `Style` values refer to the `FontWeight` and `FontStyle` enums respectively. They are stored as unsigned little-endian
 


### PR DESCRIPTION
In pursuit of #383, this adds documentation of Enum-type attributes to the attribute spec document.

In the spec, I used `EnumItem` to be distinct from `Enum`, since both are important here. I don't think we should do it in the other documentation but I'm open to opinions.

Also, there were some backticks missing from the Font attribute documentation so I added them to make things consistent with the other entries.