### PR TITLE
Decompress All Chunks Before Deserializing

### DIFF
--- a/rbx_binary/src/chunk.rs
+++ b/rbx_binary/src/chunk.rs
@@ -55,6 +55,33 @@ impl Chunk {
     }
 }
 
+/// Decompressed chunks.  Referenced by WeakDom properties
+/// when the identity string interner is used.
+pub struct Chunks {
+    chunks: Vec<Chunk>,
+}
+impl Chunks {
+    pub fn decode<R: Read>(mut reader: R) -> io::Result<Chunks> {
+        let mut chunks = Vec::new();
+        loop {
+            let chunk = Chunk::decode(&mut reader)?;
+            let is_end_chunk = matches!(&chunk.name, b"END\0");
+            chunks.push(chunk);
+            if is_end_chunk {
+                break;
+            }
+        }
+        Ok(Chunks { chunks })
+    }
+}
+impl<'a> IntoIterator for &'a Chunks {
+    type Item = &'a Chunk;
+    type IntoIter = core::slice::Iter<'a, Chunk>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.chunks.iter()
+    }
+}
+
 /// Holds a chunk that is currently being written.
 ///
 /// This type intended to be written into via io::Write and then dumped into the

--- a/rbx_binary/src/deserializer/file.rs
+++ b/rbx_binary/src/deserializer/file.rs
@@ -1,0 +1,27 @@
+use std::io::Read;
+
+use rbx_dom_weak::WeakDom;
+
+use super::{error::InnerError, header::FileHeader};
+use crate::chunk::Chunks;
+use crate::deserializer::{Deserializer, Error};
+
+/// File header and decompressed chunks.  Call deserialize to
+/// deserialize the file.
+pub struct DecompressedFile {
+    pub(crate) header: FileHeader,
+    pub(crate) chunks: Chunks,
+}
+
+impl DecompressedFile {
+    /// Perform the chunk decompression step without deserializing the file.
+    pub fn from_reader<R: Read>(mut reader: R) -> Result<Self, Error> {
+        let header = FileHeader::decode(&mut reader)?;
+        let chunks = Chunks::decode(reader).map_err(InnerError::from)?;
+        Ok(DecompressedFile { header, chunks })
+    }
+    /// Perform the deserialization step.
+    pub fn deserialize(&self) -> Result<WeakDom, Error> {
+        Deserializer::new().deserialize(self)
+    }
+}

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -15,19 +15,15 @@ use rbx_dom_weak::{
 use rbx_reflection::{DataType, PropertyKind, PropertySerialization, ReflectionDatabase};
 
 use crate::{
-    chunk::Chunk,
     core::{find_property_descriptors, RbxReadExt},
     types::Type,
 };
 
 use super::{error::InnerError, header::FileHeader, Deserializer};
 
-pub(super) struct DeserializerState<'db, R> {
+pub(super) struct DeserializerState<'db> {
     /// The user-provided configuration that we should use.
     deserializer: &'db Deserializer<'db>,
-
-    /// The input data encoded as a binary model.
-    input: R,
 
     /// The tree that instances should be written into. Eventually returned to
     /// the user.
@@ -205,14 +201,12 @@ fn add_property(instance: &mut Instance, canonical_property: &CanonicalProperty,
     }
 }
 
-impl<'db, R: Read> DeserializerState<'db, R> {
+impl<'db> DeserializerState<'db> {
     pub(super) fn new(
         deserializer: &'db Deserializer<'db>,
-        mut input: R,
+        header: &FileHeader,
     ) -> Result<Self, InnerError> {
         let mut tree = WeakDom::new(InstanceBuilder::new("DataModel"));
-
-        let header = FileHeader::decode(&mut input)?;
 
         let type_infos = HashMap::with_capacity(header.num_types as usize);
         let instances_by_ref = HashMap::with_capacity(1 + header.num_instances as usize);
@@ -221,7 +215,6 @@ impl<'db, R: Read> DeserializerState<'db, R> {
 
         Ok(DeserializerState {
             deserializer,
-            input,
             tree,
             metadata: HashMap::new(),
             shared_strings: Vec::new(),
@@ -230,10 +223,6 @@ impl<'db, R: Read> DeserializerState<'db, R> {
             root_instance_refs: Vec::new(),
             unknown_type_ids: HashSet::new(),
         })
-    }
-
-    pub(super) fn next_chunk(&mut self) -> Result<Chunk, InnerError> {
-        Ok(Chunk::decode(&mut self.input)?)
     }
 
     #[profiling::function]

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -67,6 +67,7 @@ mod tests;
 
 use std::io::{Read, Write};
 
+pub use deserializer::DecompressedFile;
 use rbx_dom_weak::{types::Ref, WeakDom};
 
 /// An unstable textual format that can be used to debug binary models.
@@ -82,7 +83,8 @@ pub use crate::{
 
 /// Deserialize a Roblox binary model or place from a stream.
 pub fn from_reader<R: Read>(reader: R) -> Result<WeakDom, DecodeError> {
-    Deserializer::new().deserialize(reader)
+    let file = DecompressedFile::from_reader(reader)?;
+    Deserializer::new().deserialize(&file)
 }
 
 /// Serializes a subset of the given DOM to a binary format model or place,

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -83,8 +83,7 @@ pub use crate::{
 
 /// Deserialize a Roblox binary model or place from a stream.
 pub fn from_reader<R: Read>(reader: R) -> Result<WeakDom, DecodeError> {
-    let file = DecompressedFile::from_reader(reader)?;
-    Deserializer::new().deserialize(&file)
+    DecompressedFile::from_reader(reader)?.deserialize()
 }
 
 /// Serializes a subset of the given DOM to a binary format model or place,


### PR DESCRIPTION
This is required for #533.  In order for the dom to reference decompressed data, it must be available from a let binding.  The `DecompressedFile` struct name is a placeholder, so please recommend a more sensible name.  This has no significant performance impact as far as I can tell.  This also opens the potential for parallel chunk decompression.  However, decompression is only around 8% of the workload most of the time, so the performance improvement potential is limited.