### PR TITLE
Use extend in `generate_referents`

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -485,7 +485,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
     #[profiling::function]
     pub fn generate_referents(&mut self) {
         // This performs the same check as next_referent.try_into().unwrap() but only once.
-        assert!(self.relevant_instances.len() < i32::MAX as usize);
+        assert!(self.relevant_instances.len() <= i32::MAX as usize);
 
         self.id_to_referent.extend(
             self.relevant_instances

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::{Borrow, Cow},
     collections::{btree_map, BTreeMap},
-    convert::TryInto,
     io::Write,
 };
 
@@ -485,12 +484,15 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
     /// be serializing to the model.
     #[profiling::function]
     pub fn generate_referents(&mut self) {
-        self.id_to_referent.reserve(self.relevant_instances.len());
+        // This performs the same check as next_referent.try_into().unwrap() but only once.
+        assert!(self.relevant_instances.len() < i32::MAX as usize);
 
-        for (next_referent, id) in self.relevant_instances.iter().enumerate() {
-            self.id_to_referent
-                .insert(*id, next_referent.try_into().unwrap());
-        }
+        self.id_to_referent.extend(
+            self.relevant_instances
+                .iter()
+                .enumerate()
+                .map(|(next_referent, id)| (*id, next_referent as i32)),
+        );
 
         log::debug!("Collected {} referents", self.id_to_referent.len());
     }


### PR DESCRIPTION
Use a primitive cast and refactor the loop into an iterator.  I kept the panic condition that was being checked for every sequential index, except factored out of the loop.  This is somehow 4% faster on "Miner's Haven/Serialize"?  Everything helps I guess.