### PR TITLE
Add support for WritePlayerSecurity in API dump

### DIFF
--- a/rbx_reflector/src/api_dump.rs
+++ b/rbx_reflector/src/api_dump.rs
@@ -86,6 +86,7 @@ pub enum Security {
     RobloxScriptSecurity,
     NotAccessibleSecurity,
     RobloxSecurity,
+    WritePlayerSecurity,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
~~Roblox has a new security type. Yay.~~

Evidently, Roblox has had a WritePlayer security type for a very long time and it's the _actual_ underlying write security for `Player.Name` and `Player.UserId`. It was exposed starting in release 664, but it's been there for ages. I have confirmed with Roblox.

This should be the last one we have to worry about, as subsequent changes will happen under Capabilities. There's apparently also an "Unknown" security but I would hope we will never run into that in public builds of Roblox!