### PR TITLE
Improve `rbx_reflector` Roblox Studio automation and logging on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Cargo stuff
-target
+/target
 **/*.rs.bk
 Cargo.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Cargo stuff
-/target
+target
 **/*.rs.bk
 Cargo.lock
 

--- a/rbx_reflector/plugin.lua
+++ b/rbx_reflector/plugin.lua
@@ -1,3 +1,7 @@
+if game.Name ~= "defaults-place.rbxlx" then
+	return
+end
+
 local HttpService = game:GetService("HttpService")
 
 local SERVER_URL = "http://localhost:22073"

--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -92,7 +92,18 @@ fn save_place_in_studio(path: &PathBuf) -> anyhow::Result<StudioInfo> {
         Command::new("osascript")
 				.args([
 					"-e",
-					"tell application \"System Events\" to tell process \"RobloxStudio\" to set frontmost to true",
+					"tell application \"System Events\"
+                        repeat with theProcess in processes whose name is \"RobloxStudio\"
+                                tell theProcess
+                                    set windowList to windows whose name contains \"defaults-place.rbxlx - Roblox Studio\"
+                                    
+                                    if (count of windowList) > 0 then
+                                        set frontmost to true
+                                        perform action \"AXRaise\" of window 1
+                                    end if
+                                end tell
+                        end repeat
+                    end tell",
 				])
 				.output()?;
 

--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -104,8 +104,7 @@ end tell
             .output()?;
     }
 
-    #[cfg(not(target_os = "windows"))]
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     println!("Please save the opened place in Roblox Studio (ctrl+s).");
 
     loop {

--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -89,29 +89,18 @@ fn save_place_in_studio(path: &PathBuf) -> anyhow::Result<StudioInfo> {
 
     #[cfg(target_os = "macos")]
     {
-        Command::new("osascript")
-				.args([
-					"-e",
-					"tell application \"System Events\"
-                        repeat with theProcess in processes whose name is \"RobloxStudio\"
-                                tell theProcess
-                                    set windowList to windows whose name contains \"defaults-place.rbxlx - Roblox Studio\"
-                                    
-                                    if (count of windowList) > 0 then
-                                        set frontmost to true
-                                        perform action \"AXRaise\" of window 1
-                                    end if
-                                end tell
-                        end repeat
-                    end tell",
-				])
-				.output()?;
+        let process_id = studio_process.id();
+        let script = format!(
+            r#"
+tell application "System Events"
+    set frontmost of the first process whose unix id is {process_id} to true
+    keystroke "s" using command down
+end tell
+"#
+        );
 
         Command::new("osascript")
-            .args([
-                "-e",
-                "tell app \"System Events\" to key code 1 using command down",
-            ])
+            .args(["-e", script.as_str()])
             .output()?;
     }
 

--- a/rbx_reflector/src/cli/dump.rs
+++ b/rbx_reflector/src/cli/dump.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use std::process::Command;
+use std::{path::PathBuf, process::Stdio};
 
 use anyhow::{bail, Context};
 use clap::Parser;
@@ -22,6 +22,8 @@ impl DumpSubcommand {
             RobloxStudio::locate().context("Could not locate Roblox Studio install")?;
 
         Command::new(studio_install.application_path())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .arg("-FullAPI")
             .arg(&self.output)
             .status()?;


### PR DESCRIPTION
This PR brings automatic place saving to macOS, so it now works exactly the same as on Windows. It also pipes the `stdout` and `stderr` streams to `null` to get rid of extreme verbosity on macOS.


https://github.com/rojo-rbx/rbx-dom/assets/78505208/c488f168-dea0-4a3f-8f26-b83c8b5b4a66
> _New automation with old verbose output_