### PR TITLE
Implement Int32 attributes

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -70,6 +70,10 @@ The `Bool` type is stored as a single byte. If the byte is `0x00`, the bool is `
 
 It is worth noting that Roblox Studio will interpret any non-zero value as `true`.
 
+### Int32
+**Type ID `0x04`**
+The `Int32` type is stored as a little-endian 32-bit integer.
+
 ### Float32
 **Type ID `0x05`**
 

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -65,4 +65,5 @@ binary_tests! {
     folder_with_cframe_attributes,
     folder_with_font_attribute,
     number_values_with_security_capabilities,
+    lighting_with_int32_attribute,
 }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__lighting-with-int32-attribute__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__lighting-with-int32-attribute__decoded.snap
@@ -1,0 +1,70 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Lighting
+  class: Lighting
+  properties:
+    Ambient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Attributes:
+      Attributes:
+        RBX_OriginalTechnologyOnFileLoad:
+          Int32: 3
+    Brightness:
+      Float32: 3
+    Capabilities:
+      SecurityCapabilities: 0
+    ColorShift_Bottom:
+      Color3:
+        - 0
+        - 0
+        - 0
+    ColorShift_Top:
+      Color3:
+        - 0
+        - 0
+        - 0
+    DefinesCapabilities:
+      Bool: false
+    EnvironmentDiffuseScale:
+      Float32: 1
+    EnvironmentSpecularScale:
+      Float32: 1
+    ExposureCompensation:
+      Float32: 0
+    FogColor:
+      Color3:
+        - 0.75294125
+        - 0.75294125
+        - 0.75294125
+    FogEnd:
+      Float32: 100000
+    FogStart:
+      Float32: 0
+    GeographicLatitude:
+      Float32: 0
+    GlobalShadows:
+      Bool: true
+    OutdoorAmbient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Outlines:
+      Bool: false
+    ShadowSoftness:
+      Float32: 0.2
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Technology:
+      Enum: 3
+    TimeOfDay:
+      String: "14:30:00"
+  children: []

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__lighting-with-int32-attribute__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__lighting-with-int32-attribute__encoded.snap
@@ -1,0 +1,168 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 1
+num_instances: 1
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: Lighting
+      object_format: 1
+      referents:
+        - 0
+      remaining: "01"
+  - Prop:
+      type_id: 0
+      prop_name: Ambient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - "\u0001\u0000\u0000\u0000 \u0000\u0000\u0000RBX_OriginalTechnologyOnFileLoad\u0004\u0003\u0000\u0000\u0000"
+  - Prop:
+      type_id: 0
+      prop_name: Brightness
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 0
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ColorShift_Bottom
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 0
+      prop_name: ColorShift_Top
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 0
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: EnvironmentDiffuseScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: EnvironmentSpecularScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: ExposureCompensation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: FogColor
+      prop_type: Color3
+      values:
+        - - 0.75294125
+          - 0.75294125
+          - 0.75294125
+  - Prop:
+      type_id: 0
+      prop_name: FogEnd
+      prop_type: Float32
+      values:
+        - 100000
+  - Prop:
+      type_id: 0
+      prop_name: FogStart
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: GeographicLatitude
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: GlobalShadows
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Lighting
+  - Prop:
+      type_id: 0
+      prop_name: OutdoorAmbient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 0
+      prop_name: Outlines
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: ShadowSoftness
+      prop_type: Float32
+      values:
+        - 0.2
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Technology
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 0
+      prop_name: TimeOfDay
+      prop_type: String
+      values:
+        - "14:30:00"
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__lighting-with-int32-attribute__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__lighting-with-int32-attribute__input.snap
@@ -1,0 +1,172 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 1
+num_instances: 1
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Inst:
+      type_id: 0
+      type_name: Lighting
+      object_format: 1
+      referents:
+        - 0
+      remaining: "00"
+  - Prop:
+      type_id: 0
+      prop_name: Ambient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - "\u0001\u0000\u0000\u0000 \u0000\u0000\u0000RBX_OriginalTechnologyOnFileLoad\u0004\u0003\u0000\u0000\u0000"
+  - Prop:
+      type_id: 0
+      prop_name: Brightness
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 0
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: ColorShift_Bottom
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 0
+      prop_name: ColorShift_Top
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 0
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: EnvironmentDiffuseScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: EnvironmentSpecularScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: ExposureCompensation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: FogColor
+      prop_type: Color3
+      values:
+        - - 0.75294125
+          - 0.75294125
+          - 0.75294125
+  - Prop:
+      type_id: 0
+      prop_name: FogEnd
+      prop_type: Float32
+      values:
+        - 100000
+  - Prop:
+      type_id: 0
+      prop_name: FogStart
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: GeographicLatitude
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: GlobalShadows
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Lighting
+  - Prop:
+      type_id: 0
+      prop_name: OutdoorAmbient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 0
+      prop_name: Outlines
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: ShadowSoftness
+      prop_type: Float32
+      values:
+        - 0.2
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Technology
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 0
+      prop_name: TimeOfDay
+      prop_type: String
+      values:
+        - "14:30:00"
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+  - End

--- a/rbx_types/src/attributes/reader.rs
+++ b/rbx_types/src/attributes/reader.rs
@@ -71,6 +71,10 @@ pub(crate) fn read_attributes<R: Read>(
                 ColorSequence { keypoints }.into()
             }
 
+            VariantType::Int32 => read_i32(&mut value)
+                .map_err(|_| AttributeError::ReadType("int32"))?
+                .into(),
+
             VariantType::Float32 => read_f32(&mut value)
                 .map_err(|_| AttributeError::ReadType("float32"))?
                 .into(),

--- a/rbx_types/src/attributes/type_id.rs
+++ b/rbx_types/src/attributes/type_id.rs
@@ -24,7 +24,7 @@ type_ids! {
     // ??? => 0x01,
     BinaryString => 0x02,
     Bool => 0x03,
-    // ??? => 0x04,
+    Int32 => 0x04,
     Float32 => 0x05,
     Float64 => 0x06,
     // ??? => 0x07,

--- a/rbx_types/src/attributes/writer.rs
+++ b/rbx_types/src/attributes/writer.rs
@@ -42,6 +42,7 @@ pub(crate) fn write_attributes<W: Write>(
                     write_color3(&mut writer, keypoint.color)?;
                 }
             }
+            Variant::Int32(int) => write_i32(&mut writer, *int)?,
             Variant::Float32(float) => write_f32(&mut writer, *float)?,
             Variant::Float64(float) => write_f64(&mut writer, *float)?,
             Variant::NumberRange(range) => {
@@ -104,6 +105,10 @@ pub(crate) fn write_attributes<W: Write>(
     }
 
     Ok(())
+}
+
+fn write_i32<W: Write>(mut writer: W, n: i32) -> io::Result<()> {
+    writer.write_all(&n.to_le_bytes()[..])
 }
 
 fn write_f32<W: Write>(mut writer: W, n: f32) -> io::Result<()> {

--- a/rbx_xml/src/tests/models.rs
+++ b/rbx_xml/src/tests/models.rs
@@ -66,4 +66,5 @@ model_tests! {
     folder_with_cframe_attributes,
     folder_with_font_attribute,
     number_values_with_security_capabilities,
+    lighting_with_int32_attribute,
 }

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__lighting-with-int32-attribute__decoded.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__lighting-with-int32-attribute__decoded.snap
@@ -1,0 +1,70 @@
+---
+source: rbx_xml/src/tests/mod.rs
+expression: "DomViewer::new().view_children(&decoded)"
+---
+- referent: referent-0
+  name: Lighting
+  class: Lighting
+  properties:
+    Ambient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Attributes:
+      Attributes:
+        RBX_OriginalTechnologyOnFileLoad:
+          Int32: 3
+    Brightness:
+      Float32: 3
+    Capabilities:
+      SecurityCapabilities: 0
+    ColorShift_Bottom:
+      Color3:
+        - 0
+        - 0
+        - 0
+    ColorShift_Top:
+      Color3:
+        - 0
+        - 0
+        - 0
+    DefinesCapabilities:
+      Bool: false
+    EnvironmentDiffuseScale:
+      Float32: 1
+    EnvironmentSpecularScale:
+      Float32: 1
+    ExposureCompensation:
+      Float32: 0
+    FogColor:
+      Color3:
+        - 0.75294125
+        - 0.75294125
+        - 0.75294125
+    FogEnd:
+      Float32: 100000
+    FogStart:
+      Float32: 0
+    GeographicLatitude:
+      Float32: 0
+    GlobalShadows:
+      Bool: true
+    OutdoorAmbient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Outlines:
+      Bool: false
+    ShadowSoftness:
+      Float32: 0.2
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Technology:
+      Enum: 3
+    TimeOfDay:
+      String: "14:30:00"
+  children: []

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__lighting-with-int32-attribute__roundtrip.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__lighting-with-int32-attribute__roundtrip.snap
@@ -1,0 +1,70 @@
+---
+source: rbx_xml/src/tests/mod.rs
+expression: "DomViewer::new().view_children(&roundtrip)"
+---
+- referent: referent-0
+  name: Lighting
+  class: Lighting
+  properties:
+    Ambient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Attributes:
+      Attributes:
+        RBX_OriginalTechnologyOnFileLoad:
+          Int32: 3
+    Brightness:
+      Float32: 3
+    Capabilities:
+      SecurityCapabilities: 0
+    ColorShift_Bottom:
+      Color3:
+        - 0
+        - 0
+        - 0
+    ColorShift_Top:
+      Color3:
+        - 0
+        - 0
+        - 0
+    DefinesCapabilities:
+      Bool: false
+    EnvironmentDiffuseScale:
+      Float32: 1
+    EnvironmentSpecularScale:
+      Float32: 1
+    ExposureCompensation:
+      Float32: 0
+    FogColor:
+      Color3:
+        - 0.75294125
+        - 0.75294125
+        - 0.75294125
+    FogEnd:
+      Float32: 100000
+    FogStart:
+      Float32: 0
+    GeographicLatitude:
+      Float32: 0
+    GlobalShadows:
+      Bool: true
+    OutdoorAmbient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Outlines:
+      Bool: false
+    ShadowSoftness:
+      Float32: 0.2
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Technology:
+      Enum: 3
+    TimeOfDay:
+      String: "14:30:00"
+  children: []


### PR DESCRIPTION
This PR adds support for the `Int32` type to the attributes parser. An attribute of this type was introduced into newly-saved place files as part of https://devforum.roblox.com/t/compatibility-lighting-becomes-retro-tone-mapping-sunset-migration/3128560.