### PR TITLE
Update authors fields for crates and relicense repository

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Lucien Greathouse
+Copyright (c) 2018-2025 The Rojo Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -7,7 +7,11 @@ documentation = "https://docs.rs/rbx_binary"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
 repository = "https://github.com/rojo-rbx/rbx-dom.git"
 readme = "README.md"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 
 [features]

--- a/rbx_dom_weak/Cargo.toml
+++ b/rbx_dom_weak/Cargo.toml
@@ -7,7 +7,11 @@ documentation = "https://docs.rs/rbx_dom_weak"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
 repository = "https://github.com/rojo-rbx/rbx-dom.git"
 readme = "README.md"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 
 [dependencies]

--- a/rbx_reflection/Cargo.toml
+++ b/rbx_reflection/Cargo.toml
@@ -7,7 +7,11 @@ documentation = "https://docs.rs/rbx_reflection"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
 repository = "https://github.com/rojo-rbx/rbx-dom.git"
 readme = "README.md"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 
 [dependencies]

--- a/rbx_reflection_database/Cargo.toml
+++ b/rbx_reflection_database/Cargo.toml
@@ -7,7 +7,11 @@ documentation = "https://docs.rs/rbx_reflection_database"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
 repository = "https://github.com/rojo-rbx/rbx-dom.git"
 readme = "README.md"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rbx_types/Cargo.toml
+++ b/rbx_types/Cargo.toml
@@ -2,7 +2,11 @@
 name = "rbx_types"
 description = "Types used to represent Roblox values"
 version = "2.0.0"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 license = "MIT"
 readme = "README.md"

--- a/rbx_util/Cargo.toml
+++ b/rbx_util/Cargo.toml
@@ -6,7 +6,11 @@ license = "MIT"
 documentation = "https://docs.rs/rbx_util"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
 repository = "https://github.com/rojo-rbx/rbx-dom.git"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 readme = "README.md"
 

--- a/rbx_xml/Cargo.toml
+++ b/rbx_xml/Cargo.toml
@@ -7,7 +7,11 @@ documentation = "https://docs.rs/rbx_xml"
 homepage = "https://github.com/rojo-rbx/rbx-dom"
 repository = "https://github.com/rojo-rbx/rbx-dom.git"
 readme = "README.md"
-authors = ["Lucien Greathouse <me@lpghatguy.com>"]
+authors = [
+    "Lucien Greathouse <me@lpghatguy.com>",
+    "Micah Reid <git@dekkonot.com>",
+    "Ken Loeffler <kenloef@gmail.com>",
+]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
After a brief discussion with Lucien, rbx-dom will be relicensed to be owned by the Rojo Developers. It was before, and then Roblox owned the repo, and when it was given back to Lucien he put himself as the owner. I've chosen to not reflect the incredibly confusing timeline under the assumption that nobody will care, but I _can_ reflect it in the license if we want.

In the same email, he suggested adding the current maintainers as authors to the various `Cargo.toml`s and I think that's a good decision so this PR does that too. I'll be opening a similar one for Rojo soon(tm).

I can attach the email I received if we want to be legally airtight but I generally default to not attaching emails to things unless I have to.