### PR TITLE
wip: Refactor DecodeOptions & EncodeOptions

### DIFF
--- a/rbx_reflector/src/defaults.rs
+++ b/rbx_reflector/src/defaults.rs
@@ -17,9 +17,7 @@ pub fn apply_defaults(
 ) -> anyhow::Result<()> {
     let file = BufReader::new(File::open(defaults_place).context("Could not find defaults place")?);
 
-    let decode_options = rbx_xml::DecodeOptions::new()
-        .property_behavior(rbx_xml::DecodePropertyBehavior::IgnoreUnknown)
-        .reflection_database(database);
+    let decode_options = rbx_xml::DecodeOptions::IgnoreUnknown { database };
 
     let tree =
         rbx_xml::from_reader(file, decode_options).context("Could not decode defaults place")?;

--- a/rbx_util/src/convert.rs
+++ b/rbx_util/src/convert.rs
@@ -28,8 +28,7 @@ impl ConvertCommand {
         log::debug!("Reading file into WeakDom");
         let dom = match input_kind {
             ModelKind::Xml => {
-                let options = rbx_xml::DecodeOptions::new()
-                    .property_behavior(rbx_xml::DecodePropertyBehavior::ReadUnknown);
+                let options = rbx_xml::DecodeOptions::read_unknown();
 
                 rbx_xml::from_reader(input_file, options)
                     .with_context(|| format!("Failed to read {}", self.input_path.display()))?

--- a/rbx_util/src/remove_prop.rs
+++ b/rbx_util/src/remove_prop.rs
@@ -32,8 +32,7 @@ impl RemovePropCommand {
         log::debug!("Reading from {input_kind:?} file {}", self.input.display());
         let mut dom = match input_kind {
             ModelKind::Xml => {
-                let options = rbx_xml::DecodeOptions::new()
-                    .property_behavior(rbx_xml::DecodePropertyBehavior::ReadUnknown);
+                let options = rbx_xml::DecodeOptions::read_unknown();
 
                 rbx_xml::from_reader(input_file, options)
                     .with_context(|| format!("Failed to read {}", self.input.display()))?

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -73,7 +73,7 @@ pub enum DecodeOptions<'db> {
     NoReflection,
 }
 
-impl<'db> DecodeOptions<'db> {
+impl DecodeOptions<'_> {
     /// Constructs a `DecodeOptions` which specifies to ignore unknown properties or classes.
     #[inline]
     pub fn ignore_unknown() -> Self {

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -81,6 +81,9 @@ pub(crate) enum DecodeErrorKind {
     UnexpectedEof,
     UnexpectedXmlEvent(xml::reader::XmlEvent),
     MissingAttribute(&'static str),
+    UnknownClassName {
+        class_name: String,
+    },
     UnknownProperty {
         class_name: String,
         property_name: String,
@@ -124,6 +127,9 @@ impl fmt::Display for DecodeErrorKind {
                 "Property {}.{} is unknown",
                 class_name, property_name
             ),
+            UnknownClassName { class_name } => {
+                write!(output, "ClassName {} is unknown", class_name)
+            }
             InvalidContent(explain) => write!(output, "Invalid text content: {}", explain),
             NameMustBeString(ty) => write!(
                 output,

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -130,7 +130,7 @@ use rbx_dom_weak::{types::Ref, WeakDom};
 use crate::{deserializer::decode_internal, serializer::encode_internal};
 
 pub use crate::{
-    deserializer::{DecodeOptions, DecodePropertyBehavior},
+    deserializer::DecodeOptions,
     error::{DecodeError, EncodeError},
     serializer::{EncodeOptions, EncodePropertyBehavior},
 };

--- a/rbx_xml/src/tests/basic.rs
+++ b/rbx_xml/src/tests/basic.rs
@@ -268,11 +268,10 @@ fn read_unique_id() {
 
     let tree = crate::from_str(
         document,
-        crate::DecodeOptions::new()
-            // This is necessary at the moment because we do not actually
-            // have UniqueId properties in our reflection database. This may
-            // change, but it should in general be safe.
-            .property_behavior(crate::DecodePropertyBehavior::ReadUnknown),
+        // This is necessary at the moment because we do not actually
+        // have UniqueId properties in our reflection database. This may
+        // change, but it should in general be safe.
+        crate::DecodeOptions::read_unknown(),
     )
     .unwrap();
 

--- a/rbx_xml/src/tests/formatting.rs
+++ b/rbx_xml/src/tests/formatting.rs
@@ -150,12 +150,9 @@ const INPUT: &str = r#"<roblox version="4">
 fn formatting() {
     let _ = env_logger::try_init();
 
-    let de = crate::from_str(
-        INPUT,
-        crate::DecodeOptions::new().property_behavior(crate::DecodePropertyBehavior::NoReflection),
-    )
-    .map_err(|e| panic!("cannot deserialize: {}", e))
-    .unwrap();
+    let de = crate::from_str(INPUT, crate::DecodeOptions::no_reflection())
+        .map_err(|e| panic!("cannot deserialize: {}", e))
+        .unwrap();
 
     insta::assert_yaml_snapshot!("deserialized", DomViewer::new().view_children(&de));
 


### PR DESCRIPTION
Change `DecodeOptions` to an enum to more accurately model the data it represents.  When `NoReflection` is used, the database does not need to exist.

TODO: refactor `EncodeOptions` similarly