### PR TITLE
Add `clear` and `drain` implementations to `Attributes`

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Unreleased Changes
 * Implement `IntoIterator` for `&Attributes`. ([#386])
 * Implement `Extend<(String, Variant)>` for `Attributes`. ([#386])
+* Implement `clear` and `drain` for `Attributes`. ([#409])
 
 [#386]: https://github.com/rojo-rbx/rbx-dom/pull/386
+[#409]: https://github.com/rojo-rbx/rbx-dom/pull/409
 
 ## 1.8.0 (2024-01-16)
 * Add `len` and `is_empty` methods to `Attributes` struct. ([#377])


### PR DESCRIPTION
Took a liberty with how the `drain` implementation works but it's fine because `BTreeMap` doesn't have a `drain` method built into it.