### PR TITLE
Make pretty JSON optional for `generate` subcommand (`rbx_reflector`)

### DIFF
--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -25,7 +25,7 @@ static PLUGIN_SOURCE: &str = include_str!("../../plugin.lua");
 #[derive(Debug, Parser)]
 pub struct DefaultsPlaceSubcommand {
     /// The path of an API dump that came from the dump command.
-    #[clap(long = "api_dump")]
+    #[clap(long)]
     pub api_dump: PathBuf,
     /// Where to output the place. The extension must be .rbxlx
     pub output: PathBuf,

--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -34,7 +34,7 @@ pub struct GenerateSubcommand {
     pub output: Vec<PathBuf>,
     /// Whether to pretty-print the JSON output. This has no effect on MessagePack.
     #[clap(long)]
-    pub pretty: bool,
+    pub no_pretty: bool,
 }
 
 impl GenerateSubcommand {

--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -77,10 +77,10 @@ impl GenerateSubcommand {
 
             match extension {
                 Some("json") => {
-                    let result = if self.pretty {
-                        serde_json::to_writer_pretty(&mut file, &database)
-                    } else {
+                    let result = if self.no_pretty {
                         serde_json::to_writer(&mut file, &database)
+                    } else {
+                        serde_json::to_writer_pretty(&mut file, &database)
                     };
 
                     result.context("Could not serialize reflection database as JSON")?;

--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -27,11 +27,14 @@ use super::{defaults_place::DefaultsPlaceSubcommand, dump::DumpSubcommand};
 /// and write it to disk.
 #[derive(Debug, Parser)]
 pub struct GenerateSubcommand {
-    #[clap(long = "patches")]
+    #[clap(long)]
     pub patches: Option<PathBuf>,
     /// Where to output the reflection database. The output format is inferred
     /// from the file path and supports JSON (.json) and MessagePack (.msgpack).
     pub output: Vec<PathBuf>,
+    /// Whether to pretty-print the JSON output. This has no effect on MessagePack.
+    #[clap(long)]
+    pub pretty: bool,
 }
 
 impl GenerateSubcommand {
@@ -74,8 +77,13 @@ impl GenerateSubcommand {
 
             match extension {
                 Some("json") => {
-                    serde_json::to_writer_pretty(&mut file, &database)
-                        .context("Could not serialize reflection database as JSON")?;
+                    let result = if self.pretty {
+                        serde_json::to_writer_pretty(&mut file, &database)
+                    } else {
+                        serde_json::to_writer(&mut file, &database)
+                    };
+
+                    result.context("Could not serialize reflection database as JSON")?;
                 }
                 Some("msgpack") => {
                     let buf = rmp_serde::to_vec(&database)


### PR DESCRIPTION
This PR makes writing of database from `generate` subcommand in pretty-printed JSON optional by adding `--pretty` option. I think that it makes sense as these files are not intended to be read by humans and it reduces the file size from `1.6MB` to `796KB`.