### PR TITLE
Make sure all popups are closed before sending file save keystroke (`rbx_reflector`)

### DIFF
--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -94,6 +94,13 @@ fn save_place_in_studio(path: &PathBuf) -> anyhow::Result<StudioInfo> {
             r#"
 tell application "System Events"
     set frontmost of the first process whose unix id is {process_id} to true
+
+    delay 0.5
+
+    repeat 5 times
+		key code 53 -- Escape key
+	end repeat
+
     keystroke "s" using command down
 end tell
 "#


### PR DESCRIPTION
Automatically closes these windows before sending the file save keystroke on **macOS only**
![image](https://github.com/user-attachments/assets/ddc3a961-efd8-48ac-8fe9-f9beb4a93ab5)
