### PR TITLE
rbx_reflection: Superclass Iterator

### DIFF
--- a/rbx_reflection/CHANGELOG.md
+++ b/rbx_reflection/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_reflection Changelog
 
 ## Unreleased Changes
+* Added `ReflectionDatabase::superclasses_iter`
 
 ## 4.7.0 (2024-08-22)
 * Update to rbx_types 1.10

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -34,17 +34,17 @@ pub struct SuperClassIter<'a> {
     database: &'a ReflectionDatabase<'a>,
     descriptor: Option<&'a ClassDescriptor<'a>>,
 }
-impl<'a> SuperClassIter<'a>{
-	fn next_descriptor(&self)->Option<&'a ClassDescriptor<'a>>{
-		let superclass = self.descriptor?.superclass.as_ref()?;
-		self.database.classes.get(superclass)
-	}
+impl<'a> SuperClassIter<'a> {
+    fn next_descriptor(&self) -> Option<&'a ClassDescriptor<'a>> {
+        let superclass = self.descriptor?.superclass.as_ref()?;
+        self.database.classes.get(superclass)
+    }
 }
 impl<'a> Iterator for SuperClassIter<'a> {
     type Item = &'a ClassDescriptor<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-    	let next_descriptor = self.next_descriptor();
-		std::mem::replace(&mut self.descriptor, next_descriptor)
+        let next_descriptor = self.next_descriptor();
+        std::mem::replace(&mut self.descriptor, next_descriptor)
     }
 }
 

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -37,13 +37,9 @@ pub struct SuperClassIter<'a> {
 impl<'a> Iterator for SuperClassIter<'a> {
     type Item = &'a ClassDescriptor<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        let next_descriptor = self.descriptor.and_then(|descriptor| {
-            descriptor
-                .superclass
-                .as_ref()
-                .and_then(|class_name| self.database.classes.get(class_name))
-        });
-        core::mem::replace(&mut self.descriptor, next_descriptor)
+        let superclass = self.descriptor?.superclass.as_ref()?;
+        let next_descriptor = self.database.classes.get(superclass)?;
+        self.descriptor.replace(next_descriptor)
     }
 }
 

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -77,7 +77,7 @@ impl<'a> ReflectionDatabase<'a> {
     pub fn superclasses_iter(&'a self, descriptor: &'a ClassDescriptor<'a>) -> SuperClassIter {
         SuperClassIter {
             database: self,
-            descriptor,
+            descriptor: Some(descriptor),
         }
     }
 

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -34,12 +34,17 @@ pub struct SuperClassIter<'a> {
     database: &'a ReflectionDatabase<'a>,
     descriptor: Option<&'a ClassDescriptor<'a>>,
 }
