### PR TITLE
Document `Content` type in spec files

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -9,6 +9,7 @@ This document is based on:
 - [rbxfile by Anaminus](https://github.com/RobloxAPI/rbxfile)
 - [Roblox-File-Format by CloneTrooper1019](https://github.com/CloneTrooper1019/Roblox-File-Format)
 - Observing `rbxm` and `rbxl` output from Roblox Studio
+- Information directly communicated by Roblox when necessary
 
 ## Contents
 - [Document Conventions](#document-conventions)
@@ -52,6 +53,7 @@ This document is based on:
 	- [OptionalCoordinateFrame](#optionalcoordinateframe)
 	- [UniqueId](#uniqueid)
 	- [Font](#font)
+	- [Content](#content)
 - [Data Storage Notes](#data-storage-notes)
 	- [Integer Transformations](#integer-transformations)
 	- [Byte Interleaving](#byte-interleaving)
@@ -679,6 +681,42 @@ The `Font` type is a struct composed of two `String` values, a `u8`, and a `u16`
 The `Weight` and `Style` fields are stored as little-endian unsigned integers. These are usually treated like enums, and to assign them in Roblox Studio an Enum is used. Interestingly, the `Weight` is *always* stored as a number in binary and XML, but `Style` is stored as a number in binary and as text in XML.
 
 The `CachedFaceId` field is always present, but is allowed to be an empty string (a string of length `0`). When represented in XML, this property will be omitted if it is an empty string. This property is not visible via any user APIs in Roblox Studio.
+
+### Content
+**Type ID `0x22`**
+
+Note that the [`Content`][Content-type] type should not be confused with the legacy `ContentId` type, which was renamed from `Content` in Roblox release 645.
+
+The `Content` type is a struct composed of the following fields:
+
+| Field Name          | Format          | Value                                                                                        |
+|:--------------------|:----------------|:---------------------------------------------------------------------------------------------|
+| SourceTypes         | Array(`Enum`)   | A list of types for items in this chunk                                                      |
+| UriCount            | `u32`           | Indicates how many items in this chunk are `Uri`s                                            |
+| Uris                | Array(`String`) | A list of the `URI`s for items in this chunk with that type                                  |
+| ObjectCount         | `u32`           | Indicates how many items in this chunk are `Object`s                                         |
+| ObjectRefs          | Array(`Ref`)    | A list of referents for `Object`s for items in this chunk                                    |
+| ExternalObjectCount | `u32`           | Indicates how many items in this chunk are `Objects` that are **external** to this file      |
+| ExternalObjectRefs  | Array(`Ref`)    | A list of referents for `Object`s for items in this chunk that are **external** to this file |
+
+`SourceTypes` is a series of values representing a type for a given `Content`. At this moment it can have one of three values:
+
+| Name    | Value |
+|:--------|:------|
+| `None`  | `0`   |
+| `Uri`   | `1`   |
+| `Object`| `2`   |
+
+`Uris` is an array `UriCount` elements long which contains a sequential list of every `Uri` included in `SourceTypes`.
+
+`ObjectRefs` is a [referent array](#referent) that is `ObjectCount` elements long and contains a list of referents pointing to [`Object`][Object-class]s that can be used for `Content`, such as `EditableImage`.
+
+`ExternalObjectRefs` is similar in purpose to `ObjectRefs` but contains a list of referents that are external to this file. This is used internally by Roblox to support copy and pasting. Both `ExternalObjectCount` and `ExternalObjectRefs` are generally not applicable to implementors, because referents are not static outside of files. They are included for completeness's sake, but implementing support for them is impossible for most people.
+
+Note that `Object`s are not included in the DataModel and thus serialization of them is generally not possible. It is presumably included for future-proofing.
+
+[Content-type]: https://create.roblox.com/docs/reference/engine/datatypes/Content
+[Object-class]: https://create.roblox.com/docs/reference/engine/classes/Object
 
 ## Data Storage Notes
 

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -709,11 +709,9 @@ The `Content` type is a struct composed of the following fields:
 
 `Uris` is an array `UriCount` elements long which contains a sequential list of every `Uri` included in `SourceTypes`.
 
-`ObjectRefs` is a [referent array](#referent) that is `ObjectCount` elements long and contains a list of referents pointing to [`Object`][Object-class]s that can be used for `Content`, such as `EditableImage`.
+`ObjectRefs` is a [referent array](#referent) that is `ObjectCount` elements long and contains a list of referents pointing to [`Object`][Object-class]s that can be used for `Content`, such as `EditableImage`. `ObjectRefs` are not populated outside of copy-and-pasting within Studio, but this may change in the future.
 
-`ExternalObjectRefs` is similar in purpose to `ObjectRefs` but contains a list of referents that are external to this file. This is used internally by Roblox to support copy and pasting. Both `ExternalObjectCount` and `ExternalObjectRefs` are generally not applicable to implementors, because referents are not static outside of files. They are included for completeness's sake, but implementing support for them is impossible for most people.
-
-Note that `Object`s are not included in the DataModel and thus serialization of them is generally not possible. It is presumably included for future-proofing.
+`ExternalObjectRefs` is similar in purpose to `ObjectRefs` but contains a list of referents that are external to this file. This is used internally by Roblox to minimize memory overhead when copy-and-pasting. Both `ExternalObjectCount` and `ExternalObjectRefs` are not applicable to implementors because referents are not static outside of files. They are included for completeness's sake.
 
 [Content-type]: https://create.roblox.com/docs/reference/engine/datatypes/Content
 [Object-class]: https://create.roblox.com/docs/reference/engine/classes/Object

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -24,7 +24,7 @@ The XML model format has generally been replaced by the newer, more efficient [b
 	- [Color3](#color3)
 	- [Color3uint8](#color3uint8)
 	- [ColorSequence](#colorsequence)
-	- [Content](#content)
+	- [ContentId](#contentid)
 	- [CoordinateFrame](#coordinateframe)
 	- [double](#double) (Float64)
 	- [Faces](#faces)
@@ -272,24 +272,26 @@ A `ColorSequence` with the value `[0, 96, 64, 32] [1, 5, 10, 15]` appears as fol
 <ColorSequence name="ColorSequenceExample">0 0.376471 0.25098 0.12549 0 1 0.0196078 0.0392157 0.0588235 0 </ColorSequence>
 ```
 
-### Content
+### ContentId
 
-The `Content` data type is represented by a single element with one of several child elements. Currently, the name of this child element MUST be either `url` or `null`. Historically, it could also be named `binary` or `hash`. This child element is not nillable and MUST include an opening and closing tag.
+Note: This type should not be confused with the `Content` type. This type was renamed from `Content` to `ContentId` in Roblox release 645.
 
-If the child element is `url`, then the value of it is the `Content`'s URI. If the element is `null`, it indicates the `Content` is empty. When the child element is `null`, it MUST be empty. 
+The `ContentId` data type is represented by an element with one of several child elements. Currently, the name of this child element MUST be either `url` or `null`. Historically, it could also be named `binary` or `hash`. This child element is not nillable and MUST include an opening and closing tag.
 
-If the child element is either `binary` or `hash`, the contents SHOULD be disregarded and the `Content` should be viewed as empty. These tags MUST NOT be written by encoders.
+If the child element is `url`, then the value of it is the `ContentId`'s URI. If the element is `null`, it indicates the `ContentId` is empty. When the child element is `null`, it MUST be empty. 
 
-A `Content` with the value `rbxasset://textures/face.png` appears as follows:
+If the child element is either `binary` or `hash`, the contents SHOULD be disregarded and the `ContentId` should be viewed as empty. These tags MUST NOT be written by encoders.
+
+A `ContentId` with the value `rbxasset://textures/face.png` appears as follows:
 
 ```xml
-<Content name="ContentExample"><url>rbxasset://textures/face.png</url></Content>
+<ContentId name="ContentExample"><url>rbxasset://textures/face.png</url></ContentId>
 ```
 
-Additionally, a `Content` with no value would appear as follows:
+Additionally, a `ContentId` with no value would appear as follows:
 
 ```xml
-<Content name="ContentExample"><null></null></Content>
+<ContentId name="ContentExample"><null></null></ContentId>
 ```
 
 ### CoordinateFrame

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -24,6 +24,7 @@ The XML model format has generally been replaced by the newer, more efficient [b
 	- [Color3](#color3)
 	- [Color3uint8](#color3uint8)
 	- [ColorSequence](#colorsequence)
+	- [Content](#content)
 	- [ContentId](#contentid)
 	- [CoordinateFrame](#coordinateframe)
 	- [double](#double) (Float64)
@@ -272,9 +273,25 @@ A `ColorSequence` with the value `[0, 96, 64, 32] [1, 5, 10, 15]` appears as fol
 <ColorSequence name="ColorSequenceExample">0 0.376471 0.25098 0.12549 0 1 0.0196078 0.0392157 0.0588235 0 </ColorSequence>
 ```
 
+### Content
+
+Note: This type should not be confused with the legacy [`ContentId`](#contentid) that used to have the name `Content` until Roblox release 645.
+
+The [`Content`][Content-type] type is represented by an element with one of several child elements. The name of this child element MUST be one of: `null`, `uri`, or `Ref`. This child element is not nillable and MUST include an opening and closing tag.
+
+If the child element is `null`, it represents a `Content` with the [`ContentSourceType`][ContentSourceType-enum] of `None`. The `null` element MUST be empty.
+
+If the child element is `uri`, it represents a `Content` with the `ContentSourceType` of `Uri`. The contents of the child element represents the `Content`'s URI in this case.
+
+If the child element is `Ref` (note the capital R), it represents a `Content` with the `ContentSourceType` of `Object`. In this case, the contents of the child element is a [referent](#ref) that points to an [`Object`][Object-class] somewhere else in the file. As of the time of writing, no `Object`s serialize regularly, so this type of `Content` is for future-proofing and MAY be ignored by implementors until it's relevant.
+
+[Content-type]: https://create.roblox.com/docs/reference/engine/datatypes/Content
+[ContentSourceType-enum]: https://create.roblox.com/docs/reference/engine/enums/ContentSourceType
+[Object-class]: https://create.roblox.com/docs/reference/engine/classes/Object
+
 ### ContentId
 
-Note: This type should not be confused with the `Content` type. This type was renamed from `Content` to `ContentId` in Roblox release 645.
+Note: This type should not be confused with the [`Content`](#content) type. This type was renamed from `Content` to `ContentId` in Roblox release 645.
 
 The `ContentId` data type is represented by an element with one of several child elements. Currently, the name of this child element MUST be either `url` or `null`. Historically, it could also be named `binary` or `hash`. This child element is not nillable and MUST include an opening and closing tag.
 


### PR DESCRIPTION
Partially resolves #480.

Based on discussions with Roblox and observing some files, here are some spec files for the `Content` type.

I'm not writing it down in the spec file because it's an implementation detail, but for the curious: `ExternalObjectRefs` is used to preserve references while copy-and-pasting. Because of 'Cut' and pasting between sessions though, the actual `Object` that's being referenced has to be serialized so that the property can be intact even if the `Object` no longer exists. If it's loaded and the external reference exists and is valid, it's used but otherwise the value in `ObjectRefs` is used.