### PR TITLE
Fix EnumItem not respecting serde feature in field rename

### DIFF
--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -36,7 +36,7 @@ impl Enum {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize,))]
 pub struct EnumItem {
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub ty: String,
     pub value: u32,
 }


### PR DESCRIPTION
This PR fixes an issue introduced in #470 where a configuration attribute did not respect the rbx_types' `serde`features, causing compilation to fail when building the crate without the `serde` feature enabled.