### PR TITLE
Change `ReflectionDatabase::superclasses` to use `&ClassDescriptor` instead of `&str`

### DIFF
--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -41,8 +41,7 @@ impl<'a> ReflectionDatabase<'a> {
     }
 
     /// Returns a list of superclasses for the provided ClassDescriptor. This
-    /// list will start with the provided class and end with `Instance` if the
-    /// class exists.
+    /// list will start with the provided class and end with `Instance`.
     pub fn superclasses(
         &'a self,
         descriptor: &'a ClassDescriptor<'a>,

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -40,15 +40,17 @@ impl<'a> ReflectionDatabase<'a> {
         }
     }
 
-    /// Returns a list of superclasses for the provided class name. This list
-    /// will start with the provided class and end with `Instance` if the class
-    /// exists.
-    pub fn superclasses(&self, class_name: &str) -> Option<Vec<&ClassDescriptor>> {
+    /// Returns a list of superclasses for the provided ClassDescriptor. This
+    /// list will start with the provided class and end with `Instance` if the
+    /// class exists.
+    pub fn superclasses(
+        &'a self,
+        descriptor: &'a ClassDescriptor<'a>,
+    ) -> Option<Vec<&ClassDescriptor>> {
         // As of the time of writing (14 March 2024), the class with the most
         // superclasses has 6 of them.
         let mut list = Vec::with_capacity(6);
-        let mut current_class = self.classes.get(class_name);
-        current_class?;
+        let mut current_class = Some(descriptor);
 
         while let Some(class) = current_class {
             list.push(class);


### PR DESCRIPTION
As mentioned in #420, there's an inconsistency in the design of `superclasses` with how `find_default_property` is going to work. It makes sense to operate on `ClassDescriptors` in database methods, so this PR just swaps `ReflectionDatabase::superclasses` to use one instead of a class name.