### PR TITLE
Add `Content::as_object` and `Content::as_uri`

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 
+* Added `Content::get_object` and `Content::get_uri` to get the respective type as an optional value. ([#511])
 * Added `Content::into_value` to support converting a `Content` into its underlying value. ([#507])
 
 [#507]: https://github.com/rojo-rbx/rbx-dom/pull/507

--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased Changes
 
-* Added `Content::get_object` and `Content::get_uri` to get the respective type as an optional value. ([#511])
+* Added `Content::as_object` and `Content::as_uri` to assume the respective type (optional value). ([#511])
 * Added `Content::into_value` to support converting a `Content` into its underlying value. ([#507])
 
 [#507]: https://github.com/rojo-rbx/rbx-dom/pull/507

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -58,7 +58,7 @@ impl Content {
 
     /// Returns Some(&str) if `Content` is a Uri.
     #[inline]
-    pub fn get_uri(&self) -> Option<&str> {
+    pub fn as_uri(&self) -> Option<&str> {
         match self {
             Self(ContentType::Uri(uri)) => Some(uri.as_str()),
             _ => None,
@@ -67,7 +67,7 @@ impl Content {
 
     /// Returns Some(Ref) if `Content` is an Object.
     #[inline]
-    pub fn get_object(&self) -> Option<Ref> {
+    pub fn as_object(&self) -> Option<Ref> {
         match self {
             &Self(ContentType::Object(referent)) => Some(referent),
             _ => None,

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -56,7 +56,7 @@ impl Content {
         self.0
     }
 
-    /// Returns Some(&str) if `Content` is a Uri.
+    /// If this `Content` is a URI, returns the URI. Otherwise, returns `None`.
     #[inline]
     pub fn as_uri(&self) -> Option<&str> {
         match self.value() {

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -65,11 +65,11 @@ impl Content {
         }
     }
 
-    /// Returns Some(Ref) if `Content` is an Object.
+    /// If this `Content` is an Object, returns the Ref. Otherwise, returns `None`.
     #[inline]
     pub fn as_object(&self) -> Option<Ref> {
         match self.value() {
-            ContentType::Object(referent) => Some(*referent),
+            &ContentType::Object(referent) => Some(referent),
             _ => None,
         }
     }

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -68,8 +68,8 @@ impl Content {
     /// Returns Some(Ref) if `Content` is an Object.
     #[inline]
     pub fn as_object(&self) -> Option<Ref> {
-        match self {
-            &Self(ContentType::Object(referent)) => Some(referent),
+        match self.value() {
+            ContentType::Object(referent) => Some(*referent),
             _ => None,
         }
     }

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -55,6 +55,24 @@ impl Content {
     pub fn into_value(self) -> ContentType {
         self.0
     }
+
+    /// Returns Some(&str) if `Content` is a Uri.
+    #[inline]
+    pub fn get_uri(&self) -> Option<&str> {
+        match self {
+            Self(ContentType::Uri(uri)) => Some(uri.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Returns Some(Ref) if `Content` is an Object.
+    #[inline]
+    pub fn get_object(&self) -> Option<Ref> {
+        match self {
+            &Self(ContentType::Object(referent)) => Some(referent),
+            _ => None,
+        }
+    }
 }
 
 impl From<String> for Content {

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -59,8 +59,8 @@ impl Content {
     /// Returns Some(&str) if `Content` is a Uri.
     #[inline]
     pub fn as_uri(&self) -> Option<&str> {
-        match self {
-            Self(ContentType::Uri(uri)) => Some(uri.as_str()),
+        match self.value() {
+            ContentType::Uri(uri) => Some(uri),
             _ => None,
         }
     }


### PR DESCRIPTION
This is convenient if you want to always assume the Content is a Uri or an Object.