### PR TITLE
Const Ref Constructor

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased Changes
 
-* Added `Ref::from_value` and  `Ref::from` to construct a Ref from a u128. ([#516])
+* Added `Ref::some` to construct a Ref from a u128. ([#516])
 * Added `Content::as_object` and `Content::as_uri` to assume the respective type (optional value). ([#511])
 * Added `Content::into_value` to support converting a `Content` into its underlying value. ([#507])
 

--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 
+* Added `Ref::from_value` and  `Ref::from` to construct a Ref from a u128. ([#516])
 * Added `Content::as_object` and `Content::as_uri` to assume the respective type (optional value). ([#511])
 * Added `Content::into_value` to support converting a `Content` into its underlying value. ([#507])
 

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -35,8 +35,11 @@ impl Ref {
     }
 
     #[inline]
-    pub const fn from_value(value: u128) -> Self {
-        Ref(NonZeroU128::new(value))
+    pub const fn from_value(value: u128) -> Option<Self> {
+        match NonZeroU128::new(value) {
+            Some(non_zero_value) => Some(Ref(Some(non_zero_value))),
+            None => None,
+        }
     }
 
     fn value(&self) -> u128 {
@@ -60,7 +63,7 @@ impl FromStr for Ref {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let value = u128::from_str_radix(input, 16)?;
 
-        Ok(Ref::from_value(value))
+        Ok(Ref(NonZeroU128::new(value)))
     }
 }
 

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -22,6 +22,17 @@ impl Ref {
         Ref(None)
     }
 
+    /// Generate a `Ref` that points to something.
+    ///
+    /// ## Panics
+    /// Panics if `value` is 0. Use the Ref::none()
+    /// constructor instead to create a `Ref` that
+    /// points to nothing.
+    #[inline]
+    pub const fn some(value: u128) -> Self {
+        Ref(Some(NonZeroU128::new(value).unwrap()))
+    }
+
     /// Tells whether this `Ref` points to something.
     #[inline]
     pub const fn is_some(&self) -> bool {
@@ -32,14 +43,6 @@ impl Ref {
     #[inline]
     pub const fn is_none(&self) -> bool {
         self.0.is_none()
-    }
-
-    #[inline]
-    pub const fn from_value(value: u128) -> Option<Self> {
-        match NonZeroU128::new(value) {
-            Some(non_zero_value) => Some(Ref(Some(non_zero_value))),
-            None => None,
-        }
     }
 
     fn value(&self) -> u128 {

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -18,19 +18,19 @@ impl Ref {
 
     /// Generate a `Ref` that points to nothing.
     #[inline]
-    pub fn none() -> Self {
+    pub const fn none() -> Self {
         Ref(None)
     }
 
     /// Tells whether this `Ref` points to something.
     #[inline]
-    pub fn is_some(&self) -> bool {
+    pub const fn is_some(&self) -> bool {
         self.0.is_some()
     }
 
     /// Tells whether this `Ref` points to nothing.
     #[inline]
-    pub fn is_none(&self) -> bool {
+    pub const fn is_none(&self) -> bool {
         self.0.is_none()
     }
 
@@ -51,6 +51,7 @@ impl fmt::Display for Ref {
 impl FromStr for Ref {
     type Err = std::num::ParseIntError;
 
+    #[inline]
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let value = u128::from_str_radix(input, 16)?;
 

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -30,7 +30,7 @@ impl Ref {
     /// points to nothing.
     #[inline]
     pub const fn some(value: u128) -> Self {
-        Ref(Some(NonZeroU128::new(value).unwrap()))
+        Ref(Some(NonZeroU128::new(value).expect("Ref value is 0")))
     }
 
     /// Tells whether this `Ref` points to something.

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -34,6 +34,11 @@ impl Ref {
         self.0.is_none()
     }
 
+    #[inline]
+    pub const fn from_value(value: u128) -> Self {
+        Ref(NonZeroU128::new(value))
+    }
+
     fn value(&self) -> u128 {
         match self.0 {
             Some(value) => value.get(),
@@ -55,7 +60,7 @@ impl FromStr for Ref {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let value = u128::from_str_radix(input, 16)?;
 
-        Ok(Ref(NonZeroU128::new(value)))
+        Ok(Ref::from_value(value))
     }
 }
 

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -53,13 +53,6 @@ impl fmt::Display for Ref {
     }
 }
 
-impl From<u128> for Ref {
-    #[inline]
-    fn from(value: u128) -> Self {
-        Ref::from_value(value)
-    }
-}
-
 impl FromStr for Ref {
     type Err = std::num::ParseIntError;
 

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -53,6 +53,13 @@ impl fmt::Display for Ref {
     }
 }
 
+impl From<u128> for Ref {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Ref::from_value(value)
+    }
+}
+
 impl FromStr for Ref {
     type Err = std::num::ParseIntError;
 


### PR DESCRIPTION
There is no way to have a Ref as a compile time constant like so:
```rust
pub(crate) const NIL_REF:Ref=Ref::from_value(u128::MAX);
```

The alternative is to litter the code with runtime construction using FromStr:
```rust
let nil_ref:Ref="ffffffffffffffffffffffffffffffff".parse().unwrap();
```
The intended use case for this is to implement runtime nil instances with a specific constant Ref that refers to the "root nil instance" within the dom. The implementation maps the None variant of `Option<Ref>` into `NIL_REF` when assigning parent:
```rust
pub struct Instance{
	referent:Ref,
}
impl Instance{
	pub const fn nil()->Self{
		Self{
			referent:NIL_REF
		}
	}
}
impl mlua::UserData for Instance{
	fn add_fields<F:mlua::UserDataFields<Self>>(fields:&mut F){
		fields.add_field_method_set("Parent",|lua,this,new_parent:Option<Instance>|{
			let parent=new_parent.unwrap_or(Instance::nil());
			dom.transfer_within(this.referent,parent.referent);
			Ok(())
		});
	}
}
```