### PR TITLE
Silence Unused Import Lint in `rbx_binary`

### DIFF
--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -9,6 +9,7 @@ use rbx_reflection::ReflectionDatabase;
 
 use self::state::DeserializerState;
 
+#[cfg(any(test, feature = "unstable_text_format"))]
 pub(crate) use self::header::FileHeader;
 
 pub use self::error::Error;


### PR DESCRIPTION
This lint shows up when the `unstable_text_format` feature is disabled.