### PR TITLE
Wait for game.Name to change before running rbx-reflector plugin

### DIFF
--- a/rbx_reflector/plugin.lua
+++ b/rbx_reflector/plugin.lua
@@ -1,4 +1,32 @@
-if game.Name ~= "defaults-place.rbxlx" then
+local function isDefaultsPlace()
+	-- After https://devforum.roblox.com/t/place-open-improvements-test/3086811, game.Name
+	-- is no longer immediately equal to its value defined in a place file after opening a
+	-- place file. Rather, game.Name is set the value defined in a place sometime after
+	-- the place is opened. We need to wait for game.Name to change before validating that
+	-- the place file in which this plugin is running is correct.
+
+	-- Since if or when game.Name changes seems to be an implementation detail, we
+	-- shouldn't assume game.Name will ever change. So, we'll wait for game.Name to
+	-- change, or else wait out a two second timeout, whichever comes first.
+	local didGameNameChange = false
+	local timeElapsed = 0
+
+	game:GetPropertyChangedSignal("Name"):Connect(function()
+		didGameNameChange = true
+	end)
+
+	while not didGameNameChange and timeElapsed <= 2 do
+		timeElapsed += task.wait()
+	end
+
+	if game.Name ~= "defaults-place.rbxlx" then
+		return false
+	end
+
+	return true
+end
+
+if not isDefaultsPlace() then
 	return
 end
 


### PR DESCRIPTION
This PR changes the rbx-reflector Roblox Studio plugin so that it waits for `game.Name` to change before checking that the place it's running in is the defaults place.

This is necessary because (likely) after https://devforum.roblox.com/t/place-open-improvements-test/3086811, `game.Name` is only set to the value specified in the place file sometime after opening the place, meaning that the rbx-reflector plugin in its current state will never run.

Since it doesn't seem prudent to assume that `game.Name` will always have this behavior, there is a two second timeout.

