### PR TITLE
Release rbx-binary v0.7.6

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,6 +1,8 @@
 # rbx_binary Changelog
 
 ## Unreleased
+
+## 0.7.6 (2024-08-06)
 * Changed the way instances are added to the serializer to a depth-first post-order traversal. ([#432])
 
 [#432]: https://github.com/rojo-rbx/rbx-dom/pull/432

--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbx_binary"
 description = "Implementation of Roblox's binary model (rbxm) and place (rbxl) file formats"
-version = "0.7.5"
+version = "0.7.6"
 license = "MIT"
 documentation = "https://docs.rs/rbx_binary"
 homepage = "https://github.com/rojo-rbx/rbx-dom"


### PR DESCRIPTION
After the bugfix for rbx-binary, we should probably make a new release. That's this.