### PR TITLE
Generic WeakDom using AsRef<Instance>

### DIFF
--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -21,11 +21,12 @@ pub use self::error::Error;
 /// use std::io::BufReader;
 ///
 /// use rbx_binary::Deserializer;
+/// use rbx_dom_weak::WeakDom;
 ///
 /// let input = BufReader::new(File::open("File.rbxm")?);
 ///
 /// let deserializer = Deserializer::new();
-/// let dom = deserializer.deserialize(input)?;
+/// let dom: WeakDom = deserializer.deserialize(input)?;
 ///
 /// // rbx_binary always returns a DOM with a DataModel at the top level.
 /// // To get to the instances from our file, we need to go one level deeper.

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -4,7 +4,7 @@ mod state;
 
 use std::{io::Read, str};
 
-use rbx_dom_weak::WeakDom;
+use rbx_dom_weak::{GenericWeakDom, Instance};
 use rbx_reflection::ReflectionDatabase;
 
 use self::state::DeserializerState;
@@ -66,7 +66,10 @@ impl<'db> Deserializer<'db> {
 
     /// Deserialize a Roblox binary model or place from the given stream using
     /// this deserializer.
-    pub fn deserialize<R: Read>(&self, reader: R) -> Result<WeakDom, Error> {
+    pub fn deserialize<R: Read, I>(&self, reader: R) -> Result<GenericWeakDom<I>, Error>
+    where
+        I: AsMut<Instance> + From<Instance>,
+    {
         profiling::scope!("rbx_binary::deserialize");
 
         let mut deserializer = DeserializerState::new(self, reader)?;

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -67,7 +67,7 @@ mod tests;
 
 use std::io::{Read, Write};
 
-use rbx_dom_weak::{types::Ref, WeakDom};
+use rbx_dom_weak::{types::Ref, GenericWeakDom, Instance};
 
 /// An unstable textual format that can be used to debug binary models.
 #[cfg(feature = "unstable_text_format")]
@@ -81,12 +81,37 @@ pub use crate::{
 };
 
 /// Deserialize a Roblox binary model or place from a stream.
-pub fn from_reader<R: Read>(reader: R) -> Result<WeakDom, DecodeError> {
+pub fn from_reader<R: Read>(reader: R) -> Result<GenericWeakDom<Instance>, DecodeError> {
+    Deserializer::new().deserialize(reader)
+}
+
+/// Deserialize a Roblox binary model or place from a stream.  Deserializes to a GenericWeakDom.
+pub fn from_reader_generic<R: Read, I>(reader: R) -> Result<GenericWeakDom<I>, DecodeError>
+where
+    I: AsMut<Instance> + From<Instance>,
+{
     Deserializer::new().deserialize(reader)
 }
 
 /// Serializes a subset of the given DOM to a binary format model or place,
 /// writing to something that implements the `std::io::Write` trait.
-pub fn to_writer<W: Write>(writer: W, dom: &WeakDom, refs: &[Ref]) -> Result<(), EncodeError> {
+pub fn to_writer<W: Write>(
+    writer: W,
+    dom: &GenericWeakDom<Instance>,
+    refs: &[Ref],
+) -> Result<(), EncodeError> {
+    Serializer::new().serialize(writer, dom, refs)
+}
+
+/// Serializes a subset of the given DOM to a binary format model or place,
+/// writing to something that implements the `std::io::Write` trait.
+pub fn to_writer_generic<W: Write, I>(
+    writer: W,
+    dom: &GenericWeakDom<I>,
+    refs: &[Ref],
+) -> Result<(), EncodeError>
+where
+    I: AsRef<Instance>,
+{
     Serializer::new().serialize(writer, dom, refs)
 }

--- a/rbx_binary/src/serializer/mod.rs
+++ b/rbx_binary/src/serializer/mod.rs
@@ -3,7 +3,7 @@ mod state;
 
 use std::io::Write;
 
-use rbx_dom_weak::{types::Ref, WeakDom};
+use rbx_dom_weak::{types::Ref, GenericWeakDom, Instance};
 use rbx_reflection::ReflectionDatabase;
 
 use self::state::SerializerState;
@@ -75,7 +75,15 @@ impl<'db> Serializer<'db> {
 
     /// Serialize a Roblox binary model or place into the given stream using
     /// this serializer.
-    pub fn serialize<W: Write>(&self, writer: W, dom: &WeakDom, refs: &[Ref]) -> Result<(), Error> {
+    pub fn serialize<W: Write, I>(
+        &self,
+        writer: W,
+        dom: &GenericWeakDom<I>,
+        refs: &[Ref],
+    ) -> Result<(), Error>
+    where
+        I: AsRef<Instance>,
+    {
         profiling::scope!("rbx_binary::seserialize");
 
         let mut serializer = SerializerState::new(self, dom, writer);

--- a/rbx_binary/src/tests/util.rs
+++ b/rbx_binary/src/tests/util.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use rbx_dom_weak::DomViewer;
+use rbx_dom_weak::{DomViewer, WeakDom};
 
 use crate::{from_reader, text_deserializer::DecodedModel, to_writer};
 
@@ -51,5 +51,5 @@ pub fn run_model_base_suite(model_path: impl AsRef<Path>) {
     // We don't make any assertions about the result right now, as our format
     // support is still lacking. In the future, we should assert that this is
     // the same as the original decoding of the test file.
-    from_reader(encoded.as_slice()).unwrap();
+    let _: WeakDom = from_reader(encoded.as_slice()).unwrap();
 }

--- a/rbx_dom_weak/src/instance.rs
+++ b/rbx_dom_weak/src/instance.rs
@@ -237,3 +237,14 @@ impl Instance {
         self.parent
     }
 }
+
+impl AsRef<Instance> for Instance {
+    fn as_ref(&self) -> &Instance {
+        self
+    }
+}
+impl AsMut<Instance> for Instance {
+    fn as_mut(&mut self) -> &mut Instance {
+        self
+    }
+}

--- a/rbx_dom_weak/src/lib.rs
+++ b/rbx_dom_weak/src/lib.rs
@@ -51,10 +51,12 @@ pub use ahash::AHashMap;
 pub use ustr::{ustr, Ustr, UstrMap, UstrSet};
 
 pub use crate::{
-    dom::WeakDom,
+    dom::WeakDom as GenericWeakDom,
     instance::{Instance, InstanceBuilder},
     viewer::{DomViewer, ViewedInstance},
 };
+/// Convenience type of GenericWeakDom<Instance>
+pub type WeakDom = GenericWeakDom<Instance>;
 
 /// Helper trait that provides convenience methods for `AHashMap` and `UstrMap`.
 pub trait HashMapExt {

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -125,7 +125,7 @@ mod tests;
 
 use std::io::{Read, Write};
 
-use rbx_dom_weak::{types::Ref, WeakDom};
+use rbx_dom_weak::{types::Ref, GenericWeakDom, Instance, WeakDom};
 
 use crate::{deserializer::decode_internal, serializer::encode_internal};
 
@@ -138,6 +138,18 @@ pub use crate::{
 /// Decodes an XML-format model or place from something that implements the
 /// `std::io::Read` trait.
 pub fn from_reader<R: Read>(reader: R, options: DecodeOptions) -> Result<WeakDom, DecodeError> {
+    decode_internal(reader, options)
+}
+
+/// Decodes an XML-format model or place from something that implements the
+/// `std::io::Read` trait.  Decodes to a GenericWeakDom.
+pub fn from_reader_generic<R: Read, I>(
+    reader: R,
+    options: DecodeOptions,
+) -> Result<GenericWeakDom<I>, DecodeError>
+where
+    I: AsRef<Instance> + AsMut<Instance> + From<Instance>,
+{
     decode_internal(reader, options)
 }
 
@@ -163,6 +175,17 @@ pub fn from_str_default<S: AsRef<str>>(reader: S) -> Result<WeakDom, DecodeError
 pub fn to_writer<W: Write>(
     writer: W,
     tree: &WeakDom,
+    ids: &[Ref],
+    options: EncodeOptions,
+) -> Result<(), EncodeError> {
+    encode_internal(writer, tree, ids, options)
+}
+
+/// Serializes a subset of the given tree to an XML format model or place,
+/// writing to something that implements the `std::io::Write` trait.
+pub fn to_writer_generic<W: Write, I: AsRef<Instance>>(
+    writer: W,
+    tree: &GenericWeakDom<I>,
     ids: &[Ref],
     options: EncodeOptions,
 ) -> Result<(), EncodeError> {

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::BTreeMap, io::Write};
 use ahash::{HashMap, HashMapExt};
 use rbx_dom_weak::{
     types::{Ref, SharedString, SharedStringHash, Variant, VariantType},
-    WeakDom,
+    GenericWeakDom, Instance,
 };
 use rbx_reflection::{DataType, PropertyKind, PropertySerialization, ReflectionDatabase};
 
@@ -16,9 +16,9 @@ use crate::{
 
 use crate::serializer_core::{XmlEventWriter, XmlWriteEvent};
 
-pub fn encode_internal<W: Write>(
+pub fn encode_internal<W: Write, I: AsRef<Instance>>(
     output: W,
-    tree: &WeakDom,
+    tree: &GenericWeakDom<I>,
     ids: &[Ref],
     options: EncodeOptions,
 ) -> Result<(), NewEncodeError> {
@@ -160,14 +160,14 @@ impl<'db> EmitState<'db> {
 ///
 /// `property_buffer` is a Vec that can be reused between calls to
 /// serialize_instance to make sorting properties more efficient.
-fn serialize_instance<'dom, W: Write>(
+fn serialize_instance<'dom, W: Write, I: AsRef<Instance>>(
     writer: &mut XmlEventWriter<W>,
     state: &mut EmitState,
-    tree: &'dom WeakDom,
+    tree: &'dom GenericWeakDom<I>,
     id: Ref,
     property_buffer: &mut Vec<(&'dom str, &'dom Variant)>,
 ) -> Result<(), NewEncodeError> {
-    let instance = tree.get_by_ref(id).unwrap();
+    let instance = tree.get_by_ref(id).unwrap().as_ref();
     let mapped_id = state.map_id(id);
 
     writer.write(

--- a/rbx_xml/src/tests/basic.rs
+++ b/rbx_xml/src/tests/basic.rs
@@ -22,7 +22,7 @@ fn with_bool() {
         </roblox>
     "#;
 
-    let tree = crate::from_str_default(document).unwrap();
+    let tree: WeakDom = crate::from_str_default(document).unwrap();
 
     let root = tree.root();
     let child = tree.get_by_ref(root.children()[0]).unwrap();
@@ -49,7 +49,7 @@ fn read_tags() {
         </roblox>
     "#;
 
-    let dom = crate::from_str_default(document).unwrap();
+    let dom: WeakDom = crate::from_str_default(document).unwrap();
     let folder = dom.get_by_ref(dom.root().children()[0]).unwrap();
 
     let mut tags = Tags::new();
@@ -112,7 +112,7 @@ fn read_attributes() {
         </roblox>
     "#;
 
-    let dom = crate::from_str_default(document).unwrap();
+    let dom: WeakDom = crate::from_str_default(document).unwrap();
     let folder = dom.get_by_ref(dom.root().children()[0]).unwrap();
 
     assert_eq!(folder.properties.get(&"AttributesSerialize".into()), None);
@@ -223,7 +223,7 @@ fn read_material_colors() {
         </roblox>
     "#;
 
-    let dom = crate::from_str_default(document).unwrap();
+    let dom: WeakDom = crate::from_str_default(document).unwrap();
     let terrain = dom.get_by_ref(dom.root().children()[0]).unwrap();
 
     if let Some(Variant::MaterialColors(colors)) = terrain.properties.get(&"MaterialColors".into())
@@ -266,7 +266,7 @@ fn read_unique_id() {
         </roblox>
     "#;
 
-    let tree = crate::from_str(
+    let tree: WeakDom = crate::from_str(
         document,
         crate::DecodeOptions::new()
             // This is necessary at the moment because we do not actually
@@ -309,7 +309,7 @@ fn number_widening() {
             </Item>
         </roblox>
     "#;
-    let tree = crate::from_str_default(document).unwrap();
+    let tree: WeakDom = crate::from_str_default(document).unwrap();
 
     let int_value = tree.get_by_ref(tree.root().children()[0]).unwrap();
     assert_eq!(int_value.class, "IntValue");
@@ -366,7 +366,7 @@ fn enum_item_to_enum() {
     let mut encoded = Vec::new();
     crate::to_writer_default(&mut encoded, &tree, &[tree.root_ref()]).unwrap();
 
-    let decoded = crate::from_reader_default(encoded.as_slice()).unwrap();
+    let decoded: WeakDom = crate::from_reader_default(encoded.as_slice()).unwrap();
     let prop_type = decoded
         .get_by_ref(*decoded.root().children().first().unwrap())
         .unwrap()

--- a/rbx_xml/src/types/mod.rs
+++ b/rbx_xml/src/types/mod.rs
@@ -43,6 +43,7 @@ use rbx_dom_weak::types::{
     SecurityCapabilities, UDim, UDim2, UniqueId, Variant, Vector2, Vector2int16, Vector3,
     Vector3int16,
 };
+use rbx_dom_weak::Instance;
 
 use crate::{
     core::XmlType,
@@ -69,9 +70,9 @@ macro_rules! declare_rbx_types {
 
         /// Reads a Roblox property value with the given type from the XML event
         /// stream.
-        pub fn read_value_xml<R: Read>(
+        pub fn read_value_xml<R: Read,I:AsRef<Instance>>(
             reader: &mut XmlEventReader<R>,
-            state: &mut ParseState,
+            state: &mut ParseState<'_,'_,I>,
             xml_type_name: &str,
             instance_id: Ref,
             property_name: &str,

--- a/rbx_xml/src/types/referent.rs
+++ b/rbx_xml/src/types/referent.rs
@@ -12,6 +12,7 @@
 use std::io::{Read, Write};
 
 use rbx_dom_weak::types::Ref;
+use rbx_dom_weak::Instance;
 
 use crate::{
     deserializer::ParseState,
@@ -42,11 +43,11 @@ pub fn write_ref<W: Write>(
     Ok(())
 }
 
-pub fn read_ref<R: Read>(
+pub fn read_ref<R: Read, I: AsRef<Instance>>(
     reader: &mut XmlEventReader<R>,
     id: Ref,
     property_name: &str,
-    state: &mut ParseState,
+    state: &mut ParseState<'_, '_, I>,
 ) -> Result<Ref, DecodeError> {
     let ref_contents = reader.read_tag_contents(XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/shared_string.rs
+++ b/rbx_xml/src/types/shared_string.rs
@@ -34,11 +34,11 @@ pub fn write_shared_string<W: Write>(
     Ok(())
 }
 
-pub fn read_shared_string<R: Read>(
+pub fn read_shared_string<R: Read, I>(
     reader: &mut XmlEventReader<R>,
     referent: Ref,
     property_name: &str,
-    state: &mut ParseState,
+    state: &mut ParseState<'_, '_, I>,
 ) -> Result<Variant, DecodeError> {
     let contents = reader.read_tag_contents(XML_TAG_NAME)?;
 


### PR DESCRIPTION
Hey I had this idea for allowing WeakDom to be usable with a generic type parameter.  The problem I am trying to solve is that additional metadata about instances (such as `RBXScriptSignal`) cannot be directly owned by the WeakDom.  Each additional piece of metadata has to live in a `HashMap<Ref,_>` somewhere else and be managed every time the dom is updated, so this essentially becomes a garbage collection problem.  Let me know your thoughts!

<details>
<summary>Here's a code example of how I imagine this being used:</summary>

```Rust
use my_lib::RBXScriptSignal;
use rbx_dom_weak::{GenericWeakDom, Instance, InstanceBuilder};

struct MyInstance {
    instance: Instance,
    render_stepped: RBXScriptSignal,
}
impl AsRef<Instance> for MyInstance {
    fn as_ref(&self) -> &Instance {
        &self.instance
    }
}
impl AsMut<Instance> for MyInstance {
    fn as_mut(&mut self) -> &mut Instance {
        &mut self.instance
    }
}
impl From<Instance> for MyInstance {
    fn from(instance: Instance) -> Self {
        Self {
            instance,
            render_stepped: RBXScriptSignal::new(),
        }
    }
}
impl Into<Instance> for MyInstance {
    fn into(self) -> Instance {
        self.instance
    }
}

fn main() {
    let builder = InstanceBuilder::new("RunService");

    let cool_dom = GenericWeakDom::<MyInstance>::new(builder);

    dbg!(cool_dom.root().render_stepped);
}
```

Of course `MyInstance` would have some sort of collection of `RBXScriptSignal` instead of every instance having a `render_stepped` property, but this is just an example.

</details>