### PR TITLE
Fix Roblox Studio crashing when using `rbx_reflector`

### DIFF
--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -136,9 +136,10 @@ fn generate_place_with_all_classes(path: &PathBuf, dump: &Dump) -> anyhow::Resul
             | "InternalSyncItem" => continue,
 
             // Settings singletons cannot be put into a DataModel. This changed
-            // in release 653.
+            // in release 653 and 657.
             "DebugSettings" | "GameSettings" | "LuaSettings" | "NetworkSettings"
-            | "PhysicsSettings" | "RenderSettings" | "Studio" | "TaskScheduler" => continue,
+            | "PhysicsSettings" | "RenderSettings" | "Studio" | "TaskScheduler"
+            | "UserGameSettings" => continue,
 
             // This class will cause studio to crash on close.
             "VoiceSource" => continue,


### PR DESCRIPTION
In [657](https://robloxapi.github.io/ref/updates/2025.html#version-96b5c87ce0ce4dff) `UserGameSettings` can no longer be inside a DataModel - same fix as in #481.