### PR TITLE
Increment crate versions in prep for release

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.7.7 (2024-08-22)
+* Updated rbx-dom dependencies
+
 ## 0.7.6 (2024-08-06)
 * Changed the way instances are added to the serializer to a depth-first post-order traversal. ([#432])
 

--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbx_binary"
 description = "Implementation of Roblox's binary model (rbxm) and place (rbxl) file formats"
-version = "0.7.6"
+version = "0.7.7"
 license = "MIT"
 documentation = "https://docs.rs/rbx_binary"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
@@ -14,9 +14,9 @@ edition = "2018"
 unstable_text_format = ["serde"]
 
 [dependencies]
-rbx_dom_weak = { version = "2.8.0", path = "../rbx_dom_weak" }
-rbx_reflection = { version = "4.6.0", path = "../rbx_reflection" }
-rbx_reflection_database = { version = "0.2.11", path = "../rbx_reflection_database" }
+rbx_dom_weak = { version = "2.9.0", path = "../rbx_dom_weak" }
+rbx_reflection = { version = "4.7.0", path = "../rbx_reflection" }
+rbx_reflection_database = { version = "0.2.12", path = "../rbx_reflection_database" }
 
 log = "0.4.17"
 lz4 = "1.23.3"

--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,6 +1,8 @@
 # rbx_dom_weak Changelog
 
 ## Unreleased Changes
+
+## 2.9.0 (2024-08-22)
 * Added `WeakDom::descendants` and `WeakDom::descendants_of` to support iterating through the descendants of a DOM. ([#431])
 
 [#431]: https://github.com/rojo-rbx/rbx-dom/pull/431

--- a/rbx_dom_weak/Cargo.toml
+++ b/rbx_dom_weak/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbx_dom_weak"
 description = "Weakly-typed Roblox DOM implementation for Rust"
-version = "2.8.0"
+version = "2.9.0"
 license = "MIT"
 documentation = "https://docs.rs/rbx_dom_weak"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
@@ -11,7 +11,7 @@ authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 edition = "2018"
 
 [dependencies]
-rbx_types = { version = "1.9.0", path = "../rbx_types", features = ["serde"] }
+rbx_types = { version = "1.10.0", path = "../rbx_types", features = ["serde"] }
 
 serde = "1.0.137"
 

--- a/rbx_reflection/CHANGELOG.md
+++ b/rbx_reflection/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased Changes
 
+## 4.7.0 (2024-08-22)
+* Update to rbx_types 1.10
+
 ## 4.6.0 (2024-07-23)
+* Update to rbx_types 1.9
 * Add `superclasses` method to `ReflectionDatabase` to get a set of superclasses for a given class. ([#402])
 * Added method `ReflectionDatabase::find_default_property`, which finds the default value of a property given its name and a class that inherits it. ([#420])
 

--- a/rbx_reflection/Cargo.toml
+++ b/rbx_reflection/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbx_reflection"
 description = "Roblox reflection database and ambiguous type resolution"
-version = "4.6.0"
+version = "4.7.0"
 license = "MIT"
 documentation = "https://docs.rs/rbx_reflection"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
@@ -11,7 +11,7 @@ authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 edition = "2018"
 
 [dependencies]
-rbx_types = { version = "1.9.0", path = "../rbx_types", features = ["serde"] }
+rbx_types = { version = "1.10.0", path = "../rbx_types", features = ["serde"] }
 
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.31"

--- a/rbx_reflection_database/CHANGELOG.md
+++ b/rbx_reflection_database/CHANGELOG.md
@@ -1,6 +1,8 @@
 # rbx\_reflection_database Changelog
 
 ## Unreleased Changes
+
+## 0.2.12+roblox-638 (2024-08-22)
 * Update to Roblox version 638.
 * `Instance.UniqueId`, `Instance.HistoryId`, and `LuaSourceContainer.ScriptGuid` are marked as `Serializes` again ([#437])
 

--- a/rbx_reflection_database/Cargo.toml
+++ b/rbx_reflection_database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbx_reflection_database"
 description = "Bundled reflection database for Roblox projects"
-version = "0.2.11+roblox-634"
+version = "0.2.12+roblox-638"
 license = "MIT"
 documentation = "https://docs.rs/rbx_reflection_database"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
@@ -13,7 +13,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rbx_reflection = { version = "4.6.0", path = "../rbx_reflection" }
+rbx_reflection = { version = "4.7.0", path = "../rbx_reflection" }
 
 lazy_static = "1.4.0"
 serde = "1.0.137"

--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -1,9 +1,13 @@
 # rbx_types Changelog
 
 ## Unreleased Changes
+
+# 1.10.0 (2024-08-22)
+* Add support for `Int32` values within `Attributes` ([#439])
 * Add `len` and `is_empty` to `Tags` ([#438])
 
 [#438]: https://github.com/rojo-rbx/rbx-dom/pull/438
+[#439]: https://github.com/rojo-rbx/rbx-dom/pull/439
 
 ## 1.9.0 (2024-07-23)
 * Implement `IntoIterator` for `&Attributes`. ([#386])

--- a/rbx_types/Cargo.toml
+++ b/rbx_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbx_types"
 description = "Types used to represent Roblox values"
-version = "1.9.0"
+version = "1.10.0"
 authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 edition = "2018"
 license = "MIT"

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.13.5 (2024-08-22)
+* Updated rbx-dom dependencies
+
 ## 0.13.4 (2024-07-23)
 * Updated rbx-dom dependencies
 

--- a/rbx_xml/Cargo.toml
+++ b/rbx_xml/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rbx_xml"
 description = "Implementation of Roblox's XML file formats, rbxlx and rbxmx"
-version = "0.13.4"
+version = "0.13.5"
 license = "MIT"
 documentation = "https://docs.rs/rbx_xml"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
@@ -11,9 +11,9 @@ authors = ["Lucien Greathouse <me@lpghatguy.com>"]
 edition = "2018"
 
 [dependencies]
-rbx_dom_weak = { version = "2.8.0", path = "../rbx_dom_weak" }
-rbx_reflection = { version = "4.6.0", path = "../rbx_reflection" }
-rbx_reflection_database = { version = "0.2.11", path = "../rbx_reflection_database" }
+rbx_dom_weak = { version = "2.9.0", path = "../rbx_dom_weak" }
+rbx_reflection = { version = "4.7.0", path = "../rbx_reflection" }
+rbx_reflection_database = { version = "0.2.12", path = "../rbx_reflection_database" }
 
 base64 = "0.13.0"
 log = "0.4.17"


### PR DESCRIPTION
Notably, this does not involve updating the reflection database like it normally does. This is because a recent change (see #439) caused Roblox to start serializing an `Int32` attribute by default on `Lighting`, which we don't want to write as a default. Since our patching mechanism doesn't let us patch inherited properties right now, we can't patch the default value for `Lighting.Attributes` and instead would have to patch it for `Instance.Attributes`.

While we need to fix that in the future, I don't think it's a huge deal right now to just not update the database in favor of getting a patch out soon(tm).