### PR TITLE
Drop Ustr Dependency

### DIFF
--- a/rbx_binary/src/chunk.rs
+++ b/rbx_binary/src/chunk.rs
@@ -55,6 +55,33 @@ impl Chunk {
     }
 }
 
+/// Decompressed chunks.  Referenced by WeakDom properties
+/// when the identity string interner is used.
+pub struct Chunks {
+    chunks: Vec<Chunk>,
+}
+impl Chunks {
+    pub fn decode<R: Read>(mut reader: R) -> io::Result<Chunks> {
+        let mut chunks = Vec::new();
+        loop {
+            let chunk = Chunk::decode(&mut reader)?;
+            let is_end_chunk = matches!(&chunk.name, b"END\0");
+            chunks.push(chunk);
+            if is_end_chunk {
+                break;
+            }
+        }
+        Ok(Chunks { chunks })
+    }
+}
+impl<'a> IntoIterator for &'a Chunks {
+    type Item = &'a Chunk;
+    type IntoIter = core::slice::Iter<'a, Chunk>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.chunks.iter()
+    }
+}
+
 /// Holds a chunk that is currently being written.
 ///
 /// This type intended to be written into via io::Write and then dumped into the

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -421,7 +421,7 @@ pub fn find_property_descriptors<'db>(
                 // return, it's possible that both the canonical and serialized
                 // forms are different.
                 PropertyKind::Alias { alias_for } => {
-                    let canonical = class_descriptor.properties.get(alias_for.as_ref()).unwrap();
+                    let canonical = class_descriptor.properties.get(*alias_for).unwrap();
 
                     if let PropertyKind::Canonical { serialization } = &canonical.kind {
                         let serialized = find_serialized_from_canonical(
@@ -490,7 +490,7 @@ fn find_serialized_from_canonical<'db>(
         // This property serializes under an alias. That property should have a
         // corresponding property descriptor within the same class descriptor.
         PropertySerialization::SerializesAs(serialized_name) => {
-            let serialized_descriptor = class.properties.get(serialized_name.as_ref()).unwrap();
+            let serialized_descriptor = class.properties.get(*serialized_name).unwrap();
 
             Some(serialized_descriptor)
         }

--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -315,6 +315,43 @@ pub trait RbxWriteExt: Write {
 
 impl<W> RbxWriteExt for W where W: Write {}
 
+/// Read a binary "string" in the format that Roblox's model files use.
+///
+/// This function is safer than read_string because Roblox generally makes
+/// no guarantees about encoding of things it calls strings. rbx_binary
+/// makes a semantic differentiation between strings and binary buffers,
+/// which makes it more strict than Roblox but more likely to be correct.
+///
+/// This function is not part of RbxReadExt, and unlike
+/// RbxReadExt::read_binary_string, this function only operates on a byte slice.
+pub fn read_binary_string_slice<'a>(slice: &mut &'a [u8]) -> io::Result<&'a [u8]> {
+    let length = slice.read_le_u32()?;
+
+    let out;
+    // split_at can panic if the slice is shorter than length
+    // but we do not expect that to happen.
+    (out, *slice) = slice.split_at(length as usize);
+
+    Ok(out)
+}
+
+/// Read a UTF-8 encoded string encoded how Roblox model files encode
+/// strings. This function isn't always appropriate because Roblox's formats
+/// generally aren't dilligent about data being valid Unicode.
+///
+/// This function is not part of RbxReadExt, and unlike
+/// RbxReadExt::read_string, this function only operates on a byte slice.
+pub fn read_string_slice<'a>(slice: &mut &'a [u8]) -> io::Result<&'a str> {
+    let out = read_binary_string_slice(slice)?;
+
+    core::str::from_utf8(out).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "stream did not contain valid UTF-8",
+        )
+    })
+}
+
 /// Applies the 'zigzag' transformation done by Roblox to many `i32` values.
 pub fn transform_i32(value: i32) -> i32 {
     (value << 1) ^ (value >> 31)

--- a/rbx_binary/src/deserializer/error.rs
+++ b/rbx_binary/src/deserializer/error.rs
@@ -39,6 +39,15 @@ pub(crate) enum InnerError {
         version: u32,
     },
 
+    #[error("Unknown class name {type_name}")]
+    UnknownClassName { type_name: String },
+
+    #[error("Unknown property name {type_name}.{prop_name}")]
+    UnknownPropertyName {
+        type_name: String,
+        prop_name: String,
+    },
+
     #[error(transparent)]
     InvalidTypeError {
         #[from]

--- a/rbx_binary/src/deserializer/file.rs
+++ b/rbx_binary/src/deserializer/file.rs
@@ -1,0 +1,27 @@
+use std::io::Read;
+
+use rbx_dom_weak::WeakDom;
+
+use super::{error::InnerError, header::FileHeader};
+use crate::chunk::Chunks;
+use crate::deserializer::{Deserializer, Error};
+
+/// File header and decompressed chunks.  Call deserialize to
+/// deserialize the file.
+pub struct DecompressedFile {
+    pub(crate) header: FileHeader,
+    pub(crate) chunks: Chunks,
+}
+
+impl DecompressedFile {
+    /// Perform the chunk decompression step without deserializing the file.
+    pub fn from_reader<R: Read>(mut reader: R) -> Result<Self, Error> {
+        let header = FileHeader::decode(&mut reader)?;
+        let chunks = Chunks::decode(reader).map_err(InnerError::from)?;
+        Ok(DecompressedFile { header, chunks })
+    }
+    /// Perform the deserialization step.
+    pub fn deserialize(&self) -> Result<WeakDom, Error> {
+        Deserializer::new().deserialize(self)
+    }
+}

--- a/rbx_binary/src/deserializer/file.rs
+++ b/rbx_binary/src/deserializer/file.rs
@@ -2,9 +2,11 @@ use std::io::Read;
 
 use rbx_dom_weak::WeakDom;
 
-use super::{error::InnerError, header::FileHeader};
+use super::{
+    error::InnerError, header::FileHeader, intern::StringIntern, state::DecodeOptions,
+    Deserializer, Error,
+};
 use crate::chunk::Chunks;
-use crate::deserializer::{Deserializer, Error};
 
 /// File header and decompressed chunks.  Call deserialize to
 /// deserialize the file.
@@ -21,7 +23,10 @@ impl DecompressedFile {
         Ok(DecompressedFile { header, chunks })
     }
     /// Perform the deserialization step.
-    pub fn deserialize(&self) -> Result<WeakDom, Error> {
-        Deserializer::new().deserialize(self)
+    pub fn deserialize<'file, 'dom, S: StringIntern<'file, 'dom>>(
+        &'file self,
+        options: DecodeOptions<S>,
+    ) -> Result<WeakDom<'dom>, Error> {
+        Deserializer::new().deserialize(self, options)
     }
 }

--- a/rbx_binary/src/deserializer/intern.rs
+++ b/rbx_binary/src/deserializer/intern.rs
@@ -1,0 +1,20 @@
+/// A trait representing string internment that lives for at least 'long.
+/// There is a blanket implementation for any function fn(&str)->&str
+/// so this can be a closure operating your very own string interner.
+pub trait StringIntern<'short, 'long> {
+    /// Take an input string with lifetime 'short and guarantee
+    /// that the identical output string lives for at least 'long.
+    fn intern(&mut self, str: &'short str) -> &'long str;
+}
+
+/// A type alias for a function which implements the StringIntern trait.
+pub type InternFunction<'short, 'long> = fn(&'short str) -> &'long str;
+
+impl<'short, 'long, F> StringIntern<'short, 'long> for F
+where
+    F: FnMut(&'short str) -> &'long str,
+{
+    fn intern(&mut self, str: &'short str) -> &'long str {
+        self(str)
+    }
+}

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -26,13 +26,13 @@ pub use self::state::DecodeOptions;
 /// use std::fs::File;
 /// use std::io::BufReader;
 ///
-/// use rbx_binary::{DecompressedFile, Deserializer};
+/// use rbx_binary::{DecodeOptions, DecompressedFile, Deserializer};
 ///
 /// let input = BufReader::new(File::open("File.rbxm")?);
 ///
 /// let file = DecompressedFile::from_reader(input)?;
 /// let deserializer = Deserializer::new();
-/// let dom = deserializer.deserialize(&file)?;
+/// let dom = deserializer.deserialize(&file, DecodeOptions::read_unknown())?;
 ///
 /// // rbx_binary always returns a DOM with a DataModel at the top level.
 /// // To get to the instances from our file, we need to go one level deeper.

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -1,6 +1,7 @@
 mod error;
 mod file;
 mod header;
+mod intern;
 mod state;
 
 use std::str;
@@ -15,6 +16,8 @@ pub(crate) use self::header::FileHeader;
 pub use self::file::DecompressedFile;
 
 pub use self::error::Error;
+pub use self::intern::*;
+pub use self::state::DecodeOptions;
 
 /// A configurable deserializer for Roblox binary models and places.
 ///
@@ -50,11 +53,11 @@ pub use self::error::Error;
 ///
 /// [ReflectionDatabase]: rbx_reflection::ReflectionDatabase
 /// [reflection_database]: Deserializer#method.reflection_database
-pub struct Deserializer<'db> {
-    database: &'db ReflectionDatabase<'db>,
+pub struct Deserializer<'de, 'db> {
+    database: &'de ReflectionDatabase<'db>,
 }
 
-impl<'db> Deserializer<'db> {
+impl<'de, 'dom, 'db: 'dom, 'file> Deserializer<'de, 'db> {
     /// Create a new `Deserializer` with the default settings.
     pub fn new() -> Self {
         Self {
@@ -64,16 +67,20 @@ impl<'db> Deserializer<'db> {
 
     /// Sets what reflection database for the deserializer to use.
     #[inline]
-    pub fn reflection_database(self, database: &'db ReflectionDatabase<'db>) -> Self {
+    pub fn reflection_database(self, database: &'de ReflectionDatabase<'db>) -> Self {
         Self { database }
     }
 
     /// Deserialize a Roblox binary model or place from the given stream using
     /// this deserializer.
-    pub fn deserialize(&self, file: &DecompressedFile) -> Result<WeakDom, Error> {
+    pub fn deserialize<S: StringIntern<'file, 'dom>>(
+        &self,
+        file: &'file DecompressedFile,
+        options: DecodeOptions<S>,
+    ) -> Result<WeakDom<'dom>, Error> {
         profiling::scope!("rbx_binary::deserialize");
 
-        let mut deserializer = DeserializerState::new(self, &file.header)?;
+        let mut deserializer = DeserializerState::new(self, &file.header, options)?;
 
         for chunk in &file.chunks {
             match &chunk.name {
@@ -94,7 +101,7 @@ impl<'db> Deserializer<'db> {
     }
 }
 
-impl Default for Deserializer<'_> {
+impl Default for Deserializer<'_, '_> {
     fn default() -> Self {
         Self::new()
     }

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -128,7 +128,7 @@ fn find_canonical_property<'de>(
             }
 
             // TODO: Do we need an additional fix here?
-            let canonical_name = &descriptors.canonical.name;
+            let canonical_name = descriptors.canonical.name;
             let canonical_type = match &descriptors.canonical.data_type {
                 DataType::Value(ty) => *ty,
                 DataType::Enum(_) => VariantType::Enum,
@@ -152,7 +152,7 @@ fn find_canonical_property<'de>(
             );
 
             Some(CanonicalProperty {
-                name: canonical_name.as_ref().into(),
+                name: canonical_name.into(),
                 ty: canonical_type,
                 migration,
             })
@@ -179,7 +179,7 @@ fn find_canonical_property<'de>(
 
 fn add_property(instance: &mut Instance, canonical_property: &CanonicalProperty, value: Variant) {
     if let Some(PropertySerialization::Migrate(migration)) = canonical_property.migration {
-        let new_property_name = &migration.new_property_name;
+        let new_property_name = migration.new_property_name;
         let old_property_name = canonical_property.name;
 
         if !instance.builder.has_property(new_property_name) {

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -74,7 +74,17 @@ impl<'file> DecodeOptions<InternFunction<'file, 'file>> {
     /// Constructs a `DecodeOptions` which uses references to the decompressed chunks
     /// for unknown properties and classes.  This has a larger memory footprint than
     /// using `DecodeOptions::read_unknown_with` with a string interner
-    /// because you cannot drop the decompressed chunks.
+    /// because you cannot drop the decompressed chunks immediately.
+    ///
+    /// Note that you cannot use this with `rbx_binary::from_reader`,
+    /// instead you must use a DecompressedFile with a let binding:
+    /// ```no_run
+    /// use rbx_binary::{DecompressedFile, DecodeOptions};
+    /// let bytes = std::fs::read("file.rbxl")?;
+    /// let file = DecompressedFile::from_reader(bytes.as_slice())?;
+    /// let dom = file.deserialize(DecodeOptions::read_unknown())?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     #[inline]
     pub fn read_unknown() -> Self {
         DecodeOptions::ReadUnknown {

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -67,6 +67,7 @@ mod tests;
 
 use std::io::{Read, Write};
 
+pub use deserializer::DecompressedFile;
 use rbx_dom_weak::{types::Ref, WeakDom};
 
 /// An unstable textual format that can be used to debug binary models.
@@ -82,7 +83,8 @@ pub use crate::{
 
 /// Deserialize a Roblox binary model or place from a stream.
 pub fn from_reader<R: Read>(reader: R) -> Result<WeakDom, DecodeError> {
-    Deserializer::new().deserialize(reader)
+    let file = DecompressedFile::from_reader(reader)?;
+    Deserializer::new().deserialize(&file)
 }
 
 /// Serializes a subset of the given DOM to a binary format model or place,

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -82,25 +82,12 @@ pub use crate::{
 };
 
 /// Deserialize a Roblox binary model or place from a stream.
-pub fn from_reader<'dom, 'file, R: Read, S: StringIntern<'file, 'dom>>(
+pub fn from_reader<'dom, R: Read, S: for<'file> StringIntern<'file, 'dom>>(
     reader: R,
     options: DecodeOptions<S>,
 ) -> Result<WeakDom<'dom>, DecodeError> {
     let file = DecompressedFile::from_reader(reader)?;
-    // SAFETY: The string internment signature gurantees that
-    // the output string slice lives for 'dom, so the input
-    // 'file lifetime is irrelevant, and yet the rust compiler
-    // forces the input lifetime to match an unspecifiable value
-    // ('file only exists inside this scope).
-    //
-    // Note that there may be a way to do this without unsafe,
-    // but I don't know how to do it.
-    unsafe fn set_lifetime<'a, T>(value: &T) -> &'a T {
-        let ptr = value as *const T;
-        unsafe { &*ptr }
-    }
-    // Force the lifetime to be 'file.
-    Deserializer::new().deserialize(unsafe { set_lifetime(&file) }, options)
+    Deserializer::new().deserialize(&file, options)
 }
 
 /// Serializes a subset of the given DOM to a binary format model or place,

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -68,6 +68,7 @@ mod tests;
 use std::io::{Read, Write};
 
 pub use deserializer::DecompressedFile;
+use deserializer::InternFunction;
 use rbx_dom_weak::{types::Ref, WeakDom};
 
 /// An unstable textual format that can be used to debug binary models.
@@ -77,14 +78,17 @@ pub mod text_format {
 }
 
 pub use crate::{
-    deserializer::{Deserializer, Error as DecodeError},
+    deserializer::{DecodeOptions, Deserializer, Error as DecodeError, StringIntern},
     serializer::{CompressionType, Error as EncodeError, Serializer},
 };
 
 /// Deserialize a Roblox binary model or place from a stream.
-pub fn from_reader<R: Read>(reader: R) -> Result<WeakDom, DecodeError> {
+pub fn from_reader<'dom, R: Read>(
+    reader: R,
+    options: DecodeOptions<InternFunction<'_, 'dom>>,
+) -> Result<WeakDom<'dom>, DecodeError> {
     let file = DecompressedFile::from_reader(reader)?;
-    Deserializer::new().deserialize(&file)
+    Deserializer::new().deserialize(&file, options)
 }
 
 /// Serializes a subset of the given DOM to a binary format model or place,

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -12,11 +12,13 @@ options.
 ```no_run
 use std::fs::File;
 use std::io::BufReader;
+use rbx_binary::{DecompressedFile, DecodeOptions};
 
 // Using buffered I/O is recommended with rbx_binary
 let input = BufReader::new(File::open("MyModel.rbxm")?);
 
-let dom = rbx_binary::from_reader(input)?;
+let file = DecompressedFile::from_reader(input)?;
+let dom = file.deserialize(DecodeOptions::read_unknown())?;
 
 // rbx_binary always returns a DOM with a DataModel at the top level.
 // To get to the instances from our file, we need to go one level deeper.

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -146,7 +146,7 @@ struct PropInfo<'db> {
     /// If a logical property has a migration associated with it (i.e. BrickColor ->
     /// Color, Font -> FontFace), this field contains Some(PropertyMigration). Otherwise,
     /// it is None.
-    migration: Option<&'db PropertyMigration>,
+    migration: Option<&'db PropertyMigration<'db>>,
 }
 
 /// Contains all of the `TypeInfo` objects known to the serializer so far. This
@@ -363,7 +363,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                 let new_descriptors = find_property_descriptors(
                                     database,
                                     instance.class,
-                                    prop_migration.new_property_name.as_str().into(),
+                                    prop_migration.new_property_name.into(),
                                 );
 
                                 migration = Some(prop_migration);
@@ -371,8 +371,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                 match new_descriptors {
                                     Some(descriptor) => match descriptor.serialized {
                                         Some(serialized) => {
-                                            canonical_name =
-                                                descriptor.canonical.name.as_ref().into();
+                                            canonical_name = descriptor.canonical.name.into();
                                             serialized
                                         }
                                         None => continue,
@@ -380,14 +379,14 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                     None => continue,
                                 }
                             } else {
-                                canonical_name = descriptors.canonical.name.as_ref().into();
+                                canonical_name = descriptors.canonical.name.into();
                                 descriptor
                             }
                         }
                         None => continue,
                     };
 
-                    serialized_name = serialized.name.as_ref().into();
+                    serialized_name = serialized.name.into();
 
                     serialized_ty = match &serialized.data_type {
                         DataType::Value(ty) => *ty,

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -5,7 +5,7 @@ use std::{
     io::Write,
 };
 
-use ahash::{HashMap, HashMapExt, HashSetExt};
+use ahash::{HashMap, HashMapExt, HashSet};
 use rbx_dom_weak::{
     types::{
         Attributes, Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
@@ -14,7 +14,7 @@ use rbx_dom_weak::{
         PhysicalProperties, Ray, Rect, Ref, SecurityCapabilities, SharedString, Tags, UDim, UDim2,
         UniqueId, Variant, VariantType, Vector2, Vector3, Vector3int16,
     },
-    Instance, Ustr, UstrSet, WeakDom,
+    Instance, WeakDom,
 };
 
 use rbx_reflection::{
@@ -43,7 +43,7 @@ pub(super) struct SerializerState<'dom, 'db, W> {
     serializer: &'db Serializer<'db>,
 
     /// The dom containing all of the instances that we're serializing.
-    dom: &'dom WeakDom,
+    dom: &'dom WeakDom<'dom>,
 
     /// Where the binary output should be written.
     output: W,
@@ -72,7 +72,7 @@ pub(super) struct SerializerState<'dom, 'db, W> {
 /// An instance class that our serializer knows about. We should have one struct
 /// per unique ClassName.
 #[derive(Debug)]
-struct TypeInfo<'dom, 'db> {
+struct TypeInfo<'dom> {
     /// The ID that this serializer will use to refer to this type of instance.
     type_id: u32,
 
@@ -82,7 +82,7 @@ struct TypeInfo<'dom, 'db> {
     is_service: bool,
 
     /// All of the instances referenced by this type.
-    instances: Vec<&'dom Instance>,
+    instances: Vec<&'dom Instance<'dom>>,
 
     /// All of the defined properties for this type found on any instance of
     /// this type. Properties are keyed by their canonical name, and only one
@@ -90,16 +90,16 @@ struct TypeInfo<'dom, 'db> {
     ///
     /// Stored in a sorted map to try to ensure that we write out properties in
     /// a deterministic order.
-    properties: BTreeMap<Ustr, PropInfo<'db>>,
+    properties: BTreeMap<&'dom str, PropInfo<'dom>>,
 
     /// A reference to the type's class descriptor from rbx_reflection, if this
     /// is a known class.
-    class_descriptor: Option<&'db ClassDescriptor<'db>>,
+    class_descriptor: Option<&'dom ClassDescriptor<'dom>>,
 
     /// A set containing the properties that we have seen so far in the file and
     /// processed. This helps us avoid traversing the reflection database
     /// multiple times if there are many copies of the same kind of instance.
-    properties_visited: UstrSet,
+    properties_visited: HashSet<&'dom str>,
 }
 
 /// A property on a specific class that our serializer knows about.
@@ -122,14 +122,14 @@ struct PropInfo<'db> {
     /// The serialized name for this property. This is the name that is actually
     /// written as part of the PROP chunk and may not line up with the canonical
     /// name for the property.
-    serialized_name: Ustr,
+    serialized_name: &'db str,
 
     /// A set containing the names of all aliases discovered while preparing to
     /// serialize this property. Ideally, this set will remain empty (and not
     /// allocate) in most cases. However, if an instance is missing a property
     /// from its canonical name, but does have another variant, we can use this
     /// set to recover and map those values.
-    aliases: UstrSet,
+    aliases: HashSet<&'db str>,
 
     /// The default value for this property that should be used if any instances
     /// are missing this property.
@@ -160,14 +160,14 @@ struct TypeInfos<'dom, 'db> {
     ///
     /// These are stored sorted so that we naturally iterate over them in order
     /// and improve our chances of being deterministic.
-    values: BTreeMap<Ustr, TypeInfo<'dom, 'db>>,
+    values: BTreeMap<&'dom str, TypeInfo<'dom>>,
 
     /// The next type ID that should be assigned if a type is discovered and
     /// added to the serializer.
     next_type_id: u32,
 }
 
-impl<'dom, 'db> TypeInfos<'dom, 'db> {
+impl<'dom, 'db: 'dom> TypeInfos<'dom, 'db> {
     fn new(database: &'db ReflectionDatabase<'db>) -> Self {
         Self {
             database,
@@ -178,12 +178,12 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
 
     /// Finds the type info from the given ClassName if it exists, or creates
     /// one and returns a reference to it if not.
-    fn get_or_create(&mut self, class: Ustr) -> &mut TypeInfo<'dom, 'db> {
+    fn get_or_create(&mut self, class: &'dom str) -> &mut TypeInfo<'dom> {
         if let btree_map::Entry::Vacant(entry) = self.values.entry(class) {
             let type_id = self.next_type_id;
             self.next_type_id += 1;
 
-            let class_descriptor = self.database.classes.get(class.as_str());
+            let class_descriptor = self.database.classes.get(class);
 
             let is_service = if let Some(descriptor) = &class_descriptor {
                 descriptor.tags.contains(&ClassTag::Service)
@@ -202,11 +202,11 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
             // We can use a dummy default_value here because instances from
             // rbx_dom_weak always have a name set.
             properties.insert(
-                "Name".into(),
+                "Name",
                 PropInfo {
                     prop_type: Type::String,
-                    serialized_name: "Name".into(),
-                    aliases: UstrSet::new(),
+                    serialized_name: "Name",
+                    aliases: HashSet::default(),
                     default_value: Cow::Owned(Variant::String(String::new())),
                     migration: None,
                 },
@@ -218,7 +218,7 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
                 instances: Vec::new(),
                 properties,
                 class_descriptor,
-                properties_visited: UstrSet::new(),
+                properties_visited: HashSet::default(),
             });
         }
 
@@ -228,8 +228,8 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
     }
 }
 
-impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
-    pub fn new(serializer: &'db Serializer<'db>, dom: &'dom WeakDom, output: W) -> Self {
+impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
+    pub fn new(serializer: &'db Serializer<'db>, dom: &'dom WeakDom<'dom>, output: W) -> Self {
         SerializerState {
             serializer,
             dom,
@@ -319,7 +319,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
         let type_info = self.type_infos.get_or_create(instance.class);
         type_info.instances.push(instance);
 
-        for (prop_name, prop_value) in &instance.properties {
+        for (&prop_name, prop_value) in &instance.properties {
             // Discover and track any shared strings we come across.
             if let Variant::SharedString(shared_string) = prop_value {
                 if !self.shared_string_ids.contains_key(shared_string) {
@@ -337,7 +337,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
 
             // ...but add it to the set of visited properties if we haven't seen
             // it.
-            type_info.properties_visited.insert(*prop_name);
+            type_info.properties_visited.insert(prop_name);
 
             let canonical_name;
             let serialized_name;
@@ -345,7 +345,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
             let mut migration = None;
 
             let database = self.serializer.database;
-            match find_property_descriptors(database, instance.class, *prop_name) {
+            match find_property_descriptors(database, instance.class, prop_name) {
                 Some(descriptors) => {
                     // For any properties that do not serialize, we can skip
                     // adding them to the set of type_infos.
@@ -363,7 +363,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                 let new_descriptors = find_property_descriptors(
                                     database,
                                     instance.class,
-                                    prop_migration.new_property_name.into(),
+                                    prop_migration.new_property_name,
                                 );
 
                                 migration = Some(prop_migration);
@@ -371,7 +371,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                 match new_descriptors {
                                     Some(descriptor) => match descriptor.serialized {
                                         Some(serialized) => {
-                                            canonical_name = descriptor.canonical.name.into();
+                                            canonical_name = descriptor.canonical.name;
                                             serialized
                                         }
                                         None => continue,
@@ -379,14 +379,14 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                     None => continue,
                                 }
                             } else {
-                                canonical_name = descriptors.canonical.name.into();
+                                canonical_name = descriptors.canonical.name;
                                 descriptor
                             }
                         }
                         None => continue,
                     };
 
-                    serialized_name = serialized.name.into();
+                    serialized_name = serialized.name;
 
                     serialized_ty = match &serialized.data_type {
                         DataType::Value(ty) => *ty,
@@ -405,8 +405,8 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                 }
 
                 None => {
-                    canonical_name = *prop_name;
-                    serialized_name = *prop_name;
+                    canonical_name = prop_name;
+                    serialized_name = prop_name;
                     serialized_ty = prop_value.ty();
                 }
             }
@@ -416,7 +416,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                     .class_descriptor
                     .and_then(|class| {
                         database
-                            .find_default_property(class, &canonical_name)
+                            .find_default_property(class, canonical_name)
                             .map(Cow::Borrowed)
                     })
                     .or_else(|| Self::fallback_default_value(serialized_ty).map(Cow::Owned))
@@ -456,7 +456,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                     PropInfo {
                         prop_type: ser_type,
                         serialized_name,
-                        aliases: UstrSet::new(),
+                        aliases: HashSet::default(),
                         default_value,
                         migration,
                     },
@@ -466,11 +466,11 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
             // If the property we found on this instance is different than the
             // canonical name for this property, stash it into the set of known
             // aliases for this PropInfo.
-            if *prop_name != canonical_name {
+            if prop_name != canonical_name {
                 let prop_info = type_info.properties.get_mut(&canonical_name).unwrap();
 
                 if !prop_info.aliases.contains(prop_name) {
-                    prop_info.aliases.insert(*prop_name);
+                    prop_info.aliases.insert(prop_name);
                 }
 
                 prop_info.migration = migration;
@@ -617,7 +617,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                 let mut chunk = ChunkBuilder::new(b"PROP", self.serializer.compression);
 
                 chunk.write_le_u32(type_info.type_id)?;
-                chunk.write_string(&prop_info.serialized_name)?;
+                chunk.write_string(prop_info.serialized_name)?;
                 chunk.write_u8(prop_info.prop_type as u8)?;
 
                 let values = type_info

--- a/rbx_binary/src/tests/util.rs
+++ b/rbx_binary/src/tests/util.rs
@@ -2,7 +2,11 @@ use std::{fs, path::Path};
 
 use rbx_dom_weak::DomViewer;
 
-use crate::{from_reader, text_deserializer::DecodedModel, to_writer};
+use crate::{
+    deserializer::{DecodeOptions, DecompressedFile},
+    text_deserializer::DecodedModel,
+    to_writer,
+};
 
 /// Run a basic gauntlet of tests to verify that the serializer and deserializer
 /// can handle this model correctly.
@@ -28,7 +32,8 @@ pub fn run_model_base_suite(model_path: impl AsRef<Path>) {
 
     // Decode the test file and snapshot a stable version of the resulting tree.
     // This should properly test the deserializer.
-    let decoded = from_reader(contents.as_slice()).unwrap();
+    let file = DecompressedFile::from_reader(contents.as_slice()).unwrap();
+    let decoded = file.deserialize(DecodeOptions::read_unknown()).unwrap();
     let decoded_viewed = DomViewer::new().view_children(&decoded);
     insta::assert_yaml_snapshot!(format!("{}__decoded", model_stem), decoded_viewed);
 
@@ -51,5 +56,8 @@ pub fn run_model_base_suite(model_path: impl AsRef<Path>) {
     // We don't make any assertions about the result right now, as our format
     // support is still lacking. In the future, we should assert that this is
     // the same as the original decoding of the test file.
-    from_reader(encoded.as_slice()).unwrap();
+    DecompressedFile::from_reader(encoded.as_slice())
+        .unwrap()
+        .deserialize(DecodeOptions::read_unknown())
+        .unwrap();
 }

--- a/rbx_dom_weak/Cargo.toml
+++ b/rbx_dom_weak/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 rbx_types = { version = "2.0.0", path = "../rbx_types", features = ["serde"] }
-ustr = { version = "1.1.0", features = ["serde"] }
 
 ahash = "0.8.11"
 serde = "1.0.137"

--- a/rbx_dom_weak/src/lib.rs
+++ b/rbx_dom_weak/src/lib.rs
@@ -48,7 +48,6 @@ mod viewer;
 pub use rbx_types as types;
 
 pub use ahash::AHashMap;
-pub use ustr::{ustr, Ustr, UstrMap, UstrSet};
 
 pub use crate::{
     dom::WeakDom,
@@ -56,26 +55,13 @@ pub use crate::{
     viewer::{DomViewer, ViewedInstance},
 };
 
-/// Helper trait that provides convenience methods for `AHashMap` and `UstrMap`.
+/// Helper trait that provides convenience methods for `AHashMap`.
 pub trait HashMapExt {
     /// Constructs an empty map.
     fn new() -> Self;
 
     /// Constructs an empty map with at least the specified capacity.
     fn with_capacity(capacity: usize) -> Self;
-}
-
-impl<V> HashMapExt for UstrMap<V> {
-    /// Creates an empty `UstrMap` using the default value for its hasher.
-    fn new() -> Self {
-        UstrMap::default()
-    }
-
-    /// Creates an empty `UstrMap` with at least the specified capacity using
-    /// the default value for its hasher.
-    fn with_capacity(capacity: usize) -> Self {
-        UstrMap::with_capacity_and_hasher(capacity, Default::default())
-    }
 }
 
 impl<K, V> HashMapExt for AHashMap<K, V> {

--- a/rbx_dom_weak/src/viewer.rs
+++ b/rbx_dom_weak/src/viewer.rs
@@ -8,7 +8,6 @@ use crate::{
     WeakDom,
 };
 use serde::{Deserialize, Serialize};
-use ustr::Ustr;
 
 /// Contains state for viewing and redacting nondeterministic portions of
 /// WeakDom objects, making them suitable for usage in snapshot tests.
@@ -81,7 +80,7 @@ impl DomViewer {
         let properties = instance
             .properties
             .iter()
-            .map(|(key, value)| {
+            .map(|(&key, value)| {
                 let new_value = match value {
                     Variant::Ref(referent) => {
                         if referent.is_some() {
@@ -111,14 +110,14 @@ impl DomViewer {
                     other => ViewedValue::Other(other.clone()),
                 };
 
-                (*key, new_value)
+                (key.to_owned(), new_value)
             })
             .collect();
 
         ViewedInstance {
             referent: self.referent_to_id.get(&referent).unwrap().clone(),
             name: instance.name.clone(),
-            class: instance.class,
+            class: instance.class.to_string(),
             properties,
             children,
         }
@@ -137,8 +136,8 @@ impl Default for DomViewer {
 pub struct ViewedInstance {
     referent: String,
     name: String,
-    class: Ustr,
-    properties: BTreeMap<Ustr, ViewedValue>,
+    class: String,
+    properties: BTreeMap<String, ViewedValue>,
     children: Vec<ViewedInstance>,
 }
 

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -2,10 +2,7 @@
 // for most cases.
 #![allow(clippy::new_without_default)]
 
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 use rbx_types::{Variant, VariantType};
 use serde::{Deserialize, Serialize};
@@ -22,12 +19,14 @@ pub struct ReflectionDatabase<'a> {
     pub version: [u32; 4],
 
     /// All of the the known classes in the database.
+    #[serde(borrow)]
     #[serde(serialize_with = "crate::serde_util::ordered_map")]
-    pub classes: HashMap<Cow<'a, str>, ClassDescriptor<'a>>,
+    pub classes: HashMap<&'a str, ClassDescriptor<'a>>,
 
     /// All of the known enums in the database.
+    #[serde(borrow)]
     #[serde(default, serialize_with = "crate::serde_util::ordered_map")]
-    pub enums: HashMap<Cow<'a, str>, EnumDescriptor<'a>>,
+    pub enums: HashMap<&'a str, EnumDescriptor<'a>>,
 }
 
 impl<'a> ReflectionDatabase<'a> {
@@ -110,7 +109,8 @@ impl<'a> ReflectionDatabase<'a> {
 #[non_exhaustive]
 pub struct ClassDescriptor<'a> {
     /// The name of the class, like "Folder" or "FlagStand".
-    pub name: Cow<'a, str>,
+    #[serde(borrow)]
+    pub name: &'a str,
 
     /// A set of all of the tags attached to this class.
     #[serde(serialize_with = "crate::serde_util::ordered_set")]
@@ -118,24 +118,27 @@ pub struct ClassDescriptor<'a> {
 
     /// If this class descends from another class, contains the name of that
     /// class.
+    #[serde(borrow)]
     #[serde(default)]
-    pub superclass: Option<Cow<'a, str>>,
+    pub superclass: Option<&'a str>,
 
     /// A map of all of the properties available on this class.
+    #[serde(borrow)]
     #[serde(serialize_with = "crate::serde_util::ordered_map")]
-    pub properties: HashMap<Cow<'a, str>, PropertyDescriptor<'a>>,
+    pub properties: HashMap<&'a str, PropertyDescriptor<'a>>,
 
     /// A map of the default properties for this instance if a value is not
     /// defined in serialization or freshly inserted with `Instance.new`.
+    #[serde(borrow)]
     #[serde(serialize_with = "crate::serde_util::ordered_map")]
-    pub default_properties: HashMap<Cow<'a, str>, Variant>,
+    pub default_properties: HashMap<&'a str, Variant>,
 }
 
 impl<'a> ClassDescriptor<'a> {
     /// Creates a new `ClassDescriptor` with the given name.
-    pub fn new<S: Into<Cow<'a, str>>>(name: S) -> Self {
+    pub fn new(name: &'a str) -> Self {
         Self {
-            name: name.into(),
+            name,
             tags: HashSet::new(),
             superclass: None,
             properties: HashMap::new(),
@@ -150,7 +153,8 @@ impl<'a> ClassDescriptor<'a> {
 #[non_exhaustive]
 pub struct PropertyDescriptor<'a> {
     /// The name of the property, like "Position" or "heat_xml".
-    pub name: Cow<'a, str>,
+    #[serde(borrow)]
+    pub name: &'a str,
 
     /// The maximum access to this property available to Lua.
     pub scriptability: Scriptability,
@@ -168,9 +172,9 @@ pub struct PropertyDescriptor<'a> {
 
 impl<'a> PropertyDescriptor<'a> {
     /// Creates a new `PropertyDescriptor` with the given name and type.
-    pub fn new<S: Into<Cow<'a, str>>>(name: S, data_type: DataType<'a>) -> Self {
+    pub fn new(name: &'a str, data_type: DataType<'a>) -> Self {
         Self {
-            name: name.into(),
+            name,
             scriptability: Scriptability::None,
             data_type,
             tags: HashSet::new(),
@@ -192,7 +196,10 @@ pub enum PropertyKind<'a> {
 
     /// This property is an alias to another property that is canonical.
     #[serde(rename_all = "PascalCase")]
-    Alias { alias_for: Cow<'a, str> },
+    Alias {
+        #[serde(borrow)]
+        alias_for: &'a str,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,12 +213,12 @@ pub enum PropertySerialization<'a> {
 
     /// The property aliases a property with the given name and should serialize
     /// from that property descriptor instead.
-    SerializesAs(Cow<'a, str>),
+    SerializesAs(#[serde(borrow)] &'a str),
 
     /// The property was originally serialized as itself, but should be migrated
     /// to a new property on deserialization. If the new property already
     /// exists, this property should be ignored.
-    Migrate(PropertyMigration),
+    Migrate(PropertyMigration<'a>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -221,7 +228,7 @@ pub enum DataType<'a> {
     Value(VariantType),
 
     /// The property is an enum with the given name.
-    Enum(Cow<'a, str>),
+    Enum(#[serde(borrow)] &'a str),
 }
 
 /// Defines how Lua can access a property, if at all.
@@ -252,18 +259,20 @@ pub enum Scriptability {
 #[non_exhaustive]
 pub struct EnumDescriptor<'a> {
     /// The name of the enum, like "FormFactor" or "Material".
-    pub name: Cow<'a, str>,
+    #[serde(borrow)]
+    pub name: &'a str,
 
     /// All of the members of this enum, stored as a map from names to values.
+    #[serde(borrow)]
     #[serde(serialize_with = "crate::serde_util::ordered_map")]
-    pub items: HashMap<Cow<'a, str>, u32>,
+    pub items: HashMap<&'a str, u32>,
 }
 
 impl<'a> EnumDescriptor<'a> {
     /// Create a new `EnumDescriptor` with the given name and no items.
-    pub fn new<S: Into<Cow<'a, str>>>(name: S) -> Self {
+    pub fn new(name: &'a str) -> Self {
         Self {
-            name: name.into(),
+            name,
             items: HashMap::new(),
         }
     }

--- a/rbx_reflection/src/migration.rs
+++ b/rbx_reflection/src/migration.rs
@@ -22,10 +22,11 @@ pub enum MigrationError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct PropertyMigration {
+pub struct PropertyMigration<'a> {
+    #[serde(borrow)]
     #[serde(rename = "To")]
-    pub new_property_name: String,
-    migration: MigrationOperation,
+    pub new_property_name: &'a str,
+    pub migration: MigrationOperation,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -37,7 +38,7 @@ pub enum MigrationOperation {
     ContentIdToContent,
 }
 
-impl PropertyMigration {
+impl PropertyMigration<'_> {
     pub fn perform(&self, input: &Variant) -> Result<Variant, MigrationError> {
         match self.migration {
             MigrationOperation::IgnoreGuiInsetToScreenInsets => {

--- a/rbx_reflection_database/src/lib.rs
+++ b/rbx_reflection_database/src/lib.rs
@@ -40,8 +40,8 @@ mod test {
         class_descriptor_eq(iter.next(), part_class_descriptor);
 
         let mut current_class_descriptor = part_class_descriptor.unwrap();
-        while let Some(superclass) = current_class_descriptor.superclass.as_ref() {
-            let superclass_descriptor = database.classes.get(superclass.as_ref());
+        while let Some(superclass) = current_class_descriptor.superclass {
+            let superclass_descriptor = database.classes.get(superclass);
             class_descriptor_eq(iter.next(), superclass_descriptor);
             current_class_descriptor = superclass_descriptor.unwrap();
         }

--- a/rbx_reflector/src/defaults.rs
+++ b/rbx_reflector/src/defaults.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::{HashSet, VecDeque},
     fs::File,
     io::BufReader,
@@ -59,15 +58,13 @@ fn apply_instance_defaults(database: &mut ReflectionDatabase, instance: &Instanc
     };
 
     for (property_name, property_value) in &instance.properties {
-        let property_name = Cow::Owned(property_name.to_string());
-
         match property_value.ty() {
             // We skip the Ref type because its default value is not useful.
             VariantType::Ref => continue,
 
             _ => class
                 .default_properties
-                .insert(property_name, property_value.clone()),
+                .insert(property_name.as_str(), property_value.clone()),
         };
     }
 }

--- a/rbx_reflector/src/patches.rs
+++ b/rbx_reflector/src/patches.rs
@@ -1,9 +1,8 @@
-use std::{borrow::Cow, collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, fs, path::Path};
 
 use anyhow::{anyhow, bail, Context};
 use rbx_reflection::{
-    DataType, PropertyKind, PropertyMigration, PropertySerialization, ReflectionDatabase,
-    Scriptability,
+    MigrationOperation, PropertyKind, PropertySerialization, ReflectionDatabase, Scriptability,
 };
 use rbx_types::{Variant, VariantType};
 use serde::Deserialize;
@@ -28,7 +27,10 @@ impl Patches {
         Ok(Self { change })
     }
 
-    pub fn apply_pre_default(&self, database: &mut ReflectionDatabase) -> anyhow::Result<()> {
+    pub fn apply_pre_default<'db>(
+        &'db self,
+        database: &mut ReflectionDatabase<'db>,
+    ) -> anyhow::Result<()> {
         for (class_name, class_changes) in &self.change {
             let class = database
                 .classes
@@ -53,7 +55,7 @@ impl Patches {
                     })?;
 
                 if let Some(data_type) = &property_change.data_type {
-                    existing_property.data_type = data_type.clone();
+                    existing_property.data_type = data_type.into();
                 }
 
                 if let Some(kind) = property_change.kind() {
@@ -92,7 +94,10 @@ impl Patches {
         Ok(())
     }
 
-    pub fn apply_post_default(&self, database: &mut ReflectionDatabase) -> anyhow::Result<()> {
+    pub fn apply_post_default<'db>(
+        &'db self,
+        database: &mut ReflectionDatabase<'db>,
+    ) -> anyhow::Result<()> {
         // A map of every class to all subclasses, by name. This uses `String`
         // rather than some borrowed variant to get around borrowing `database`
         // as both mutable and immutable
@@ -123,8 +128,8 @@ impl Patches {
                     .get(prop_name.as_str());
                 if let Some(prop_data) = prop_data {
                     match (&prop_data.data_type, default_value.ty()) {
-                        (DataType::Enum(_), VariantType::Enum) => {}
-                        (DataType::Value(existing), new) if *existing == new => {}
+                        (rbx_reflection::DataType::Enum(_), VariantType::Enum) => {}
+                        (rbx_reflection::DataType::Value(existing), new) if *existing == new => {}
                         (expected, actual) => bail!(
                             "Bad type given for {class_name}.{prop_name}'s DefaultValue patch.\n\
                             Expected {expected:?}, got {actual:?}"
@@ -144,7 +149,7 @@ impl Patches {
                         .expect("class listed in subclass map should exist");
                     class
                         .default_properties
-                        .insert(prop_name.clone().into(), default_value.clone());
+                        .insert(prop_name.as_str(), default_value.clone());
                 }
             }
         }
@@ -163,22 +168,38 @@ struct Patch {
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase", deny_unknown_fields)]
 struct PropertyChange {
-    data_type: Option<DataType<'static>>,
+    data_type: Option<DataType>,
     alias_for: Option<String>,
     serialization: Option<Serialization>,
     scriptability: Option<Scriptability>,
     default_value: Option<Variant>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[non_exhaustive]
+pub enum DataType {
+    /// The property is a regular value of the given type.
+    Value(VariantType),
+
+    /// The property is an enum with the given name.
+    Enum(String),
+}
+impl<'db> From<&'db DataType> for rbx_reflection::DataType<'db> {
+    fn from(value: &'db DataType) -> Self {
+        match value {
+            DataType::Value(variant_type) => rbx_reflection::DataType::Value(*variant_type),
+            DataType::Enum(e) => rbx_reflection::DataType::Enum(e),
+        }
+    }
+}
+
 impl PropertyChange {
-    fn kind(&self) -> Option<PropertyKind<'static>> {
+    fn kind(&self) -> Option<PropertyKind<'_>> {
         match (&self.alias_for, &self.serialization) {
-            (Some(alias), None) => Some(PropertyKind::Alias {
-                alias_for: Cow::Owned(alias.clone()),
-            }),
+            (Some(alias_for), None) => Some(PropertyKind::Alias { alias_for }),
 
             (None, Some(serialization)) => Some(PropertyKind::Canonical {
-                serialization: serialization.clone().into(),
+                serialization: serialization.into(),
             }),
 
             (None, None) => None,
@@ -201,15 +222,29 @@ pub enum Serialization {
     Migrate(PropertyMigration),
 }
 
-impl From<Serialization> for PropertySerialization<'_> {
-    fn from(value: Serialization) -> Self {
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PropertyMigration {
+    #[serde(rename = "To")]
+    new_property_name: String,
+    migration: MigrationOperation,
+}
+
+impl<'db> From<&'db Serialization> for PropertySerialization<'db> {
+    fn from(value: &'db Serialization) -> Self {
         match value {
             Serialization::Serializes => PropertySerialization::Serializes,
             Serialization::DoesNotSerialize => PropertySerialization::DoesNotSerialize,
             Serialization::SerializesAs { serializes_as } => {
-                PropertySerialization::SerializesAs(Cow::Owned(serializes_as))
+                PropertySerialization::SerializesAs(serializes_as)
             }
-            Serialization::Migrate(migration) => PropertySerialization::Migrate(migration),
+            Serialization::Migrate(PropertyMigration {
+                new_property_name,
+                migration,
+            }) => PropertySerialization::Migrate(rbx_reflection::PropertyMigration {
+                new_property_name,
+                migration: *migration,
+            }),
         }
     }
 }

--- a/rbx_xml/src/core.rs
+++ b/rbx_xml/src/core.rs
@@ -89,7 +89,7 @@ fn find_property_descriptors<'db>(
                     PropertySerialization::SerializesAs(serialized_name) => {
                         let serialized_descriptor = current_class_descriptor
                             .properties
-                            .get(serialized_name.as_ref())
+                            .get(serialized_name)
                             .unwrap();
 
                         return Some((property_descriptor, serialized_descriptor));
@@ -97,10 +97,8 @@ fn find_property_descriptors<'db>(
                     _ => unimplemented!(),
                 },
                 PropertyKind::Alias { alias_for } => {
-                    let canonical_descriptor = current_class_descriptor
-                        .properties
-                        .get(alias_for.as_ref())
-                        .unwrap();
+                    let canonical_descriptor =
+                        current_class_descriptor.properties.get(alias_for).unwrap();
 
                     // FIXME: This code is duplicated with above.
                     match &canonical_descriptor.kind {
@@ -116,7 +114,7 @@ fn find_property_descriptors<'db>(
                             PropertySerialization::SerializesAs(serialized_name) => {
                                 let serialized_descriptor = current_class_descriptor
                                     .properties
-                                    .get(serialized_name.as_ref())
+                                    .get(serialized_name)
                                     .unwrap();
 
                                 return Some((canonical_descriptor, serialized_descriptor));

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -588,12 +588,16 @@ fn deserialize_properties<R: Read>(
         };
 
         if let Some(descriptor) = maybe_descriptor {
-            let value =
-                match read_value_xml(reader, state, &xml_type_name, instance_id, &descriptor.name)?
-                {
-                    Some(value) => value,
-                    None => continue,
-                };
+            let value = match read_value_xml(
+                reader,
+                state,
+                &xml_type_name,
+                instance_id,
+                descriptor.name,
+            )? {
+                Some(value) => value,
+                None => continue,
+            };
 
             let xml_ty = value.ty();
 
@@ -635,8 +639,8 @@ fn deserialize_properties<R: Read>(
                 PropertyKind::Canonical {
                     serialization: PropertySerialization::Migrate(migration),
                 } => {
-                    let new_property_name = &migration.new_property_name;
-                    let old_property_name = &descriptor.name;
+                    let new_property_name = migration.new_property_name;
+                    let old_property_name = descriptor.name;
 
                     if let Entry::Vacant(entry) = props.entry(new_property_name.into()) {
                         log::trace!(
@@ -656,7 +660,7 @@ fn deserialize_properties<R: Read>(
                     }
                 }
                 _ => {
-                    props.insert(descriptor.name.as_ref().into(), value);
+                    props.insert(descriptor.name.into(), value);
                 }
             };
         } else {

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -208,7 +208,7 @@ fn serialize_instance<'dom, W: Write>(
                 _ => unimplemented!(),
             };
 
-            let mut serialized_name = serialized_descriptor.name.as_ref();
+            let mut serialized_name = serialized_descriptor.name;
 
             let mut converted_value = match value.try_convert_ref(instance.class, data_type) {
                 Ok(value) => value,
@@ -234,7 +234,7 @@ fn serialize_instance<'dom, W: Write>(
                 // since old values will still load in Studio.
                 if let Ok(new_value) = migration.perform(&converted_value) {
                     converted_value = Cow::Owned(new_value);
-                    serialized_name = &migration.new_property_name
+                    serialized_name = migration.new_property_name
                 }
             }
 


### PR DESCRIPTION
- Depends on #528 to avoid Cow AsRef using 'de lifetime instead of 'db
- Depends on #530 to hold &str references of chunk data
- Depends on  #532 to prevent dropping decompressed chunks while holding references

Closes #515.

Here's a draft of what it could look like to drop the ustr sledgehammer in favour of fine-grained memory control. This addresses all my concerns in #515.  There is only enough code here to run rbx_binary benches, but the rest of the code for rbx_xml, rbx_util, rbx_reflector, etc. can be adapted from my raw-str branch https://github.com/krakow10/rbx-dom/compare/1482a07ec4d6184fee6769f62745fdcc177c6d49...raw-str, which is where most of this code came from as well.

Here are just the commits on top of the prerequisite dependencies:
branch https://github.com/krakow10/rbx-dom/compare/prereq...lifetimes

Overview:
- `Ustr` is completely dropped in favour of `&'a str` for properties and class names
- Introduce lifetimes to `WeakDom` and `Instance` for properties
- Introduce `DecodeOptions` to rbx_binary with an optional string interner

Performance:
Deserialization is within 2%, but Serialization performance seems to be significantly (40%) slower, which I don't understand why.  Most of the code affects deserialization only.  I suspect it could have to do with using `HashSet<&str>` instead of `UstrSet`.

There are three supported use cases:
1. Ignore or deny invalid properties, get `WeakDom<'static>`:
```Rust
let dom = rbx_binary::from_reader(reader, DecodeOptions::ignore_unknown())?;
let dom = rbx_binary::from_reader(reader, DecodeOptions::error_on_unknown())?;
```
2. Allow invalid properties by referencing `DecompressedFile` binding, required to outlive `WeakDom<'dom>`:
```Rust
let file = DecompressedFile::from_reader(reader)?;
let dom = file.deserialize(DecodeOptions::read_unknown())?;
```
3. Allow invalid properties using a custom string interner, enabling the DecompressedFile data to be immediately dropped to save memory:
```Rust
let host = bumpalo::Bump::new();
let mut cache = HashSet::new();
let dom = rbx_binary::from_reader(reader, DecodeOptions::read_unknown_with(|str: &str|{
	match cache.get(str) {
		Some(interned) => interned,
		None => {
			let interned = host.alloc_str(str) as &str;
			cache.insert(interned);
			interned
		}
	}
}))?;
```