### PR TITLE
Validate attribute removals, handle reserved failures separately from invalid ones

### DIFF
--- a/rbx_dom_lua/src/customProperties.lua
+++ b/rbx_dom_lua/src/customProperties.lua
@@ -26,6 +26,21 @@ local TERRAIN_MATERIAL_COLORS = {
 	Enum.Material.Pavement,
 }
 
+local function isAttributeNameValid(attributeName)
+	-- For SetAttribute to succeed, the attribute name must be less than or
+	-- equal to 100 characters...
+	return #attributeName <= 100
+		-- ...and must only contain alphanumeric characters, periods, hyphens,
+		-- underscores, or forward slashes.
+		and attributeName:match("[^%w%.%-_/]") == nil
+end
+
+local function isAttributeNameReserved(attributeName)
+	-- For SetAttribute to succeed, attribute names must not use the RBX
+	-- prefix, which is reserved by Roblox.
+	return attributeName:sub(1, 3) ~= "RBX"
+end
+
 -- Defines how to read and write properties that aren't directly scriptable.
 --
 -- The reflection database refers to these as having scriptability = "Custom"
@@ -40,26 +55,33 @@ return {
 				local didAllWritesSucceed = true
 
 				for attributeName, attributeValue in pairs(value) do
-					local isNameValid =
-						-- For our SetAttribute to succeed, the attribute name must be
-						-- less than or equal to 100 characters...
-						#attributeName <= 100
-						-- ...must only contain alphanumeric characters, periods, hyphens,
-						-- underscores, or forward slashes...
-						and attributeName:match("[^%w%.%-_/]") == nil
-						-- ... and must not use the RBX prefix, which is reserved by Roblox.
-						and attributeName:sub(1, 3) ~= "RBX"
-
-					if isNameValid then
-						instance:SetAttribute(attributeName, attributeValue)
-					else
-						didAllWritesSucceed = false
+					if isAttributeNameReserved(attributeName) then
+						-- If the attribute name is reserved, then we don't
+						-- really care about reporting any failures about
+						-- it.
+						continue
 					end
+
+					if not isAttributeNameValid(attributeName) then
+						didAllWritesSucceed = false
+						continue
+					end
+
+					instance:SetAttribute(attributeName, attributeValue)
 				end
 
-				for key in pairs(existing) do
-					if value[key] == nil then
-						instance:SetAttribute(key, nil)
+				for existingAttributeName in pairs(existing) do
+					if isAttributeNameReserved(existingAttributeName) then
+						continue
+					end
+
+					if not isAttributeNameValid(existingAttributeName) then
+						didAllWritesSucceed = false
+						continue
+					end
+
+					if value[existingAttributeName] == nil then
+						instance:SetAttribute(existingAttributeName, nil)
 					end
 				end
 


### PR DESCRIPTION
When implementing #374, we forgot to also validate attribute names when removing attributes from the existing instance. In addition to adding that validation, this PR reworks attribute set validation so we consider reserved names separately from invalid ones - we probably don't want to indicate failure on reserved names, since reserved attribute names seem to be Roblox implementation details and won't impact the correctness of results.