### PR TITLE
Add `Content::into_value`

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased Changes
 
+* Added `Content::into_value` to support converting a `Content` into its underlying value. ([#507])
+
+[#507]: https://github.com/rojo-rbx/rbx-dom/pull/507
+
 ## 2.0.0 (2025-03-28)
 * Changed `Content` to more closely align with Roblox's new `Content` type. This is a breaking change. ([#495])
 * Renamed the old `Content` to `ContentId` to reflect Roblox's API changes. ([#495])

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -49,6 +49,12 @@ impl Content {
     pub fn value_mut(&mut self) -> &mut ContentType {
         &mut self.0
     }
+
+    /// Consumes this `Content` and returns the underlying value.
+    #[inline]
+    pub fn into_value(self) -> ContentType {
+        self.0
+    }
 }
 
 impl From<String> for Content {
@@ -72,7 +78,6 @@ impl From<&'_ str> for Content {
     derive(serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]
-
 pub struct ContentId {
     url: String,
 }


### PR DESCRIPTION
While implementing Content for Lune, I've noticed that an ergonomic feature is missing from `Content`. We should fix that.