### PR TITLE
Add method for getting UniqueId for referent

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,10 +1,16 @@
 # rbx_dom_weak Changelog
 
 ## Unreleased Changes
-* Added `InstanceBuilder::with_referent` that allows building instance with predefined `Ref`
+* Added `InstanceBuilder::with_referent` that allows building instance with predefined `Ref` ([#400])
+* Added `WeakDom::get_unique_id` to get the UniqueId for a provided referent. ([#405])
+
+[#400]: https://github.com/rojo-rbx/rbx-dom/pull/400
+[#405]: https://github.com/rojo-rbx/rbx-dom/pull/405
 
 ## 2.7.0 (2024-01-16)
-* Implemented `Default` for `WeakDom`, useful when using Serde or creating an empty `WeakDom`
+* Implemented `Default` for `WeakDom`, useful when using Serde or creating an empty `WeakDom` ([#379])
+
+[#379]: https://github.com/rojo-rbx/rbx-dom/pull/379
 
 ## 2.6.0 (2023-10-03)
 * Added `WeakDom::clone_multiple_into_external` that allows cloning multiple subtrees all at once into a given `WeakDom`, useful for preserving `Ref` properties that point across cloned subtrees ([#364])

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -65,6 +65,16 @@ impl WeakDom {
         self.instances.get_mut(&referent)
     }
 
+    /// Returns the [`UniqueId`] for the Instance with the provided referent, if it
+    /// exists.
+    pub fn get_unique_id(&self, referent: Ref) -> Option<UniqueId> {
+        let inst = self.instances.get(&referent)?;
+        match inst.properties.get("UniqueId") {
+            Some(Variant::UniqueId(id)) => Some(*id),
+            _ => None,
+        }
+    }
+
     /// Insert a new instance into the DOM with the given parent. The parent is allowed to
     /// be the none Ref.
     ///


### PR DESCRIPTION
Adds a method for getting the UniqueId for a given referent in a WeakDom.

Technically unnecessary but a convenience function is helpful and there's nothing stopping us from linking referents more directly to their UniqueId in the future, which this method would benefit from.