### PR TITLE
Changed WorldPivotData getter/setter to WorldPivot

### DIFF
--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -113,13 +113,14 @@ return {
 		},
 		WorldPivotData = {
 			read = function(instance)
-				return true, instance:GetPivot()
+				return true, instance.WorldPivot
 			end,
 			write = function(instance, _, value)
 				if value == nil then
 					return true, nil
 				else
-					return true, instance:PivotTo(value)
+					instance.WorldPivot = value
+					return true
 				end
 			end,
 		},


### PR DESCRIPTION
`GetPivot` / `PivotTo` don't always reflect the value of `WorldPivotData`, actual value of which is reflected through `WorldPivot` (as mentioned in the #179 )
This can be observed by running the following tests in Studio
```lua
local Model = Instance.new("Model")
local Part = Instance.new("Part")

Part.Parent = Model

Model.PrimaryPart = Part -- If PrimaryPart doesn't exist then WorldPivot == GetPivot (Pretty sure)

Model.Name = "WPDTest"
Model.Parent = workspace
Model.WorldPivot *= CFrame.new(2.1, 2.3, 2.5) -- Try swapping this with PivotTo

local WorldPivot, GetPivot = Model.WorldPivot, Model:GetPivot()

print(WorldPivot)
warn(GetPivot)
print(WorldPivot == GetPivot)
-- Save the file & see it's contents
```