### PR TITLE
Use as_deref instead of clone when writing font cached face ID

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -798,7 +798,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                 chunk.write_le_u16(value.weight.as_u16())?;
                                 chunk.write_u8(value.style.as_u8())?;
                                 chunk.write_string(
-                                    &value.cached_face_id.clone().unwrap_or_default(),
+                                    value.cached_face_id.as_deref().unwrap_or_default(),
                                 )?;
                             } else {
                                 return type_mismatch(i, &rbx_value, "Font");

--- a/rbx_types/src/attributes/writer.rs
+++ b/rbx_types/src/attributes/writer.rs
@@ -95,7 +95,7 @@ pub(crate) fn write_attributes<W: Write>(
                 write_string(&mut writer, &font.family)?;
                 write_string(
                     &mut writer,
-                    &font.cached_face_id.clone().unwrap_or_default(),
+                    font.cached_face_id.as_deref().unwrap_or_default(),
                 )?;
             }
 


### PR DESCRIPTION
This PR removes an unnecessary clone and reference when writing font values to binary files or attributes, fixing a clippy lint that recently started being reported 