### PR TITLE
Implement `WeakDom::ancestors_of`

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+* Add `WeakDom::ancestors_of` helper function. ([#520])
+
 ## 3.0.0 (2025-03-28)
 This version contains a number of breaking changes to achieve dramatically improved performance by interning property and class names with [ustr](https://docs.rs/ustr/latest/ustr/).
 

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -155,13 +155,19 @@ impl WeakDom {
         }
     }
 
-    /// Returns an iterator that goes through the ancestors of a particular [`Instance`].
+    /// Returns an iterator that goes through the ancestors of a particular
+    /// [`Ref`]. The passed `Ref` *must* be a part of this `WeakDom`.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `referent` is not a member of this DOM.
     #[inline]
-    pub fn ancestors_of<'a>(
-        &'a self,
-        some_instance: &'a Instance,
-    ) -> impl Iterator<Item = &'a Instance> {
-        std::iter::successors(Some(some_instance), move |&instance| {
+    pub fn ancestors_of(&self, referent: Ref) -> impl Iterator<Item = &Instance> {
+        let initial_instance = self.get_by_ref(referent);
+        if initial_instance.is_none() {
+            panic!("the referent provided to `ancestors_of` must be a part of the DOM");
+        }
+        std::iter::successors(initial_instance, move |&instance| {
             self.get_by_ref(instance.parent())
         })
     }

--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -155,6 +155,17 @@ impl WeakDom {
         }
     }
 
+    /// Returns an iterator that goes through the ancestors of a particular [`Instance`].
+    #[inline]
+    pub fn ancestors_of<'a>(
+        &'a self,
+        some_instance: &'a Instance,
+    ) -> impl Iterator<Item = &'a Instance> {
+        std::iter::successors(Some(some_instance), move |&instance| {
+            self.get_by_ref(instance.parent())
+        })
+    }
+
     /// Insert a new instance into the DOM with the given parent. The parent is allowed to
     /// be the none Ref.
     ///


### PR DESCRIPTION
The commit history also includes a version with a different type signature that does not panic.