### PR TITLE
Temporary workaround for MeshPart.MeshId writes

### DIFF
--- a/patches/parts.yml
+++ b/patches/parts.yml
@@ -36,6 +36,11 @@ Change:
     formFactorRaw:
       AliasFor: FormFactor
 
+  MeshPart:
+    # MeshPart.MeshId writes have to be deferred through InsertService:CreateMeshPartAsync
+    MeshId:
+      Scriptability: Custom
+
   Part:
     Shape:
       Serialization:

--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -119,7 +119,7 @@ return {
 				return true, instance.MeshId
 			end,
 			write = function(instance, _, value)
-				task.spawn(function ()
+				task.spawn(function()
 					local mesh = InsertService:CreateMeshPartAsync(value, instance.CollisionFidelity, instance.RenderFidelity)
 					instance:ApplyMesh(mesh)
 				end)

--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -1,3 +1,4 @@
+local InsertService = game:GetService("InsertService")
 local CollectionService = game:GetService("CollectionService")
 local ScriptEditorService = game:GetService("ScriptEditorService")
 
@@ -109,6 +110,21 @@ return {
 			end,
 			write = function(instance, _, value)
 				return true, instance:ScaleTo(value)
+			end,
+		},
+	},
+	MeshPart = {
+		MeshId = {
+			read = function(instance, _, _)
+				return true, instance.MeshId
+			end,
+			write = function(instance, _, value)
+				task.spawn(function ()
+					local mesh = InsertService:CreateMeshPartAsync(value, instance.CollisionFidelity, instance.RenderFidelity)
+					instance:ApplyMesh(mesh)
+				end)
+				
+				return true
 			end,
 		},
 	},


### PR DESCRIPTION
Not an ideal solution, but it works and takes a similar hacky measure to patching the `Source` of a `Script` via the `ScriptEditorService`. This can be killed off from rojo once the `game:GetObjects` hack is implemented.