### PR TITLE
Implement Serde for SharedString

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -4,9 +4,11 @@
 * Implement `IntoIterator` for `&Attributes`. ([#386])
 * Implement `Extend<(String, Variant)>` for `Attributes`. ([#386])
 * Implement `clear` and `drain` for `Attributes`. ([#409])
+* Implement `Serialize` and `Deserialize` for `SharedString` ([#414])
 
 [#386]: https://github.com/rojo-rbx/rbx-dom/pull/386
 [#409]: https://github.com/rojo-rbx/rbx-dom/pull/409
+[#414]: https://github.com/rojo-rbx/rbx-dom/pull/414
 
 ## 1.8.0 (2024-01-16)
 * Add `len` and `is_empty` methods to `Attributes` struct. ([#377])

--- a/rbx_types/src/variant.rs
+++ b/rbx_types/src/variant.rs
@@ -114,10 +114,6 @@ make_variant! {
     Ref(Ref),
     Region3(Region3),
     Region3int16(Region3int16),
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "crate::shared_string::variant_serialization"),
-    )]
     SharedString(SharedString),
     String(String),
     UDim(UDim),


### PR DESCRIPTION
Implements Serde for SharedString. The implementation is pulled from `BinaryString` to avoid us having to do anything fancy.

This will allow users to specify SharedString properties in Rojo, which is of some importance.