### PR TITLE
Implement descendant iterators for WeakDom

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,6 +1,9 @@
 # rbx_dom_weak Changelog
 
 ## Unreleased Changes
+* Added `WeakDom::descendants` and `WeakDom::descendants_of` to support iterating through the descendants of a DOM. ([#431])
+
+[#431]: https://github.com/rojo-rbx/rbx-dom/pull/431
 
 ## 2.8.0 (2024-07-23)
 * Added `InstanceBuilder::with_referent` that allows building instance with predefined `Ref` ([#400])

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -787,4 +787,28 @@ mod test {
             panic!("UniqueId property must exist and contain a Variant::UniqueId")
         };
     }
+
+    #[test]
+    fn descendants() {
+        let mut dom = WeakDom::new(InstanceBuilder::new("ROOT"));
+
+        let child_1 = dom.insert(dom.root_ref(), InstanceBuilder::new("Folder"));
+        let sibling_1 = dom.insert(child_1, InstanceBuilder::new("Folder"));
+        let child_2 = dom.insert(dom.root_ref(), InstanceBuilder::new("Folder"));
+        let sibling_2 = dom.insert(child_1, InstanceBuilder::new("Folder"));
+
+        let mut descendants = dom.descendants();
+        assert_eq!(descendants.next().unwrap().referent(), dom.root_ref());
+        assert_eq!(descendants.next().unwrap().referent(), child_1);
+        assert_eq!(descendants.next().unwrap().referent(), child_2);
+        assert_eq!(descendants.next().unwrap().referent(), sibling_1);
+        assert_eq!(descendants.next().unwrap().referent(), sibling_2);
+        assert!(descendants.next().is_none());
+
+        let mut descendants_2 = dom.descendants_of(child_1);
+        assert_eq!(descendants_2.next().unwrap().referent(), child_1);
+        assert_eq!(descendants_2.next().unwrap().referent(), sibling_1);
+        assert_eq!(descendants_2.next().unwrap().referent(), sibling_2);
+        assert!(descendants_2.next().is_none());
+    }
 }


### PR DESCRIPTION
Iterating through WeakDoms is a common enough code pattern that I feel it warrants its own function. This implements those functions.