### PR TITLE
Harden rbx_reflector against unknown data types

### DIFF
--- a/rbx_reflection/src/class_tag.rs
+++ b/rbx_reflection/src/class_tag.rs
@@ -18,6 +18,7 @@ pub enum ClassTag {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct ClassTagFromStrError(String);
 
 impl FromStr for ClassTag {

--- a/rbx_reflection/src/property_tag.rs
+++ b/rbx_reflection/src/property_tag.rs
@@ -17,6 +17,7 @@ pub enum PropertyTag {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct PropertyTagFromStrError(String);
 
 impl FromStr for PropertyTag {

--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -179,7 +179,7 @@ fn apply_dump(database: &mut ReflectionDatabase, dump: &Dump) -> anyhow::Result<
                         // VariantType. Exactly what we'd like to do about
                         // unimplemented data types like this depends on if the
                         // property serializes or not.
-                        match (variant_type_from_str(type_name)?, &kind) {
+                        match (variant_type_from_str(type_name), &kind) {
                             // The happy path: the data type has a corresponding
                             // VariantType. We don't need to care about whether
                             // the data type is ever serialized, because it
@@ -259,8 +259,8 @@ fn apply_dump(database: &mut ReflectionDatabase, dump: &Dump) -> anyhow::Result<
     Ok(())
 }
 
-fn variant_type_from_str(type_name: &str) -> anyhow::Result<Option<VariantType>> {
-    Ok(Some(match type_name {
+fn variant_type_from_str(type_name: &str) -> Option<VariantType> {
+    Some(match type_name {
         "Axes" => VariantType::Axes,
         "BinaryString" => VariantType::BinaryString,
         "BrickColor" => VariantType::BrickColor,
@@ -299,6 +299,6 @@ fn variant_type_from_str(type_name: &str) -> anyhow::Result<Option<VariantType>>
         // ProtectedString is handled as the same as string
         "ProtectedString" => VariantType::String,
 
-        _ => return Ok(None),
-    }))
+        _ => return None,
+    })
 }

--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -261,17 +261,6 @@ fn variant_type_from_str(type_name: &str) -> anyhow::Result<Option<VariantType>>
         // ProtectedString is handled as the same as string
         "ProtectedString" => VariantType::String,
 
-        // TweenInfo is not supported by rbx_types yet
-        "TweenInfo" => return Ok(None),
-
-        // While DateTime is possible to Serialize, the only use it has as a
-        // DataType is for the TextChatMessage class, which cannot be serialized
-        // (at least not saved to file as it is locked to nil parent)
-        "DateTime" => return Ok(None),
-
-        // These types are not generally implemented right now.
-        "QDir" | "QFont" | "SystemAddress" | "CSGPropertyData" => return Ok(None),
-
-        _ => bail!("unknown type {type_name}"),
+        _ => return Ok(None),
     }))
 }

--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -221,8 +221,8 @@ fn apply_dump(database: &mut ReflectionDatabase, dump: &Dump) -> anyhow::Result<
     Ok(())
 }
 
-fn variant_type_from_str(value: &str) -> anyhow::Result<Option<VariantType>> {
-    Ok(Some(match value {
+fn variant_type_from_str(type_name: &str) -> anyhow::Result<Option<VariantType>> {
+    Ok(Some(match type_name {
         "Axes" => VariantType::Axes,
         "BinaryString" => VariantType::BinaryString,
         "BrickColor" => VariantType::BrickColor,
@@ -272,6 +272,6 @@ fn variant_type_from_str(value: &str) -> anyhow::Result<Option<VariantType>> {
         // These types are not generally implemented right now.
         "QDir" | "QFont" | "SystemAddress" | "CSGPropertyData" => return Ok(None),
 
-        _ => bail!("Unknown type {}", value),
+        _ => bail!("unknown type {type_name}"),
     }))
 }


### PR DESCRIPTION
Today I noticed that `rbx_reflector generate` failed to output a database due to a new datatype: 
```
     Running `target/debug/rbx_reflector generate rbx_reflection_database/database.msgpack rbx_dom_lua/src/database.json --patches patches`
[INFO  rbx_reflector::cli::defaults_place] Installing Studio plugin
[INFO  rbx_reflector::cli::defaults_place] Starting Roblox Studio...
[INFO  rbx_reflector::cli::defaults_place] Waiting for Roblox Studio to re-save place...
[INFO  rbx_reflector::cli::defaults_place] Uninstalling Studio plugin
Please save the opened place in Roblox Studio (ctrl+s).
[INFO  rbx_reflector::cli::defaults_place] Place saved, killing Studio...
Error: Unknown type Path2DControlPoint
```

This got me thinking about how rbx_reflector can more gracefully deal with unknown data types. I intuit that we only need to care about unknown data types if they serialize. With this in mind, this PR makes `rbx_reflector generate` only bail on unknown serializable data types (with the exception of `QDir` and `QFont` - see comments).