### PR TITLE
Remove PrimaryPart conditional in WorldPivotData custom setter

### DIFF
--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -113,13 +113,7 @@ return {
 		},
 		WorldPivotData = {
 			read = function(instance)
-				if instance.PrimaryPart == nil then
-					-- Model.WorldPivotData is unoccupied when the model does not have a
-					-- PrimaryPart
-					return true, nil
-				else
-					return true, instance:GetPivot()
-				end
+				return true, instance:GetPivot()
 			end,
 			write = function(instance, _, value)
 				if value == nil then


### PR DESCRIPTION
There was a mistake in #393 caused by some confusion around when `Model.WorldPivotData` is occupied and how it interacts `Model.PrimaryPart`. This PR removes a conditional that could cause incorrect behavior.