### PR TITLE
Add `InstanceBuilder::with_referent` constructing method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Cargo.lock
 # Editor-specific folders and files
 /.vscode
 sourcemap.json
+
+# macOS Finder files
+.DS_Store

--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_dom_weak Changelog
 
 ## Unreleased Changes
+* Added `InstanceBuilder::with_referent` that allows building instance with predefined `Ref`
 
 ## 2.7.0 (2024-01-16)
 * Implemented `Default` for `WeakDom`, useful when using Serde or creating an empty `WeakDom`

--- a/rbx_dom_weak/src/instance.rs
+++ b/rbx_dom_weak/src/instance.rs
@@ -72,6 +72,14 @@ impl InstanceBuilder {
         self.referent
     }
 
+    /// Change the referent of the `InstanceBuilder`.
+    pub fn with_referent<R: Into<Ref>>(self, referent: R) -> Self {
+        Self {
+            referent: referent.into(),
+            ..self
+        }
+    }
+
     /// Change the name of the `InstanceBuilder`.
     pub fn with_name<S: Into<String>>(self, name: S) -> Self {
         Self {


### PR DESCRIPTION
This PR adds `with_referent` method for `InstanceBuilder` that allows to specify instance `Ref` manually. I also updated `.gitignore` for macOS users.