### PR TITLE
Add method for getting the superclasses of an Instance to rbx_reflection

### DIFF
--- a/rbx_reflection/CHANGELOG.md
+++ b/rbx_reflection/CHANGELOG.md
@@ -1,6 +1,9 @@
 # rbx_reflection Changelog
 
 ## Unreleased Changes
+* Add `superclasses` method to `ReflectionDatabase` to get a set of superclasses for a given class. ([#402])
+
+[#402]: https://github.com/rojo-rbx/rbx-dom/pull/402
 
 ## 4.5.0 (2024-01-16)
 * Update to rbx_types 1.8.

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -43,17 +43,15 @@ impl<'a> ReflectionDatabase<'a> {
     /// Returns a list of superclasses for the provided class name. This list
     /// will start with the provided class and end with `Instance` if the class
     /// exists.
-    pub fn superclasses(&self, class_name: &str) -> Option<Vec<Cow<'a, str>>> {
-        // Parts have 4 superclasses, and they're generally what most models
-        // are composed of so we allocate enough for them.
-        // On average each class has 2.6 superclasses, so this benefits our
-        // theoretical 'average' case too.
+    pub fn superclasses(&self, class_name: &str) -> Option<Vec<&ClassDescriptor>> {
+        // As of the time of writing (14 March 2024), the class with the most
+        // superclasses has 6 of them.
         let mut list = Vec::with_capacity(6);
         let mut current_class = self.classes.get(class_name);
         current_class?;
 
         while let Some(class) = current_class {
-            list.push(class.name.clone());
+            list.push(class);
             current_class = class.superclass.as_ref().and_then(|s| self.classes.get(s));
         }
 

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -50,6 +50,7 @@ impl<'a> ReflectionDatabase<'a> {
         // theoretical 'average' case too.
         let mut list = HashSet::with_capacity(5);
         let mut current_class = self.classes.get(class_name);
+        current_class?;
 
         while let Some(class) = current_class {
             list.insert(class.name.as_ref());

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -39,6 +39,25 @@ impl<'a> ReflectionDatabase<'a> {
             enums: HashMap::new(),
         }
     }
+
+    /// Returns a list of superclasses for the provided class name. This list
+    /// will start with the provided class and end with `Instance` if the class
+    /// exists.
+    pub fn superclasses(&self, class_name: &str) -> Option<HashSet<&str>> {
+        // Parts have 4 superclasses, and they're generally what most models
+        // are composed of so we allocate enough for them.
+        // On average each class has 2.6 superclasses, so this benefits our
+        // theoretical 'average' case too.
+        let mut list = HashSet::with_capacity(5);
+        let mut current_class = self.classes.get(class_name);
+
+        while let Some(class) = current_class {
+            list.insert(class.name.as_ref());
+            current_class = class.superclass.as_ref().and_then(|s| self.classes.get(s));
+        }
+
+        Some(list)
+    }
 }
 
 /// Describes a class of Instance, its properties, and its relation to other

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -43,17 +43,17 @@ impl<'a> ReflectionDatabase<'a> {
     /// Returns a list of superclasses for the provided class name. This list
     /// will start with the provided class and end with `Instance` if the class
     /// exists.
-    pub fn superclasses(&self, class_name: &str) -> Option<HashSet<Cow<'a, str>>> {
+    pub fn superclasses(&self, class_name: &str) -> Option<Vec<Cow<'a, str>>> {
         // Parts have 4 superclasses, and they're generally what most models
         // are composed of so we allocate enough for them.
         // On average each class has 2.6 superclasses, so this benefits our
         // theoretical 'average' case too.
-        let mut list = HashSet::with_capacity(5);
+        let mut list = Vec::with_capacity(6);
         let mut current_class = self.classes.get(class_name);
         current_class?;
 
         while let Some(class) = current_class {
-            list.insert(class.name.clone());
+            list.push(class.name.clone());
             current_class = class.superclass.as_ref().and_then(|s| self.classes.get(s));
         }
 

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -43,7 +43,7 @@ impl<'a> ReflectionDatabase<'a> {
     /// Returns a list of superclasses for the provided class name. This list
     /// will start with the provided class and end with `Instance` if the class
     /// exists.
-    pub fn superclasses(&self, class_name: &str) -> Option<HashSet<&str>> {
+    pub fn superclasses(&self, class_name: &str) -> Option<HashSet<Cow<'a, str>>> {
         // Parts have 4 superclasses, and they're generally what most models
         // are composed of so we allocate enough for them.
         // On average each class has 2.6 superclasses, so this benefits our
@@ -53,7 +53,7 @@ impl<'a> ReflectionDatabase<'a> {
         current_class?;
 
         while let Some(class) = current_class {
-            list.insert(class.name.as_ref());
+            list.insert(class.name.clone());
             current_class = class.superclass.as_ref().and_then(|s| self.classes.get(s));
         }
 


### PR DESCRIPTION
It's fairly common to need a list of superclasses for a class, so we should provide a method for it. This is an implementation.

It uses a `HashSet` for convenience. It's slightly more expensive than a `Vec` but provides an easy mechanism for checking if a class is in the returned set, so it feels worth it.