### PR TITLE
rbx_reflection: Add `DataType.ty()`

### DIFF
--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -12,7 +12,7 @@ use rbx_dom_weak::{
     },
     InstanceBuilder, Ustr, WeakDom,
 };
-use rbx_reflection::{DataType, PropertyKind, PropertySerialization, ReflectionDatabase};
+use rbx_reflection::{PropertyKind, PropertySerialization, ReflectionDatabase};
 
 use crate::{
     chunk::Chunk,
@@ -129,14 +129,7 @@ fn find_canonical_property<'de>(
 
             // TODO: Do we need an additional fix here?
             let canonical_name = &descriptors.canonical.name;
-            let canonical_type = match &descriptors.canonical.data_type {
-                DataType::Value(ty) => *ty,
-                DataType::Enum(_) => VariantType::Enum,
-                _ => {
-                    // TODO: Configurable handling of unknown types?
-                    return None;
-                }
-            };
+            let canonical_type = descriptors.canonical.data_type.ty();
             let migration = match &descriptors.canonical.kind {
                 PropertyKind::Canonical {
                     serialization: migration @ PropertySerialization::Migrate(_),

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -18,7 +18,7 @@ use rbx_dom_weak::{
 };
 
 use rbx_reflection::{
-    ClassDescriptor, ClassTag, DataType, PropertyKind, PropertyMigration, PropertySerialization,
+    ClassDescriptor, ClassTag, PropertyKind, PropertyMigration, PropertySerialization,
     ReflectionDatabase,
 };
 
@@ -389,20 +389,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
 
                     serialized_name = serialized.name.as_ref().into();
 
-                    serialized_ty = match &serialized.data_type {
-                        DataType::Value(ty) => *ty,
-                        DataType::Enum(_) => VariantType::Enum,
-
-                        unknown_ty => {
-                            // rbx_binary is not new enough to handle this kind
-                            // of property, whatever it is.
-                            return Err(InnerError::UnsupportedPropType {
-                                type_name: instance.class.to_string(),
-                                prop_name: prop_name.to_string(),
-                                prop_type: format!("{:?}", unknown_ty),
-                            });
-                        }
-                    };
+                    serialized_ty = serialized.data_type.ty();
                 }
 
                 None => {

--- a/rbx_reflection/src/database.rs
+++ b/rbx_reflection/src/database.rs
@@ -223,6 +223,14 @@ pub enum DataType<'a> {
     /// The property is an enum with the given name.
     Enum(Cow<'a, str>),
 }
+impl DataType<'_> {
+    pub fn ty(&self) -> VariantType {
+        match self {
+            DataType::Value(variant_type) => *variant_type,
+            DataType::Enum(_) => VariantType::Enum,
+        }
+    }
+}
 
 /// Defines how Lua can access a property, if at all.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/rbx_reflector/src/patches.rs
+++ b/rbx_reflector/src/patches.rs
@@ -5,7 +5,7 @@ use rbx_reflection::{
     DataType, PropertyKind, PropertyMigration, PropertySerialization, ReflectionDatabase,
     Scriptability,
 };
-use rbx_types::{Variant, VariantType};
+use rbx_types::Variant;
 use serde::Deserialize;
 
 pub struct Patches {
@@ -122,9 +122,8 @@ impl Patches {
                     .properties
                     .get(prop_name.as_str());
                 if let Some(prop_data) = prop_data {
-                    match (&prop_data.data_type, default_value.ty()) {
-                        (DataType::Enum(_), VariantType::Enum) => {}
-                        (DataType::Value(existing), new) if *existing == new => {}
+                    match (prop_data.data_type.ty(), default_value.ty()) {
+                        (existing, new) if existing == new => {}
                         (expected, actual) => bail!(
                             "Bad type given for {class_name}.{prop_name}'s DefaultValue patch.\n\
                             Expected {expected:?}, got {actual:?}"

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -3,10 +3,10 @@ use std::{collections::hash_map::Entry, io::Read};
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use log::trace;
 use rbx_dom_weak::{
-    types::{Ref, SharedString, Variant, VariantType},
+    types::{Ref, SharedString, Variant},
     InstanceBuilder, Ustr, WeakDom,
 };
-use rbx_reflection::{DataType, PropertyKind, PropertySerialization, ReflectionDatabase};
+use rbx_reflection::{PropertyKind, PropertySerialization, ReflectionDatabase};
 
 use crate::{
     conversion::ConvertVariant,
@@ -606,11 +606,7 @@ fn deserialize_properties<R: Read>(
             // For example:
             // - Int/Float widening from 32-bit to 64-bit
             // - BrickColor properties turning into Color3
-            let expected_type = match &descriptor.data_type {
-                DataType::Value(data_type) => *data_type,
-                DataType::Enum(_enum_name) => VariantType::Enum,
-                _ => unimplemented!(),
-            };
+            let expected_type = descriptor.data_type.ty();
             log::trace!("property's read type: {xml_ty:?}, canonical type: {expected_type:?}");
 
             let value = match value.try_convert(class_name, expected_type) {

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -2,10 +2,10 @@ use std::{borrow::Cow, collections::BTreeMap, io::Write};
 
 use ahash::{HashMap, HashMapExt};
 use rbx_dom_weak::{
-    types::{Ref, SharedString, SharedStringHash, Variant, VariantType},
+    types::{Ref, SharedString, SharedStringHash, Variant},
     WeakDom,
 };
-use rbx_reflection::{DataType, PropertyKind, PropertySerialization, ReflectionDatabase};
+use rbx_reflection::{PropertyKind, PropertySerialization, ReflectionDatabase};
 
 use crate::{
     conversion::ConvertVariant,
@@ -202,11 +202,7 @@ fn serialize_instance<'dom, W: Write>(
         };
 
         if let Some(serialized_descriptor) = maybe_serialized_descriptor {
-            let data_type = match &serialized_descriptor.data_type {
-                DataType::Value(data_type) => *data_type,
-                DataType::Enum(_enum_name) => VariantType::Enum,
-                _ => unimplemented!(),
-            };
+            let data_type = serialized_descriptor.data_type.ty();
 
             let mut serialized_name = serialized_descriptor.name.as_ref();
 


### PR DESCRIPTION
All call sites become simplified with this conversion function.  The non-exhaustive cases are no longer applicable because the matching is handled from within the same crate as `DataType` is defined.