### PR TITLE
Don't bail on attempt to reflect unknown serialized data types

### DIFF
--- a/rbx_reflector/src/cli/generate.rs
+++ b/rbx_reflector/src/cli/generate.rs
@@ -227,12 +227,18 @@ fn apply_dump(database: &mut ReflectionDatabase, dump: &Dump) -> anyhow::Result<
                             // are usually only present in Roblox Studio
                             // settings files. They are not used otherwise and
                             // can safely be ignored.
-                            (None, PropertyKind::Canonical {
-                                serialization: PropertySerialization::Serializes
-                            }) if type_name != "QDir" && type_name != "QFont"  => bail!(
+                            (
+                                None,
+                                PropertyKind::Canonical {
+                                    serialization: PropertySerialization::Serializes,
+                                },
+                            ) if type_name != "QDir" && type_name != "QFont" => {
+                                log::warn!(
                                 "Property {}.{} serializes, but its data type ({}) is unimplemented",
                                 dump_class.name, dump_property.name, type_name
-                            ),
+                            );
+                                continue;
+                            }
 
                             // The data type does not have a corresponding a
                             // VariantType, and it does not serialize (with QDir
@@ -241,7 +247,11 @@ fn apply_dump(database: &mut ReflectionDatabase, dump: &Dump) -> anyhow::Result<
                             // need to know about data types that are never
                             // serialized.
                             (None, _) => {
-                                ignored_properties.push((&dump_class.name, &dump_property.name, type_name));
+                                ignored_properties.push((
+                                    &dump_class.name,
+                                    &dump_property.name,
+                                    type_name,
+                                ));
                                 continue;
                             }
                         }


### PR DESCRIPTION
Currently, `rbx_reflector generate` bails immediately upon encountering a unknown serialized data type. This lets us know when we might need to implement a new data type, but it's kind of annoying to know only that there's a least one property that has the data type, and for the command to fail completely instead of generating a database.

This PR makes `rbx_reflector generate` print a warning and continue when encountering unknown serialized data types, rather than bailing. This allows the operator to see all of the properties, instead of just one, and will also actually generate the database.