### PR TITLE
Fix clippy lints across all crates

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -3,7 +3,6 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     convert::TryInto,
     io::Write,
-    u32,
 };
 
 use rbx_dom_weak::{

--- a/rbx_reflector/src/api_dump.rs
+++ b/rbx_reflector/src/api_dump.rs
@@ -22,6 +22,8 @@ pub struct DumpClass {
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "MemberType")]
+// We're using this with Serde, it's ok that there's unused struct members.
+#[allow(dead_code)]
 pub enum DumpClassMember {
     Property(DumpClassProperty),
 
@@ -95,6 +97,8 @@ pub struct PropertySecurity {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+// We're using this with Serde, it's ok that there's unused struct members.
+#[allow(dead_code)]
 pub struct Serialization {
     pub can_save: bool,
     pub can_load: bool,
@@ -116,6 +120,8 @@ pub struct DumpEnumItem {
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
+// We're using this with Serde, it's ok that there's unused struct members.
+#[allow(dead_code)]
 pub enum Tag {
     Regular(String),
     Named(HashMap<String, String>),

--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -79,9 +79,9 @@ pub struct Vector3 {
 }
 
 fn approx_unit_or_zero(value: f32) -> Option<i32> {
-    if value.abs() <= std::f32::EPSILON {
+    if value.abs() <= f32::EPSILON {
         Some(0)
-    } else if value.abs() - 1.0 <= std::f32::EPSILON {
+    } else if value.abs() - 1.0 <= f32::EPSILON {
         Some(1.0f32.copysign(value) as i32)
     } else {
         None
@@ -409,9 +409,9 @@ impl Color3uint8 {
 impl From<Color3> for Color3uint8 {
     fn from(value: Color3) -> Self {
         Self {
-            r: ((value.r.max(0.0).min(1.0)) * 255.0).round() as u8,
-            g: ((value.g.max(0.0).min(1.0)) * 255.0).round() as u8,
-            b: ((value.b.max(0.0).min(1.0)) * 255.0).round() as u8,
+            r: (value.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+            g: (value.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+            b: (value.b.clamp(0.0, 1.0) * 255.0).round() as u8,
         }
     }
 }

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -126,7 +126,7 @@ mod test {
         let thirty = Ref(NonZeroU128::new(30));
         assert_eq!(thirty.to_string(), "0000000000000000000000000000001e");
 
-        let max = Ref(NonZeroU128::new(u128::max_value()));
+        let max = Ref(NonZeroU128::new(u128::MAX));
         assert_eq!(max.to_string(), "ffffffffffffffffffffffffffffffff");
     }
 
@@ -144,7 +144,7 @@ mod test {
 
         assert_eq!(
             Ref::from_str("ffffffffffffffffffffffffffffffff").unwrap(),
-            Ref(NonZeroU128::new(u128::max_value()))
+            Ref(NonZeroU128::new(u128::MAX))
         );
     }
 

--- a/rbx_xml/src/types/numbers.rs
+++ b/rbx_xml/src/types/numbers.rs
@@ -16,9 +16,9 @@ macro_rules! float_type {
                 &self,
                 writer: &mut XmlEventWriter<W>,
             ) -> Result<(), EncodeError> {
-                if *self == std::$rust_type::INFINITY {
+                if *self == $rust_type::INFINITY {
                     writer.write_characters("INF")
-                } else if *self == std::$rust_type::NEG_INFINITY {
+                } else if *self == $rust_type::NEG_INFINITY {
                     writer.write_characters("-INF")
                 } else if self.is_nan() {
                     writer.write_characters("NAN")
@@ -31,9 +31,9 @@ macro_rules! float_type {
                 let contents = reader.read_characters()?;
 
                 Ok(match contents.as_str() {
-                    "INF" => std::$rust_type::INFINITY,
-                    "-INF" => std::$rust_type::NEG_INFINITY,
-                    "NAN" => std::$rust_type::NAN,
+                    "INF" => $rust_type::INFINITY,
+                    "-INF" => $rust_type::NEG_INFINITY,
+                    "NAN" => $rust_type::NAN,
                     number => number.parse().map_err(|e| reader.error(e))?,
                 })
             }
@@ -99,12 +99,9 @@ mod test {
 
     #[test]
     fn test_inf_and_nan_deserialize() {
-        test_util::test_xml_deserialize(r#"<float name="foo">INF</float>"#, &std::f32::INFINITY);
+        test_util::test_xml_deserialize(r#"<float name="foo">INF</float>"#, &f32::INFINITY);
 
-        test_util::test_xml_deserialize(
-            r#"<float name="foo">-INF</float>"#,
-            &std::f32::NEG_INFINITY,
-        );
+        test_util::test_xml_deserialize(r#"<float name="foo">-INF</float>"#, &f32::NEG_INFINITY);
 
         // Can't just use test_util::test_xml_deserialize, because NaN != NaN!
 
@@ -119,10 +116,10 @@ mod test {
 
     #[test]
     fn test_inf_and_nan_serialize() {
-        test_util::test_xml_serialize(r#"<float name="foo">INF</float>"#, &std::f32::INFINITY);
+        test_util::test_xml_serialize(r#"<float name="foo">INF</float>"#, &f32::INFINITY);
 
-        test_util::test_xml_serialize(r#"<float name="foo">-INF</float>"#, &std::f32::NEG_INFINITY);
+        test_util::test_xml_serialize(r#"<float name="foo">-INF</float>"#, &f32::NEG_INFINITY);
 
-        test_util::test_xml_serialize(r#"<float name="foo">NAN</float>"#, &std::f32::NAN);
+        test_util::test_xml_serialize(r#"<float name="foo">NAN</float>"#, &f32::NAN);
     }
 }


### PR DESCRIPTION
babe wake up, new clippy version just dropped, and with it new lints.

Mostly in this case it was that we were using outdated stuff. Some dead code in rbx_reflector but we're ignoring it since we need it for Serde (well, we don't, but it'd be weird to just ignore all unknown values in the API dump)