### PR TITLE
rbx_binary: Prefer IntoIterator For `RbxWriteExt::write_interleaved_*`

### DIFF
--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -260,16 +260,22 @@ pub trait RbxWriteExt: Write {
     /// bytes. Transformation is applied to the values as they're written.
     fn write_interleaved_i32_array<I>(&mut self, values: I) -> io::Result<()>
     where
-        I: Iterator<Item = i32>,
+        I: IntoIterator<Item = i32>,
     {
-        let values: Vec<_> = values.map(|v| transform_i32(v).to_be_bytes()).collect();
+        let values: Vec<_> = values
+            .into_iter()
+            .map(|v| transform_i32(v).to_be_bytes())
+            .collect();
         self.write_interleaved_bytes(&values)
     }
 
     /// Writes all items from `values` into the buffer as a blob of interleaved
     /// bytes.
-    fn write_interleaved_u32_array(&mut self, values: &[u32]) -> io::Result<()> {
-        let values: Vec<_> = values.iter().map(|v| v.to_be_bytes()).collect();
+    fn write_interleaved_u32_array<I>(&mut self, values: I) -> io::Result<()>
+    where
+        I: IntoIterator<Item = u32>,
+    {
+        let values: Vec<_> = values.into_iter().map(|v| v.to_be_bytes()).collect();
         self.write_interleaved_bytes(&values)
     }
 
@@ -277,9 +283,10 @@ pub trait RbxWriteExt: Write {
     /// bytes. Rotation is applied to the values as they're written.
     fn write_interleaved_f32_array<I>(&mut self, values: I) -> io::Result<()>
     where
-        I: Iterator<Item = f32>,
+        I: IntoIterator<Item = f32>,
     {
         let values: Vec<_> = values
+            .into_iter()
             .map(|v| v.to_bits().rotate_left(1).to_be_bytes())
             .collect();
         self.write_interleaved_bytes(&values)
@@ -290,10 +297,10 @@ pub trait RbxWriteExt: Write {
     /// values are written.
     fn write_referent_array<I>(&mut self, values: I) -> io::Result<()>
     where
-        I: Iterator<Item = i32>,
+        I: IntoIterator<Item = i32>,
     {
         let mut last_value = 0;
-        let delta_encoded = values.map(|value| {
+        let delta_encoded = values.into_iter().map(|value| {
             let encoded = value - last_value;
             last_value = value;
             encoded
@@ -306,9 +313,12 @@ pub trait RbxWriteExt: Write {
     /// bytes. Transformation is applied to the values as they're written.
     fn write_interleaved_i64_array<I>(&mut self, values: I) -> io::Result<()>
     where
-        I: Iterator<Item = i64>,
+        I: IntoIterator<Item = i64>,
     {
-        let values: Vec<_> = values.map(|v| transform_i64(v).to_be_bytes()).collect();
+        let values: Vec<_> = values
+            .into_iter()
+            .map(|v| transform_i64(v).to_be_bytes())
+            .collect();
         self.write_interleaved_bytes(&values)
     }
 }

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -744,7 +744,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_i32_array(buf.into_iter())?;
+                        chunk.write_interleaved_i32_array(buf)?;
                     }
                     Type::Float32 => {
                         let mut buf = Vec::with_capacity(values.len());
@@ -757,7 +757,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(buf.into_iter())?;
+                        chunk.write_interleaved_f32_array(buf)?;
                     }
                     Type::Float64 => {
                         for (i, rbx_value) in values {
@@ -785,8 +785,8 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(scale.into_iter())?;
-                        chunk.write_interleaved_i32_array(offset.into_iter())?;
+                        chunk.write_interleaved_f32_array(scale)?;
+                        chunk.write_interleaved_i32_array(offset)?;
                     }
                     Type::UDim2 => {
                         let mut scale_x = Vec::with_capacity(values.len());
@@ -805,10 +805,10 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(scale_x.into_iter())?;
-                        chunk.write_interleaved_f32_array(scale_y.into_iter())?;
-                        chunk.write_interleaved_i32_array(offset_x.into_iter())?;
-                        chunk.write_interleaved_i32_array(offset_y.into_iter())?;
+                        chunk.write_interleaved_f32_array(scale_x)?;
+                        chunk.write_interleaved_f32_array(scale_y)?;
+                        chunk.write_interleaved_i32_array(offset_x)?;
+                        chunk.write_interleaved_i32_array(offset_y)?;
                     }
                     Type::Font => {
                         for (i, rbx_value) in values {
@@ -869,7 +869,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_u32_array(&numbers)?;
+                        chunk.write_interleaved_u32_array(numbers)?;
                     }
                     Type::Color3 => {
                         let mut r = Vec::with_capacity(values.len());
@@ -886,9 +886,9 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(r.into_iter())?;
-                        chunk.write_interleaved_f32_array(g.into_iter())?;
-                        chunk.write_interleaved_f32_array(b.into_iter())?;
+                        chunk.write_interleaved_f32_array(r)?;
+                        chunk.write_interleaved_f32_array(g)?;
+                        chunk.write_interleaved_f32_array(b)?;
                     }
                     Type::Vector2 => {
                         let mut x = Vec::with_capacity(values.len());
@@ -903,8 +903,8 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(x.into_iter())?;
-                        chunk.write_interleaved_f32_array(y.into_iter())?;
+                        chunk.write_interleaved_f32_array(x)?;
+                        chunk.write_interleaved_f32_array(y)?;
                     }
                     Type::Vector3 => {
                         let mut x = Vec::with_capacity(values.len());
@@ -921,9 +921,9 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(x.into_iter())?;
-                        chunk.write_interleaved_f32_array(y.into_iter())?;
-                        chunk.write_interleaved_f32_array(z.into_iter())?;
+                        chunk.write_interleaved_f32_array(x)?;
+                        chunk.write_interleaved_f32_array(y)?;
+                        chunk.write_interleaved_f32_array(z)?;
                     }
                     Type::CFrame => {
                         let mut rotations = Vec::with_capacity(values.len());
@@ -962,9 +962,9 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(x.into_iter())?;
-                        chunk.write_interleaved_f32_array(y.into_iter())?;
-                        chunk.write_interleaved_f32_array(z.into_iter())?;
+                        chunk.write_interleaved_f32_array(x)?;
+                        chunk.write_interleaved_f32_array(y)?;
+                        chunk.write_interleaved_f32_array(z)?;
                     }
                     Type::Enum => {
                         let mut buf = Vec::with_capacity(values.len());
@@ -977,7 +977,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_u32_array(&buf)?;
+                        chunk.write_interleaved_u32_array(buf)?;
                     }
                     Type::Ref => {
                         let mut buf = Vec::with_capacity(values.len());
@@ -994,7 +994,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_referent_array(buf.into_iter())?;
+                        chunk.write_referent_array(buf)?;
                     }
                     Type::Vector3int16 => {
                         for (i, rbx_value) in values {
@@ -1068,10 +1068,10 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(x_min.into_iter())?;
-                        chunk.write_interleaved_f32_array(y_min.into_iter())?;
-                        chunk.write_interleaved_f32_array(x_max.into_iter())?;
-                        chunk.write_interleaved_f32_array(y_max.into_iter())?;
+                        chunk.write_interleaved_f32_array(x_min)?;
+                        chunk.write_interleaved_f32_array(y_min)?;
+                        chunk.write_interleaved_f32_array(x_max)?;
+                        chunk.write_interleaved_f32_array(y_max)?;
                     }
                     Type::PhysicalProperties => {
                         for (i, rbx_value) in values {
@@ -1133,7 +1133,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_i64_array(buf.into_iter())?;
+                        chunk.write_interleaved_i64_array(buf)?;
                     }
                     Type::SharedString => {
                         let mut entries = Vec::with_capacity(values.len());
@@ -1153,7 +1153,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_u32_array(&entries)?;
+                        chunk.write_interleaved_u32_array(entries)?;
                     }
                     Type::OptionalCFrame => {
                         let mut rotations = Vec::with_capacity(values.len());
@@ -1204,9 +1204,9 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_f32_array(x.into_iter())?;
-                        chunk.write_interleaved_f32_array(y.into_iter())?;
-                        chunk.write_interleaved_f32_array(z.into_iter())?;
+                        chunk.write_interleaved_f32_array(x)?;
+                        chunk.write_interleaved_f32_array(y)?;
+                        chunk.write_interleaved_f32_array(z)?;
 
                         chunk.write_u8(Type::Bool as u8)?;
                         chunk.write_all(bools.as_slice())?;
@@ -1241,7 +1241,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             }
                         }
 
-                        chunk.write_interleaved_i64_array(capabilities.into_iter())?;
+                        chunk.write_interleaved_i64_array(capabilities)?;
                     }
                     Type::Content => {
                         let mut source_types = Vec::with_capacity(values.len());
@@ -1269,14 +1269,14 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                 return type_mismatch(i, &rbx_value, "Content");
                             }
                         }
-                        chunk.write_interleaved_i32_array(source_types.into_iter())?;
+                        chunk.write_interleaved_i32_array(source_types)?;
 
                         chunk.write_le_u32(uris.len() as u32)?;
                         for uri in uris {
                             chunk.write_string(&uri)?;
                         }
                         chunk.write_le_u32(objects.len() as u32)?;
-                        chunk.write_referent_array(objects.into_iter())?;
+                        chunk.write_referent_array(objects)?;
 
                         // If we ever need to support the external referents,
                         // we will need to add it here.


### PR DESCRIPTION
- Superseded by #545 (builds on and replaces these changes)

`IntoIterator` is the best trait bound for an iterable function argument, just like `Vec::extend`.  Calling .into_iter() on anything already an iterator is a no-op.