### PR TITLE
Add WeakDom::from_raw

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -102,11 +102,13 @@ pub fn into_raw(self) -> (Ref, AHashMap<Ref, Instance>) {
 * Added `HashMapExt`, a helper trait providing convenience methods `UstrMap::new`, `UstrMap::with_capacity`, `AHashMap::new`, and `AHashMap::with_capacity`.
 * Added re-exports for `AHashMap`.
 * Added re-exports for `ustr` (a convenience function for creating `Ustr`s), `Ustr`, `UstrMap`, and `UstrSet`.
-* Added `InstanceBuilder::with_property_capacity`, which can preallocate an `InstanceBuilder`'s property table. [#464]
-* Added `WeakDom::reserve`, which can preallocate additional space for instances in the `WeakDom`. [#465]
+* Added `InstanceBuilder::with_property_capacity`, which can preallocate an `InstanceBuilder`'s property table. ([#464])
+* Added `WeakDom::reserve`, which can preallocate additional space for instances in the `WeakDom`. ([#465])
+* Added `WeakDom::from_raw` to provide the inverse for `WeakDom::into_raw`. ([#482])
 
 [#465]: https://github.com/rojo-rbx/rbx-dom/pull/465
 [#464]: https://github.com/rojo-rbx/rbx-dom/pull/464
+[#482]: https://github.com/rojo-rbx/rbx-dom/pull/482
 
 ## 2.9.0 (2024-08-22)
 * Added `WeakDom::descendants` and `WeakDom::descendants_of` to support iterating through the descendants of a DOM. ([#431])

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -972,4 +972,24 @@ mod test {
 
         let _ = WeakDom::from_raw(root, tree);
     }
+
+    #[test]
+    fn from_raw_normal_unique_id() {
+        let mut dom = WeakDom::new(InstanceBuilder::new("ROOT"));
+
+        let inst_ref_1 = dom.insert(dom.root_ref(), InstanceBuilder::new("Folder"));
+        let inst_ref_2 = dom.insert(dom.root_ref(), InstanceBuilder::new("Folder"));
+        let (root, mut tree) = dom.into_raw();
+
+        tree.get_mut(&inst_ref_1)
+            .unwrap()
+            .properties
+            .insert(ustr("UniqueId"), UniqueId::now().unwrap().into());
+        tree.get_mut(&inst_ref_2)
+            .unwrap()
+            .properties
+            .insert(ustr("UniqueId"), UniqueId::now().unwrap().into());
+
+        let _ = WeakDom::from_raw(root, tree);
+    }
 }

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -56,7 +56,7 @@ impl WeakDom {
         for inst in instances.values() {
             match inst.properties.get(&ustr("UniqueId")) {
                 Some(Variant::UniqueId(id)) => {
-                    if unique_ids.insert(*id) {
+                    if !unique_ids.insert(*id) {
                         panic!(
                             "UniqueId {} is duplicated in the provided `instances` map",
                             id


### PR DESCRIPTION
When reading files, we produce `WeakDom`s with one root that has multiple children. This allows for e.g. model files to have multiple roots, despite our DOMs only support one.

However, if you want to get a DOM read from a file and have one of the children at the root (as in e.g. Rojo) you need to jump through some hoops. The current way to handle that is essentially:

- Make a new `WeakDom` with the right class at the root
- Transfer children of the Instance into the new DOM
- Transfer properties from the Instance to the new DOM's root

This is fine, except that it breaks Ref properties: since you can't overwrite the root of a DOM, you have to make a new DOM, which means that inserting the other Instances creates new referents for each of them. Solving this is non-trivial because it requires tracking ref properties and overwriting them, which is slow.

A solution to this is to allow constructing a WeakDom given a root referent and a tree of Instances. In practice this allows you to just replace the root referent of a DOM and reconstruct a tree, which we could allow separately, but I feel this is the path of least resistance.

There's a view invariants we have to uphold, but they're easy enough to check. Everything else is up to the caller to maintain.