### PR TITLE
Support ContentId in rbx_reflector and rbx_xml

### DIFF
--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -300,7 +300,7 @@ fn variant_type_from_str(type_name: &str) -> Option<VariantType> {
         "Color3" => VariantType::Color3,
         "Color3uint8" => VariantType::Color3uint8,
         "ColorSequence" => VariantType::ColorSequence,
-        "Content" => VariantType::Content,
+        "ContentId" => VariantType::Content,
         "Faces" => VariantType::Faces,
         "Font" => VariantType::Font,
         "Instance" => VariantType::Ref,

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* `Content` data now serializes with `ContentId`, reflecting Roblox's changes. ([#455])
+
+[#455]: https://github.com/rojo-rbx/rbx-dom/pull/455
 
 ## 0.13.5 (2024-08-22)
 * Updated rbx-dom dependencies

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__serialized.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__serialized.snap
@@ -1,5 +1,6 @@
 ---
 source: rbx_xml/src/tests/formatting.rs
+assertion_line: 174
 expression: ser_str
 ---
 <roblox version="4">
@@ -31,13 +32,13 @@ expression: ser_str
         <B>125600</B>
       </Color3>
       <ColorSequence name="TestColorSequence">0 0 0.5 1 0 1 1 0.5 0 0 </ColorSequence>
-      <Content name="TestContent1">
+      <ContentId name="TestContent1">
         <url>Wow!</url>
-      </Content>
-      <Content name="TestContent2">
+      </ContentId>
+      <ContentId name="TestContent2">
         <null>
         </null>
-      </Content>
+      </ContentId>
     </Properties>
     <Item class="TestClass" referent="1">
       <Properties>

--- a/rbx_xml/src/types/mod.rs
+++ b/rbx_xml/src/types/mod.rs
@@ -83,6 +83,10 @@ macro_rules! declare_rbx_types {
                     let value = self::strings::ProtectedStringDummy::read_outer_xml(reader)?;
                     Ok(Some(Variant::String(value.0)))
                 },
+                self::content::ContentDummy::XML_TAG_NAME => {
+                    let value = self::content::ContentDummy::read_outer_xml(reader)?;
+                    Ok(Some(Variant::Content(value.0)))
+                }
 
                 self::referent::XML_TAG_NAME => Ok(Some(Variant::Ref(read_ref(reader, instance_id, property_name, state)?))),
                 self::shared_string::XML_TAG_NAME => read_shared_string(reader, instance_id, property_name, state).map(Some),


### PR DESCRIPTION
Recently (release 645), Roblox renamed their existing `Content` type to `ContentId`. This broke `rbx_reflector` and also means that `rbx_xml` is technically wrong.

Long-term, we should probably rename `Content` to `ContentId` in `rbx_types`. This is breaking though, so for now we can just change what tag is written in `rbx_xml`.