### PR TITLE
Fix `Lister` utility in `rbx_types`

### DIFF
--- a/rbx_types/src/lister.rs
+++ b/rbx_types/src/lister.rs
@@ -11,10 +11,11 @@ impl Lister {
     }
 
     pub fn write(&mut self, out: &mut fmt::Formatter, label: impl fmt::Display) -> fmt::Result {
-        if !self.first {
-            write!(out, ", ")?;
+        if self.first {
+            self.first = false;
+            write!(out, "{}", label)
+        } else {
+            write!(out, ", {}", label)
         }
-
-        write!(out, "{}", label)
     }
 }


### PR DESCRIPTION
~This is _technically_ a breaking change (?), but I don't think anyone is using the `fmt::Debug` output for Axes and Faces (the only uses in the entire crate) programmatically in a way that would break if we changed this.~

Actually, apparently `Debug` is unstable [(at least for derived `Debug` and the standard library)](https://doc.rust-lang.org/std/fmt/trait.Debug.html#stability), so I guess it isn't even a breaking change.