### PR TITLE
Fix tests by borrowing attributes value in roundtrip test

### DIFF
--- a/rbx_types/src/attributes/mod.rs
+++ b/rbx_types/src/attributes/mod.rs
@@ -186,7 +186,7 @@ mod tests {
         let attributes = Attributes::from_reader(&attributes_value[..])
             .expect("couldn't deserialize attributes");
 
-        insta::assert_yaml_snapshot!(attributes);
+        insta::assert_yaml_snapshot!(&attributes);
 
         let mut new_attribute_bytes = Vec::<u8>::new();
         attributes


### PR DESCRIPTION
After doing tests with a totally clean build (running `cargo clean` on the workspace, deleting `Cargo.lock`, then running `cargo test --all-features` on the workspace), I was able to trace the CI failure we noticed in #398 to an unintentionally breaking change that was shipped as part of a minor version bump to an external library: https://github.com/mitsuhiko/insta/pull/385. It looks like previous versions of the `_assert_serialized_snapshot` macro borrowed the value, while the new one takes ownership. It is probably better for us to explicitly borrow the value here, but I'll still let them know that this change was breaking