### PR TITLE
Add rbx_dom_lua OptionalCFrame codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | Int64                   | `Player.UserId`                 | ✔ | ✔ | ✔ | ✔ |
 | NumberRange             | `ParticleEmitter.Lifetime`      | ✔ | ✔ | ✔ | ✔ |
 | NumberSequence          | `Beam.Transparency`             | ✔ | ✔ | ✔ | ✔ |
-| OptionalCoordinateFrame | `Model.WorldPivotData`          | ✔ | ❌ | ✔ | ✔ |
+| OptionalCFrame          | `Model.WorldPivotData`          | ✔ | ✔ | ✔ | ✔ |
 | PhysicalProperties      | `Part.CustomPhysicalProperties` | ✔ | ✔ | ✔ | ✔ |
 | ProtectedString         | `ModuleScript.Source`           | ✔ | ✔ | ✔ | ✔ |
 | Ray                     | `RayValue.Value`                | ✔ | ✔ | ✔ | ✔ |

--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -493,6 +493,24 @@ types = {
 	},
 }
 
+types.OptionalCFrame = {
+	fromPod = function(pod)
+		if pod == nil then
+			return nil
+		else
+			return types.CFrame.fromPod(pod)
+		end
+	end,
+
+	toPod = function(roblox)
+		if roblox == nil then
+			return nil
+		else
+			return types.CFrame.toPod(roblox)
+		end
+	end,
+}
+
 function EncodedValue.decode(encodedValue)
 	local ty, value = next(encodedValue)
 

--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -514,6 +514,11 @@ types.OptionalCFrame = {
 function EncodedValue.decode(encodedValue)
 	local ty, value = next(encodedValue)
 
+	if ty == nil then
+		-- If the encoded pair is empty, assume it is an unoccupied optional value
+		return true, nil
+	end
+
 	local typeImpl = types[ty]
 	if typeImpl == nil then
 		return false, "Couldn't decode value " .. tostring(ty)

--- a/rbx_dom_lua/src/allValues.json
+++ b/rbx_dom_lua/src/allValues.json
@@ -370,6 +370,41 @@
     },
     "ty": "NumberSequence"
   },
+  "OptionalCFrame-None": {
+    "value": {
+      "OptionalCFrame": null
+    },
+    "ty": "OptionalCFrame"
+  },
+  "OptionalCFrame-Some": {
+    "value": {
+      "OptionalCFrame": {
+        "position": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "orientation": [
+          [
+            1.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            1.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            1.0
+          ]
+        ]
+      }
+    },
+    "ty": "OptionalCFrame"
+  },
   "PhysicalProperties-Custom": {
     "value": {
       "PhysicalProperties": {

--- a/rbx_reflector/src/cli/values.rs
+++ b/rbx_reflector/src/cli/values.rs
@@ -139,6 +139,14 @@ impl ValuesSubcommand {
             ])
             .into(),
         );
+        values.insert("OptionalCFrame-None", Variant::OptionalCFrame(None));
+        values.insert(
+            "OptionalCFrame-Some",
+            Variant::OptionalCFrame(Some(CFrame::new(
+                Vector3::new(0.0, 0.0, 0.0),
+                Matrix3::identity(),
+            ))),
+        );
         values.insert(
             "PhysicalProperties-Custom",
             PhysicalProperties::Custom(CustomPhysicalProperties {


### PR DESCRIPTION
This PR closes #179 by adding an `OptionalCFrame` codec (and tests for it) to rbx_dom_lua.

As mentioned in #391, there was also a change needed to `EncodedValue.decode` so it doesn't error out when the encoded value pair is empty, which occurs when optional types (like `OptionalCFrame`) are unoccupied.