### PR TITLE
rbx_reflection: Superclass Iterator v2

### DIFF
--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -86,6 +86,17 @@ impl<'a> ReflectionDatabase<'a> {
         }
     }
 
+    /// Walks the class tree, checking if superclass matches
+    /// any class names the class inherits from
+    pub fn class_is_a(
+        &'a self,
+        descriptor: &'a ClassDescriptor<'a>,
+        superclass_descriptor: &'a ClassDescriptor<'a>,
+    ) -> bool {
+        self.superclasses_iter(descriptor)
+            .any(|class_descriptor| class_descriptor.name == superclass_descriptor.name)
+    }
+
     /// Finds the default value of a property given its name and a class that
     /// contains or inherits the property. Returns `Some(&Variant)` if a default
     /// value exists, None otherwise.

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -84,13 +84,9 @@ impl<'a> ReflectionDatabase<'a> {
 
     /// This mimics the behavior of the Roblox Lua Instance:IsA(ClassName) method.
     /// Returns whether superclass_descriptor is a superclass of descriptor.
-    pub fn class_is_a(
-        &'a self,
-        descriptor: &'a ClassDescriptor<'a>,
-        superclass_descriptor: &'a ClassDescriptor<'a>,
-    ) -> bool {
-        self.superclasses_iter(descriptor)
-            .any(|class_descriptor| class_descriptor.name == superclass_descriptor.name)
+    pub fn class_is_a(&'a self, class_name: &'a str, superclass_name: &'a str) -> bool {
+        self.superclasses_iter(class_name)
+            .any(|class_descriptor| class_descriptor.name == superclass_name)
     }
 
     /// Finds the default value of a property given its name and a class that

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -86,8 +86,8 @@ impl<'a> ReflectionDatabase<'a> {
         }
     }
 
-    /// Walks the class tree, checking if superclass matches
-    /// any class names the class inherits from
+    /// This mimics the behavior of the Roblox Lua Instance:IsA(ClassName) method.
+    /// Returns whether superclass_descriptor is a superclass of descriptor.
     pub fn class_is_a(
         &'a self,
         descriptor: &'a ClassDescriptor<'a>,

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -46,15 +46,7 @@ mod test {
     #[test]
     fn class_is_a_test() {
         let database = get();
-        let part_class_descriptor = database.classes.get("Part").unwrap();
-        let instance_class_descriptor = database.classes.get("Instance").unwrap();
-        assert_eq!(
-            database.class_is_a(part_class_descriptor, instance_class_descriptor),
-            true
-        );
-        assert_eq!(
-            database.class_is_a(instance_class_descriptor, part_class_descriptor),
-            false
-        );
+        assert_eq!(database.class_is_a("Part", "Instance"), true);
+        assert_eq!(database.class_is_a("Instance", "Part"), false);
     }
 }

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -48,5 +48,7 @@ mod test {
         let database = get();
         assert!(database.class_is_a("Part", "Instance"));
         assert!(!database.class_is_a("Instance", "Part"));
+        assert!(!database.class_is_a("Invalid", "Part"));
+        assert!(!database.class_is_a("Part", "Invalid"));
     }
 }

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -43,4 +43,19 @@ mod test {
         class_descriptor_eq(iter.next(), database.classes.get("Instance"));
         class_descriptor_eq(iter.next(), None);
     }
+
+    #[test]
+    fn class_is_a_test() {
+        let database = get();
+        let part_class_descriptor = database.classes.get("Part").unwrap();
+        let instance_class_descriptor = database.classes.get("Instance").unwrap();
+        assert_eq!(
+            database.class_is_a(part_class_descriptor, instance_class_descriptor),
+            true
+        );
+        assert_eq!(
+            database.class_is_a(instance_class_descriptor, part_class_descriptor),
+            false
+        );
+    }
 }

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -26,8 +26,7 @@ mod test {
     #[test]
     fn superclasses_iter_test() {
         let database = get();
-        let part_class_descriptor = database.classes.get("Part");
-        let mut iter = database.superclasses_iter(part_class_descriptor.unwrap());
+        let mut iter = database.superclasses_iter("Part");
         fn class_descriptor_eq(lhs: Option<&ClassDescriptor>, rhs: Option<&ClassDescriptor>) {
             let eq = match (lhs, rhs) {
                 (Some(lhs), Some(rhs)) => lhs.name == rhs.name,
@@ -36,7 +35,7 @@ mod test {
             };
             assert!(eq, "{:?} != {:?}", lhs, rhs);
         }
-        class_descriptor_eq(iter.next(), part_class_descriptor);
+        class_descriptor_eq(iter.next(), database.classes.get("Part"));
         class_descriptor_eq(iter.next(), database.classes.get("FormFactorPart"));
         class_descriptor_eq(iter.next(), database.classes.get("BasePart"));
         class_descriptor_eq(iter.next(), database.classes.get("PVInstance"));

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -46,7 +46,7 @@ mod test {
     #[test]
     fn class_is_a_test() {
         let database = get();
-        assert_eq!(database.class_is_a("Part", "Instance"), true);
-        assert_eq!(database.class_is_a("Instance", "Part"), false);
+        assert!(database.class_is_a("Part", "Instance"));
+        assert!(!database.class_is_a("Instance", "Part"));
     }
 }


### PR DESCRIPTION
Depends on #452 

I had an idea about how to simplify the implementation of the superclass iterator.  The function signature is more like the Roblox function where invalid class names are ignored and return false.  I could go either way on this.  On the one hand, behaviour does match Roblox better, but forcing the user to provide valid classes has some merit in terms of reporting an error rather than silently failing.