### PR TITLE
Add rbx_binary Miner's Haven benchmark and readme

### DIFF
--- a/rbx_binary/benches/README.md
+++ b/rbx_binary/benches/README.md
@@ -1,0 +1,39 @@
+# `rbx_binary` Benchmark Suite
+
+This directory contains a suite of benchmarks used to measure the performance of the `rbx_binary` serializer and deserializer.
+
+### Adding a new benchmark
+
+To add a new benchmark, first add the file you'd like to measure performance against to the `files` directory. Then, add a new benchmark function to `suite/main.rs`, like this:
+```rust
+pub fn my_benchmark(c: &mut Criterion) {
+    bench(
+        &mut c.benchmark_group("My Benchmark")
+        include_bytes!("../files/bench-file.rbxl"),
+    )
+}
+```
+and also make sure to add your benchmark function to the `criterion_group!` macro invocation.
+
+Benchmark groups provide a number of configuration options which are useful under different circumstances. See the [Criterion.rs benchmark configuration documentation](https://bheisler.github.io/criterion.rs/book/user_guide/advanced_configuration.html) for details.
+
+### Running the benchmarks
+
+To run all benchmarks, run the following command somewhere in the `rbx_binary` crate directory:
+```bash
+cargo bench
+```
+
+To run a specific benchmark, run the following command somewhere in the `rbx_binary` crate directory, subsituting `My Benchmark` with the name of the benchmark group:
+```bash
+cargo bench "My Benchmark"
+```
+
+To measure only serialization or deserialization, add `/Serialize` or `/Deserialize` to the end of the benchmark name, like this:
+```bash
+cargo bench "My Benchmark/Serialize"
+```
+
+Once the benchmark is complete, an HTML report will be generated at `rbx-dom/target/criterion/reports/index.html` that contains detailed statistics collected during the run. This file can be opened in a web browser.
+
+For more information, see the [Criterion.rs documentation](https://bheisler.github.io/criterion.rs/book/).

--- a/rbx_binary/benches/suite/main.rs
+++ b/rbx_binary/benches/suite/main.rs
@@ -32,12 +32,21 @@ pub fn parts_1000(c: &mut Criterion) {
     )
 }
 
+pub fn miners_haven(c: &mut Criterion) {
+    bench(
+        c.benchmark_group("Miner's Haven")
+            .sampling_mode(SamplingMode::Flat),
+        include_bytes!("../files/miners-haven.rbxl"),
+    )
+}
+
 criterion_group!(
     bench_suite,
     folders_100,
     deep_folders_100,
     modulescripts_100_lines_100,
     parts_1000,
+    miners_haven,
 );
 
 criterion_main!(bench_suite);

--- a/rbx_binary/benches/suite/util.rs
+++ b/rbx_binary/benches/suite/util.rs
@@ -12,6 +12,11 @@ fn serialize_bench<T: Measurement>(group: &mut BenchmarkGroup<T>, buffer: &[u8])
 
     rbx_binary::to_writer(&mut buffer, &tree, &[root_ref]).unwrap();
     let buffer_len = buffer.len();
+    let batch_size = if buffer_len > 1024 {
+        BatchSize::LargeInput
+    } else {
+        BatchSize::SmallInput
+    };
 
     group
         .throughput(Throughput::Bytes(buffer_len as u64))
@@ -21,7 +26,7 @@ fn serialize_bench<T: Measurement>(group: &mut BenchmarkGroup<T>, buffer: &[u8])
                 |mut buffer: Vec<u8>| {
                     rbx_binary::to_writer(&mut buffer, &tree, &[root_ref]).unwrap();
                 },
-                BatchSize::SmallInput,
+                batch_size,
             )
         });
 }


### PR DESCRIPTION
This PR adds a benchmark for Miner's Haven, a real-world Roblox game that is open sourced at https://github.com/berezaa/minershaven. It's representative of workloads rbx_binary will see most often.

It also adds a readme that documents how the benchmark suite works and how to use it. 