### PR TITLE
Reserve space for additional instances in binary deserializer

### DIFF
--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -216,12 +216,14 @@ impl<'db, R: Read> DeserializerState<'db, R> {
         deserializer: &'db Deserializer<'db>,
         mut input: R,
     ) -> Result<Self, InnerError> {
-        let tree = WeakDom::new(InstanceBuilder::new("DataModel"));
+        let mut tree = WeakDom::new(InstanceBuilder::new("DataModel"));
 
         let header = FileHeader::decode(&mut input)?;
 
         let type_infos = HashMap::with_capacity(header.num_types as usize);
         let instances_by_ref = HashMap::with_capacity(1 + header.num_instances as usize);
+
+        tree.reserve(header.num_instances as usize);
 
         Ok(DeserializerState {
             deserializer,

--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -96,7 +96,7 @@ where
 * Added `InstanceBuilder::with_property_capacity`, which can preallocate an `InstanceBuilder`'s property table. [#464]
 * Added `WeakDom::reserve`, which can preallocate additional space for instances in the `WeakDom`. [#465]
 
-[#465]: https://github.com/rojo-rbx/rbx-dom/pull/464
+[#465]: https://github.com/rojo-rbx/rbx-dom/pull/465
 [#464]: https://github.com/rojo-rbx/rbx-dom/pull/464
 
 ## 2.9.0 (2024-08-22)

--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -94,7 +94,9 @@ where
 * Added `UstrMapExt`, a helper trait providing convenience methods `UstrMap::new` and `UstrMap::with_capacity`.
 * Added re-exports for `ustr` (a convenience function for creating `Ustr`s), `Ustr`, `UstrMap`, and `UstrSet`.
 * Added `InstanceBuilder::with_property_capacity`, which can preallocate an `InstanceBuilder`'s property table. [#464]
+* Added `WeakDom::reserve`, which can preallocate additional space for instances in the `WeakDom`. [#465]
 
+[#465]: https://github.com/rojo-rbx/rbx-dom/pull/464
 [#464]: https://github.com/rojo-rbx/rbx-dom/pull/464
 
 ## 2.9.0 (2024-08-22)

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -36,7 +36,6 @@ impl WeakDom {
     /// the WeakDom.
     pub fn reserve(&mut self, additional: usize) {
         self.instances.reserve(additional);
-        self.unique_ids.reserve(additional);
     }
 
     /// Consumes the WeakDom, returning its underlying root ref and backing

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -36,6 +36,7 @@ impl WeakDom {
     /// the WeakDom.
     pub fn reserve(&mut self, additional: usize) {
         self.instances.reserve(additional);
+        self.unique_ids.reserve(additional);
     }
 
     /// Consumes the WeakDom, returning its underlying root ref and backing

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -32,6 +32,12 @@ impl WeakDom {
         dom
     }
 
+    /// Reserve at least enough space for `additional` number of instances in
+    /// the WeakDom.
+    pub fn reserve(&mut self, additional: usize) {
+        self.instances.reserve(additional);
+    }
+
     /// Consumes the WeakDom, returning its underlying root ref and backing
     /// storage. This method is useful when tree-preserving operations are too
     /// slow.


### PR DESCRIPTION
This PR adds a new method `WeakDom::reserve` that can preallocate additional space for instances, and makes the binary deserializer use it before adding instances.

On my machine, this improves rbx_binary's "Deserialize 10,000 Parts" benchmark by ~4%, reduces the number of heap allocations by a negligible amount, but allocates ~2.4MB less memory. 

I'm not sure if this should also call `reserve` on `WeakDom.unique_ids`, because UniqueIds won't always be present in inputs, and it could take a possibly significant amount of space for no reason.