### PR TITLE
Use UstrSet for TypeInfo.properties_visited and TypeInfo.aliases

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::{Borrow, Cow},
-    collections::{btree_map, BTreeMap, BTreeSet},
+    collections::{btree_map, BTreeMap},
     convert::TryInto,
     io::Write,
 };
@@ -129,7 +129,7 @@ struct PropInfo<'db> {
     /// allocate) in most cases. However, if an instance is missing a property
     /// from its canonical name, but does have another variant, we can use this
     /// set to recover and map those values.
-    aliases: BTreeSet<Ustr>,
+    aliases: UstrSet,
 
     /// The default value for this property that should be used if any instances
     /// are missing this property.
@@ -206,7 +206,7 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
                 PropInfo {
                     prop_type: Type::String,
                     serialized_name: "Name".into(),
-                    aliases: BTreeSet::new(),
+                    aliases: UstrSet::new(),
                     default_value: Cow::Owned(Variant::String(String::new())),
                     migration: None,
                 },
@@ -457,7 +457,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                     PropInfo {
                         prop_type: ser_type,
                         serialized_name,
-                        aliases: BTreeSet::new(),
+                        aliases: UstrSet::new(),
                         default_value,
                         migration,
                     },

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -5,7 +5,7 @@ use std::{
     io::Write,
 };
 
-use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use ahash::{HashMap, HashMapExt, HashSetExt};
 use rbx_dom_weak::{
     types::{
         Attributes, Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
@@ -14,7 +14,7 @@ use rbx_dom_weak::{
         SecurityCapabilities, SharedString, Tags, UDim, UDim2, UniqueId, Variant, VariantType,
         Vector2, Vector3, Vector3int16,
     },
-    Instance, Ustr, WeakDom,
+    Instance, Ustr, UstrSet, WeakDom,
 };
 
 use rbx_reflection::{
@@ -99,7 +99,7 @@ struct TypeInfo<'dom, 'db> {
     /// A set containing the properties that we have seen so far in the file and
     /// processed. This helps us avoid traversing the reflection database
     /// multiple times if there are many copies of the same kind of instance.
-    properties_visited: HashSet<(Ustr, VariantType)>,
+    properties_visited: UstrSet,
 }
 
 /// A property on a specific class that our serializer knows about.
@@ -218,7 +218,7 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
                 instances: Vec::new(),
                 properties,
                 class_descriptor,
-                properties_visited: HashSet::new(),
+                properties_visited: UstrSet::new(),
             });
         }
 
@@ -330,19 +330,14 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                 }
             }
 
-            // Skip this property+value type pair if we've already seen it.
-            if type_info
-                .properties_visited
-                .contains(&(*prop_name, prop_value.ty()))
-            {
+            // Skip this property if we've already seen it.
+            if type_info.properties_visited.contains(prop_name) {
                 continue;
             }
 
             // ...but add it to the set of visited properties if we haven't seen
             // it.
-            type_info
-                .properties_visited
-                .insert((*prop_name, prop_value.ty()));
+            type_info.properties_visited.insert(*prop_name);
 
             let canonical_name;
             let serialized_name;


### PR DESCRIPTION
For better rbx_binary serialization performance, this PR changes the type of `TypeInfo.properties_visited` from `HashSet<(Ustr, VariantType)>` to `UstrSet`, and changes the type of `TypeInfo.aliases` from `BTreeSet<Ustr>` to `UstrSet`. These changes are sound because:

*  The second tuple field in `TypeInfo.properties_visited` entries is not used for anything outside of the collection, and it's impossible for an instance to contain two properties that have the same name, but different types.
* The order of `TypeInfo.aliases` is unimportant. 

On my machine, serialization benchmark results compared to latest master are as follows:
```
100 Folders/Serialize   time:   [20.219 µs 20.256 µs 20.298 µs]                                   
                        thrpt:  [37.165 MiB/s 37.242 MiB/s 37.309 MiB/s]
                 change:
                        time:   [-2.1144% -1.9337% -1.7269%] (p = 0.00 < 0.05)
                        thrpt:  [+1.7573% +1.9719% +2.1600%]
                        Performance has improved.

100 Deep Folders/Serialize                                                                             
                        time:   [22.818 µs 22.837 µs 22.858 µs]
                        thrpt:  [33.001 MiB/s 33.032 MiB/s 33.060 MiB/s]
                 change:
                        time:   [-2.5076% -2.3625% -2.2207%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2711% +2.4196% +2.5721%]
                        Performance has improved.

100 100-line ModuleScripts/Serialize                                                                            
                        time:   [76.197 µs 76.256 µs 76.313 µs]
                        thrpt:  [48.338 MiB/s 48.374 MiB/s 48.412 MiB/s]
                 change:
                        time:   [+0.9836% +1.5364% +2.1002%] (p = 0.00 < 0.05)
                        thrpt:  [-2.0570% -1.5131% -0.9740%]
                        Change within noise threshold.

1,000 Parts/Serialize   time:   [1.3277 ms 1.3290 ms 1.3303 ms]                                   
                        thrpt:  [3.1464 MiB/s 3.1495 MiB/s 3.1526 MiB/s]
                 change:
                        time:   [-6.6982% -6.5511% -6.4099%] (p = 0.00 < 0.05)
                        thrpt:  [+6.8490% +7.0104% +7.1791%]
                        Performance has improved.
```