### PR TITLE
Added NaN protections

### DIFF
--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -313,7 +313,12 @@ types = {
 			local keypoints = {}
 
 			for index, keypoint in ipairs(pod.keypoints) do
-				keypoints[index] = NumberSequenceKeypoint.new(keypoint.time, keypoint.value or 0, keypoint.envelope)
+				-- TODO: Add a test for NaN or Infinity values and envelopes
+				-- Right now it isn't possible because it'd fail the roundtrip.
+				-- It's more important that it works right now, though.
+				local value = keypoint.value or 0
+				local envelope = keypoint.envelope or 0
+				keypoints[index] = NumberSequenceKeypoint.new(keypoint.time, value, envelope)
 			end
 
 			return NumberSequence.new(keypoints)

--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -313,7 +313,7 @@ types = {
 			local keypoints = {}
 
 			for index, keypoint in ipairs(pod.keypoints) do
-				keypoints[index] = NumberSequenceKeypoint.new(keypoint.time, keypoint.value, keypoint.envelope)
+				keypoints[index] = NumberSequenceKeypoint.new(keypoint.time, keypoint.value or 0, keypoint.envelope)
 			end
 
 			return NumberSequence.new(keypoints)


### PR DESCRIPTION
Earlier this week I encountered some rbxm files that appeared to have the values of some NumberSequenceKeypoints as NaN. This would cause the rojo sync to fail as that value was being serialized as nil. Adding a zero here allowed the sync to complete successfully.