### PR TITLE
Don't create queue in WeakDom::insert for leaf instances

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -147,7 +147,7 @@ impl WeakDom {
         // Fast path: if the builder does not have any children, then we don't have to
         // construct a queue to keep track of descendants for insertion, avoiding a heap
         // allocation.
-        if root_builder.children.len() == 0 {
+        if root_builder.children.is_empty() {
             insert(self, root_builder, parent_ref, None);
         } else {
             // Rather than performing this movement recursively, we instead use a

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -109,16 +109,13 @@ impl WeakDom {
     /// ## Panics
     /// Panics if `parent_ref` is some and does not refer to an instance in the DOM.
     pub fn insert(&mut self, parent_ref: Ref, root_builder: InstanceBuilder) -> Ref {
-        let root_referent = root_builder.referent;
-
-        // Rather than performing this movement recursively, we instead use a
-        // queue that we load the children of each `InstanceBuilder` into.
-        // Then we can just iter through that.
-        let mut queue = VecDeque::with_capacity(1);
-        queue.push_back((parent_ref, root_builder));
-
-        while let Some((parent, builder)) = queue.pop_front() {
-            self.inner_insert(
+        fn insert(
+            dom: &mut WeakDom,
+            builder: InstanceBuilder,
+            parent: Ref,
+            queue: Option<&mut VecDeque<(Ref, InstanceBuilder)>>,
+        ) {
+            dom.inner_insert(
                 builder.referent,
                 Instance {
                     referent: builder.referent,
@@ -131,15 +128,36 @@ impl WeakDom {
             );
 
             if parent.is_some() {
-                self.instances
+                dom.instances
                     .get_mut(&parent)
                     .unwrap_or_else(|| panic!("cannot insert into parent that does not exist"))
                     .children
                     .push(builder.referent);
             }
 
-            for child in builder.children {
-                queue.push_back((builder.referent, child));
+            if let Some(queue) = queue {
+                for child in builder.children {
+                    queue.push_back((builder.referent, child));
+                }
+            }
+        }
+
+        let root_referent = root_builder.referent;
+
+        // Fast path: if the builder does not have any children, then we don't have to
+        // construct a queue to keep track of descendants for insertion, avoiding a heap
+        // allocation.
+        if root_builder.children.len() == 0 {
+            insert(self, root_builder, parent_ref, None);
+        } else {
+            // Rather than performing this movement recursively, we instead use a
+            // queue that we load the children of each `InstanceBuilder` into.
+            // Then we can just iter through that.
+            let mut queue = VecDeque::with_capacity(1);
+            queue.push_back((parent_ref, root_builder));
+
+            while let Some((parent, builder)) = queue.pop_front() {
+                insert(self, builder, parent, Some(&mut queue));
             }
         }
 


### PR DESCRIPTION
This PR adds a fast path for leaf instances to `WeakDom::insert`. When an instance does not have any children, then we don't need to create a queue, avoiding a heap allocation, and can perform the insertion then exit the method immediately.

On my machine, this improves rbx_binary's "Deserialize 10,000 Parts" benchmark by ~4%, and reduces the number of heap allocations by ~7%. Note that the effectiveness of this optimization depends on how many leaf instances the requested insertion has, so this improvement is probably overstated on this benchmark, which contains vastly more leaf instances than internal instances.