### PR TITLE
Allow `WeakDom::transfer_within` dest_parent_ref to be the None Ref

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -336,11 +336,13 @@ impl WeakDom {
         }
 
         // Add the instance's referent to its new parent's list of children.
-        let dest_parent = self
-            .instances
-            .get_mut(&dest_parent_ref)
-            .unwrap_or_else(|| panic!("cannot move into an instance that does not exist"));
-        dest_parent.children.push(referent);
+        if dest_parent_ref.is_some() {
+            let dest_parent = self
+                .instances
+                .get_mut(&dest_parent_ref)
+                .unwrap_or_else(|| panic!("cannot move into an instance that does not exist"));
+            dest_parent.children.push(referent);
+        }
     }
 
     /// Clone the instance with the given `referent` and all its descendants


### PR DESCRIPTION
Allow the following code to run without panic:
```rust
dom.transfer_within(instance.referent(),Ref::none());
```