### PR TITLE
Perform revamp of rbx_util to make it easier to add thing to

### DIFF
--- a/rbx_util/CHANGELOG.md
+++ b/rbx_util/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Version 0.2.0
+
+- Refactor commands into seperate files
+- Add `verbosity` and `color` global flags to control logging and terminal color
+
+# Version 0.1.0
+
+- Initial implementation

--- a/rbx_util/Cargo.toml
+++ b/rbx_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbx_util"
-version = "0.1.0"
+version = "0.2.0"
 description = "Utilities for working with Roblox model and place files"
 license = "MIT"
 documentation = "https://docs.rs/rbx_util"
@@ -20,9 +20,12 @@ path = "src/main.rs"
 name = "rbx-util"
 
 [dependencies]
-anyhow = "1.0.57"
-fs-err = "2.7.0"
 rbx_binary = { path = "../rbx_binary", features = ["unstable_text_format"] }
 rbx_xml = { path = "../rbx_xml" }
+
 serde_yaml = "0.8.24"
-structopt = "0.3.26"
+clap = { version = "4.5.4", features = ["derive"] }
+
+fs-err = "2.7.0"
+anyhow = "1.0.57"
+env_logger = "0.11.3"

--- a/rbx_util/Cargo.toml
+++ b/rbx_util/Cargo.toml
@@ -29,3 +29,4 @@ clap = { version = "4.5.4", features = ["derive"] }
 fs-err = "2.7.0"
 anyhow = "1.0.57"
 env_logger = "0.11.3"
+log = "0.4.21"

--- a/rbx_util/src/convert.rs
+++ b/rbx_util/src/convert.rs
@@ -1,0 +1,62 @@
+use std::{
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+};
+
+use anyhow::Context;
+use clap::Parser;
+use fs_err::File;
+
+use crate::ModelKind;
+
+#[derive(Debug, Parser)]
+pub struct ConvertCommand {
+    /// A path to the file to convert.
+    input_path: PathBuf,
+    /// A path to the desired output for the conversion. The output format is
+    /// deteremined by the file extension of this path.
+    output_path: PathBuf,
+}
+
+impl ConvertCommand {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let input_kind = ModelKind::from_path(&self.input_path)?;
+        let output_kind = ModelKind::from_path(&self.output_path)?;
+
+        let input_file = BufReader::new(File::open(&self.input_path)?);
+
+        let dom = match input_kind {
+            ModelKind::Xml => {
+                let options = rbx_xml::DecodeOptions::new()
+                    .property_behavior(rbx_xml::DecodePropertyBehavior::ReadUnknown);
+
+                rbx_xml::from_reader(input_file, options)
+                    .with_context(|| format!("Failed to read {}", self.input_path.display()))?
+            }
+
+            ModelKind::Binary => rbx_binary::from_reader(input_file)
+                .with_context(|| format!("Failed to read {}", self.input_path.display()))?,
+        };
+
+        let root_ids = dom.root().children();
+
+        let output_file = BufWriter::new(File::create(&self.output_path)?);
+
+        match output_kind {
+            ModelKind::Xml => {
+                let options = rbx_xml::EncodeOptions::new()
+                    .property_behavior(rbx_xml::EncodePropertyBehavior::WriteUnknown);
+
+                rbx_xml::to_writer(output_file, &dom, root_ids, options)
+                    .with_context(|| format!("Failed to write {}", self.output_path.display()))?;
+            }
+
+            ModelKind::Binary => {
+                rbx_binary::to_writer(output_file, &dom, root_ids)
+                    .with_context(|| format!("Failed to write {}", self.output_path.display()))?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/rbx_util/src/convert.rs
+++ b/rbx_util/src/convert.rs
@@ -25,6 +25,7 @@ impl ConvertCommand {
 
         let input_file = BufReader::new(File::open(&self.input_path)?);
 
+        log::debug!("Reading file into WeakDom");
         let dom = match input_kind {
             ModelKind::Xml => {
                 let options = rbx_xml::DecodeOptions::new()
@@ -42,6 +43,7 @@ impl ConvertCommand {
 
         let output_file = BufWriter::new(File::create(&self.output_path)?);
 
+        log::debug!("Writing into new file at {}", self.output_path.display());
         match output_kind {
             ModelKind::Xml => {
                 let options = rbx_xml::EncodeOptions::new()

--- a/rbx_util/src/main.rs
+++ b/rbx_util/src/main.rs
@@ -53,6 +53,7 @@ pub enum ModelKind {
 
 impl ModelKind {
     pub fn from_path(path: &Path) -> anyhow::Result<ModelKind> {
+        log::trace!("Resolving type of file for path {}", path.display());
         match path.extension().and_then(|ext| ext.to_str()) {
             Some("rbxm") | Some("rbxl") => Ok(ModelKind::Binary),
             Some("rbxmx") | Some("rbxlx") => Ok(ModelKind::Xml),

--- a/rbx_util/src/view_binary.rs
+++ b/rbx_util/src/view_binary.rs
@@ -1,0 +1,35 @@
+use std::{
+    io::{self, BufReader, BufWriter},
+    path::PathBuf,
+};
+
+use clap::Parser;
+use fs_err::File;
+
+use crate::ModelKind;
+
+#[derive(Debug, Parser)]
+pub struct ViewBinaryCommand {
+    /// The file to emit the contents of.
+    input: PathBuf,
+}
+
+impl ViewBinaryCommand {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let input_kind = ModelKind::from_path(&self.input)?;
+
+        if input_kind != ModelKind::Binary {
+            anyhow::bail!("not a binary model or place file: {}", self.input.display());
+        }
+
+        let input_file = BufReader::new(File::open(&self.input)?);
+
+        let model = rbx_binary::text_format::DecodedModel::from_reader(input_file);
+
+        let stdout = io::stdout();
+        let output = BufWriter::new(stdout.lock());
+        serde_yaml::to_writer(output, &model)?;
+
+        Ok(())
+    }
+}

--- a/rbx_util/src/view_binary.rs
+++ b/rbx_util/src/view_binary.rs
@@ -24,8 +24,10 @@ impl ViewBinaryCommand {
 
         let input_file = BufReader::new(File::open(&self.input)?);
 
+        log::debug!("Decoding file into text format");
         let model = rbx_binary::text_format::DecodedModel::from_reader(input_file);
 
+        log::debug!("Writing to stdout");
         let stdout = io::stdout();
         let output = BufWriter::new(stdout.lock());
         serde_yaml::to_writer(output, &model)?;


### PR DESCRIPTION
This essentially just spins each command off into its own file and adds QOL global flags for verbosity and color.

Quick tests show that nothing has broke, and this isn't a particularly complex change.

Also I added a changelog because I think it's worth it.