+impl<'a> SuperClassIter<'a>{
+	fn next_descriptor(&self)->Option<&'a ClassDescriptor<'a>>{
+		let superclass = self.descriptor?.superclass.as_ref()?;
+		self.database.classes.get(superclass)
+	}
+}
 impl<'a> Iterator for SuperClassIter<'a> {
     type Item = &'a ClassDescriptor<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        let superclass = self.descriptor?.superclass.as_ref()?;
-        let next_descriptor = self.database.classes.get(superclass)?;
-        self.descriptor.replace(next_descriptor)
+    	let next_descriptor = self.next_descriptor();
+		std::mem::replace(&mut self.descriptor, next_descriptor)
     }
 }
 

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -29,11 +29,11 @@ mod test {
         let part_class_descriptor = database.classes.get("Part");
         let mut iter = database.superclasses_iter(part_class_descriptor.unwrap());
         fn class_descriptor_eq(lhs: Option<&ClassDescriptor>, rhs: Option<&ClassDescriptor>) {
-            match (lhs, rhs) {
-                (Some(lhs), Some(rhs)) => assert_eq!(lhs.name, rhs.name),
-                (None, None) => assert!(true),
-                _ => assert!(false),
-            }
+            assert!(match (lhs, rhs) {
+                (Some(lhs), Some(rhs)) => std::ptr::addr_eq(lhs, rhs),
+                (None, None) => true,
+                _ => false,
+            })
         }
         class_descriptor_eq(iter.next(), part_class_descriptor);
         class_descriptor_eq(iter.next(), database.classes.get("FormFactorPart"));

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -29,11 +29,12 @@ mod test {
         let part_class_descriptor = database.classes.get("Part");
         let mut iter = database.superclasses_iter(part_class_descriptor.unwrap());
         fn class_descriptor_eq(lhs: Option<&ClassDescriptor>, rhs: Option<&ClassDescriptor>) {
-            assert!(match (lhs, rhs) {
+            let eq = match (lhs, rhs) {
                 (Some(lhs), Some(rhs)) => lhs.name == rhs.name,
                 (None, None) => true,
                 _ => false,
-            })
+            };
+            assert!(eq, "{:?} != {:?}", lhs, rhs);
         }
         class_descriptor_eq(iter.next(), part_class_descriptor);
         class_descriptor_eq(iter.next(), database.classes.get("FormFactorPart"));

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -28,18 +28,18 @@ mod test {
         let database = get();
         let part_class_descriptor = database.classes.get("Part");
         let mut iter = database.superclasses_iter(part_class_descriptor.unwrap());
-        fn class_descriptor_eq(lhs:Option<&ClassDescriptor>,rhs:Option<&ClassDescriptor>){
-			match (lhs,rhs){
-				(Some(lhs),Some(rhs))=>assert_eq!(lhs.name,rhs.name),
-				(None,None)=>assert!(true),
-				_=>assert!(false),
-			}
+        fn class_descriptor_eq(lhs: Option<&ClassDescriptor>, rhs: Option<&ClassDescriptor>) {
+            match (lhs, rhs) {
+                (Some(lhs), Some(rhs)) => assert_eq!(lhs.name, rhs.name),
+                (None, None) => assert!(true),
+                _ => assert!(false),
+            }
         }
-        class_descriptor_eq(iter.next(),part_class_descriptor);
-        class_descriptor_eq(iter.next(),database.classes.get("FormFactorPart"));
-        class_descriptor_eq(iter.next(),database.classes.get("BasePart"));
-        class_descriptor_eq(iter.next(),database.classes.get("PVInstance"));
-        class_descriptor_eq(iter.next(),database.classes.get("Instance"));
-        class_descriptor_eq(iter.next(),None);
+        class_descriptor_eq(iter.next(), part_class_descriptor);
+        class_descriptor_eq(iter.next(), database.classes.get("FormFactorPart"));
+        class_descriptor_eq(iter.next(), database.classes.get("BasePart"));
+        class_descriptor_eq(iter.next(), database.classes.get("PVInstance"));
+        class_descriptor_eq(iter.next(), database.classes.get("Instance"));
+        class_descriptor_eq(iter.next(), None);
     }
 }

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -30,7 +30,7 @@ mod test {
         let mut iter = database.superclasses_iter(part_class_descriptor.unwrap());
         fn class_descriptor_eq(lhs: Option<&ClassDescriptor>, rhs: Option<&ClassDescriptor>) {
             assert!(match (lhs, rhs) {
-                (Some(lhs), Some(rhs)) => std::ptr::addr_eq(lhs, rhs),
+                (Some(lhs), Some(rhs)) => lhs.name == rhs.name,
                 (None, None) => true,
                 _ => false,
             })

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -14,10 +14,32 @@ pub fn get() -> &'static ReflectionDatabase<'static> {
 
 #[cfg(test)]
 mod test {
+    use rbx_reflection::ClassDescriptor;
+
     use super::*;
 
     #[test]
     fn smoke_test() {
         let _database = get();
+    }
+
+    #[test]
+    fn superclasses_iter_test() {
+        let database = get();
+        let part_class_descriptor = database.classes.get("Part");
+        let mut iter = database.superclasses_iter(part_class_descriptor.unwrap());
+        fn class_descriptor_eq(lhs:Option<&ClassDescriptor>,rhs:Option<&ClassDescriptor>){
+			match (lhs,rhs){
+				(Some(lhs),Some(rhs))=>assert_eq!(lhs.name,rhs.name),
+				(None,None)=>assert!(true),
+				_=>assert!(false),
+			}
+        }
+        class_descriptor_eq(iter.next(),part_class_descriptor);
+        class_descriptor_eq(iter.next(),database.classes.get("FormFactorPart"));
+        class_descriptor_eq(iter.next(),database.classes.get("BasePart"));
+        class_descriptor_eq(iter.next(),database.classes.get("PVInstance"));
+        class_descriptor_eq(iter.next(),database.classes.get("Instance"));
+        class_descriptor_eq(iter.next(),None);
     }
 }


### PR DESCRIPTION
I thought it was weird that database.superclasses() returns a Vec<ClassDescriptor> rather than an iterator, perhaps it should be replaced or supplemented by something like this?