### PR TITLE
Directly Build UstrMap For Properties

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -175,7 +175,7 @@ impl WeakDom {
                     parent,
                     name: builder.name,
                     class: builder.class,
-                    properties: builder.properties.into_iter().collect(),
+                    properties: builder.properties,
                 },
             );
 

--- a/rbx_dom_weak/src/instance.rs
+++ b/rbx_dom_weak/src/instance.rs
@@ -1,3 +1,4 @@
+use ahash::HashMapExt;
 use rbx_types::{Ref, Variant};
 use ustr::{Ustr, UstrMap};
 
@@ -35,7 +36,7 @@ pub struct InstanceBuilder {
     pub(crate) referent: Ref,
     pub(crate) name: String,
     pub(crate) class: Ustr,
-    pub(crate) properties: Vec<(Ustr, Variant)>,
+    pub(crate) properties: UstrMap<Variant>,
     pub(crate) children: Vec<InstanceBuilder>,
 }
 
@@ -50,7 +51,7 @@ impl InstanceBuilder {
             referent: Ref::new(),
             name,
             class,
-            properties: Vec::new(),
+            properties: UstrMap::new(),
             children: Vec::new(),
         }
     }
@@ -65,7 +66,7 @@ impl InstanceBuilder {
             referent: Ref::new(),
             name,
             class,
-            properties: Vec::with_capacity(capacity),
+            properties: UstrMap::with_capacity(capacity),
             children: Vec::new(),
         }
     }
@@ -76,7 +77,7 @@ impl InstanceBuilder {
             referent: Ref::new(),
             name: String::new(),
             class: Ustr::default(),
-            properties: Vec::new(),
+            properties: UstrMap::new(),
             children: Vec::new(),
         }
     }
@@ -122,19 +123,19 @@ impl InstanceBuilder {
 
     /// Add a new property to the `InstanceBuilder`.
     pub fn with_property<K: Into<Ustr>, V: Into<Variant>>(mut self, key: K, value: V) -> Self {
-        self.properties.push((key.into(), value.into()));
+        self.properties.insert(key.into(), value.into());
         self
     }
 
     /// Add a new property to the `InstanceBuilder`.
     pub fn add_property<K: Into<Ustr>, V: Into<Variant>>(&mut self, key: K, value: V) {
-        self.properties.push((key.into(), value.into()));
+        self.properties.insert(key.into(), value.into());
     }
 
     /// Check if the `InstanceBuilder` already has a property with the given key.
     pub fn has_property<K: Into<Ustr>>(&self, key: K) -> bool {
         let key = key.into();
-        self.properties.iter().any(|(k, _)| *k == key)
+        self.properties.contains_key(&key)
     }
 
     /// Add multiple properties to the `InstanceBuilder` at once.

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -4,7 +4,7 @@ use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use log::trace;
 use rbx_dom_weak::{
     types::{Ref, SharedString, Variant, VariantType},
-    InstanceBuilder, Ustr, WeakDom,
+    InstanceBuilder, Ustr, UstrMap, WeakDom,
 };
 use rbx_reflection::{DataType, PropertyKind, PropertySerialization, ReflectionDatabase};
 
@@ -460,7 +460,7 @@ fn deserialize_instance<R: Read>(
         state.referents_to_ids.insert(referent, instance_id);
     }
 
-    let mut properties: HashMap<Ustr, Variant> = HashMap::new();
+    let mut properties = UstrMap::new();
 
     loop {
         match reader.expect_peek()? {
@@ -507,7 +507,7 @@ fn deserialize_instance<R: Read>(
         None => instance.class.to_string(),
     };
 
-    instance.properties = properties.into_iter().collect();
+    instance.properties = properties;
 
     Ok(())
 }
@@ -516,7 +516,7 @@ fn deserialize_properties<R: Read>(
     reader: &mut XmlEventReader<R>,
     state: &mut ParseState,
     instance_id: Ref,
-    props: &mut HashMap<Ustr, Variant>,
+    props: &mut UstrMap<Variant>,
 ) -> Result<(), DecodeError> {
     reader.expect_start_with_name("Properties")?;
 


### PR DESCRIPTION
If there's no reason why InstanceBuilder.properties can't be directly assigned to Instance.properties, then let's do that.  Also applied the same logic to building the properties in rbx_xml.  The "Miner's Haven/Deserialize" benchmark says throughput is increased by 30%.