### PR TITLE
rbx_binary: serializer: Index Properties Once

### DIFF
--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -20,7 +20,7 @@ rbx_reflection_database = { version = "1.0.3", path = "../rbx_reflection_databas
 
 ahash = "0.8.11"
 log = "0.4.17"
-lz4 = "1.23.3"
+lz4_flex = "0.11"
 thiserror = "1.0.31"
 serde = { version = "1.0.137", features = ["derive"], optional = true }
 profiling = "1.0.6"

--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0.31"
 serde = { version = "1.0.137", features = ["derive"], optional = true }
 profiling = "1.0.6"
 zstd = "0.13.2"
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/rbx_binary/src/chunk.rs
+++ b/rbx_binary/src/chunk.rs
@@ -41,7 +41,8 @@ impl Chunk {
                 zstd::bulk::decompress(&compressed_data, header.len as usize)?
             } else {
                 log::trace!("LZ4 compression");
-                lz4::block::decompress(&compressed_data, Some(header.len as i32))?
+                lz4_flex::block::decompress(&compressed_data, header.len as usize)
+                    .map_err(io::Error::other)?
             }
         };
 
@@ -83,7 +84,7 @@ impl ChunkBuilder {
 
         match self.compression {
             CompressionType::Lz4 => {
-                let compressed = lz4::block::compress(&self.buffer, None, false)?;
+                let compressed = lz4_flex::block::compress(&self.buffer);
 
                 writer.write_le_u32(compressed.len() as u32)?;
                 writer.write_le_u32(self.buffer.len() as u32)?;

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -665,29 +665,6 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                 chunk.write_string(&prop_info.serialized_name)?;
                 chunk.write_u8(prop_info.prop_type as u8)?;
 
-                // Do migration
-                let migrated_values_bind: Vec<_>;
-                let migrated_values;
-                let property_values = if let Some(property_migration) = prop_info.migration {
-                    migrated_values_bind = prop_info
-                        .values
-                        .iter()
-                        .map(|&value| {
-                            property_migration
-                                .perform(value)
-                                // take original if migration failed
-                                .map_or(Cow::Borrowed(value), Cow::Owned)
-                        })
-                        .collect();
-                    // We need to map twice to type match `values`
-                    migrated_values = migrated_values_bind.iter().map(Cow::as_ref).collect();
-                    &migrated_values
-                } else {
-                    &prop_info.values
-                };
-
-                let values = property_values.iter().copied().enumerate();
-
                 // Helper to generate a type mismatch error with context from
                 // this chunk.
                 let type_mismatch =
@@ -708,15 +685,39 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                     prop_type: format!("{:?}", bad_value.ty()),
                 };
 
-                write_prop_values(
-                    &mut chunk,
-                    &self.id_to_referent,
-                    &self.shared_string_ids,
-                    prop_info.prop_type,
-                    values,
-                    type_mismatch,
-                    invalid_value,
-                )?;
+                if let Some(property_migration) = prop_info.migration {
+                    let migrated_values_bind: Vec<_> = prop_info
+                        .values
+                        .iter()
+                        .map(|&value| {
+                            property_migration
+                                .perform(value)
+                                // take original if migration failed
+                                .map_or(Cow::Borrowed(value), Cow::Owned)
+                        })
+                        .collect();
+
+                    write_prop_values(
+                        &mut chunk,
+                        &self.id_to_referent,
+                        &self.shared_string_ids,
+                        prop_info.prop_type,
+                        migrated_values_bind.iter().map(Cow::as_ref).enumerate(),
+                        type_mismatch,
+                        invalid_value,
+                    )?;
+                } else {
+                    write_prop_values(
+                        &mut chunk,
+                        &self.id_to_referent,
+                        &self.shared_string_ids,
+                        prop_info.prop_type,
+                        prop_info.values.iter().copied().enumerate(),
+                        type_mismatch,
+                        invalid_value,
+                    )?;
+                };
+
                 chunk.dump(&mut self.output)?;
             }
             fn write_prop_values<'a, I, TypeMismatch, InvalidValue>(

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    borrow::{Borrow, Cow},
+    borrow::Cow,
     collections::{btree_map, BTreeMap},
     convert::TryInto,
     io::Write,
@@ -141,7 +141,7 @@ struct PropInfo<'db> {
     ///
     /// Default values are first populated from the reflection database, if
     /// present, followed by an educated guess based on the type of the value.
-    default_value: Cow<'db, Variant>,
+    default_value: &'db Variant,
 
     /// If a logical property has a migration associated with it (i.e. BrickColor ->
     /// Color, Font -> FontFace), this field contains Some(PropertyMigration). Otherwise,
@@ -207,7 +207,7 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
                     prop_type: Type::String,
                     serialized_name: "Name".into(),
                     aliases: UstrSet::new(),
-                    default_value: Cow::Owned(Variant::String(String::new())),
+                    default_value: &DEFAULT_STRING,
                     migration: None,
                 },
             );
@@ -415,12 +415,8 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
             if !type_info.properties.contains_key(&canonical_name) {
                 let default_value = type_info
                     .class_descriptor
-                    .and_then(|class| {
-                        database
-                            .find_default_property(class, &canonical_name)
-                            .map(Cow::Borrowed)
-                    })
-                    .or_else(|| Self::fallback_default_value(serialized_ty).map(Cow::Owned))
+                    .and_then(|class| database.find_default_property(class, &canonical_name))
+                    .or_else(|| fallback_default_value(serialized_ty))
                     .ok_or_else(|| {
                         // Since we don't know how to generate the default value
                         // for this property, we consider it unsupported.
@@ -434,7 +430,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                 // There's no assurance that the default SharedString value
                 // will actually get serialized inside of the SSTR chunk, so we
                 // check here just to make sure.
-                if let Variant::SharedString(sstr) = default_value.borrow() {
+                if let Variant::SharedString(sstr) = default_value {
                     if !self.shared_string_ids.contains_key(sstr) {
                         self.shared_string_ids.insert(sstr.clone(), 0);
                         self.shared_strings.push(sstr.clone());
@@ -650,7 +646,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                         // computed for this PropInfo. This is sourced from the
                         // reflection database if available, or falls back to a
                         // reasonable default.
-                        Cow::Borrowed(prop_info.default_value.borrow())
+                        Cow::Borrowed(prop_info.default_value)
                     })
                     .map(|value| {
                         if let Some(migration) = prop_info.migration {
@@ -1365,70 +1361,110 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
 
         name
     }
-
-    fn fallback_default_value(rbx_type: VariantType) -> Option<Variant> {
-        Some(match rbx_type {
-            VariantType::String => Variant::String(String::new()),
-            VariantType::BinaryString => Variant::BinaryString(BinaryString::new()),
-            VariantType::Bool => Variant::Bool(false),
-            VariantType::Int32 => Variant::Int32(0),
-            VariantType::Float32 => Variant::Float32(0.0),
-            VariantType::Float64 => Variant::Float64(0.0),
-            VariantType::UDim => Variant::UDim(UDim::new(0.0, 0)),
-            VariantType::UDim2 => Variant::UDim2(UDim2::new(UDim::new(0.0, 0), UDim::new(0.0, 0))),
-            VariantType::Ray => Variant::Ray(Ray::new(
-                Vector3::new(0.0, 0.0, 0.0),
-                Vector3::new(0.0, 0.0, 0.0),
-            )),
-            VariantType::Faces => Variant::Faces(Faces::from_bits(0)?),
-            VariantType::Axes => Variant::Axes(Axes::from_bits(0)?),
-            VariantType::BrickColor => Variant::BrickColor(BrickColor::MediumStoneGrey),
-            VariantType::CFrame => Variant::CFrame(CFrame::new(
-                Vector3::new(0.0, 0.0, 0.0),
-                Matrix3::identity(),
-            )),
-            VariantType::Enum => Variant::Enum(Enum::from_u32(u32::MAX)),
-            VariantType::Color3 => Variant::Color3(Color3::new(0.0, 0.0, 0.0)),
-            VariantType::Vector2 => Variant::Vector2(Vector2::new(0.0, 0.0)),
-            VariantType::Vector3 => Variant::Vector3(Vector3::new(0.0, 0.0, 0.0)),
-            VariantType::Ref => Variant::Ref(Ref::none()),
-            VariantType::Vector3int16 => Variant::Vector3int16(Vector3int16::new(0, 0, 0)),
-            VariantType::NumberSequence => Variant::NumberSequence(NumberSequence {
-                keypoints: [
-                    NumberSequenceKeypoint::new(0.0, 0.0, 0.0),
-                    NumberSequenceKeypoint::new(0.0, 0.0, 0.0),
-                ]
-                .to_vec(),
-            }),
-            VariantType::ColorSequence => Variant::ColorSequence(ColorSequence {
-                keypoints: [
-                    ColorSequenceKeypoint::new(0.0, Color3::new(0.0, 0.0, 0.0)),
-                    ColorSequenceKeypoint::new(0.0, Color3::new(0.0, 0.0, 0.0)),
-                ]
-                .to_vec(),
-            }),
-            VariantType::NumberRange => Variant::NumberRange(NumberRange::new(0.0, 0.0)),
-            VariantType::Rect => {
-                Variant::Rect(Rect::new(Vector2::new(0.0, 0.0), Vector2::new(0.0, 0.0)))
-            }
-            VariantType::PhysicalProperties => {
-                Variant::PhysicalProperties(PhysicalProperties::Default)
-            }
-            VariantType::Color3uint8 => Variant::Color3uint8(Color3uint8::new(0, 0, 0)),
-            VariantType::Int64 => Variant::Int64(0),
-            VariantType::SharedString => Variant::SharedString(SharedString::new(Vec::new())),
-            VariantType::OptionalCFrame => Variant::OptionalCFrame(None),
-            VariantType::Tags => Variant::Tags(Tags::new()),
-            VariantType::ContentId => Variant::ContentId(ContentId::new()),
-            VariantType::Attributes => Variant::Attributes(Attributes::new()),
-            VariantType::UniqueId => Variant::UniqueId(UniqueId::nil()),
-            VariantType::Font => Variant::Font(Font::default()),
-            VariantType::MaterialColors => Variant::MaterialColors(MaterialColors::new()),
-            VariantType::SecurityCapabilities => {
-                Variant::SecurityCapabilities(SecurityCapabilities::default())
-            }
-            VariantType::Content => Variant::Content(Content::none()),
-            _ => return None,
-        })
+}
+static DEFAULT_STRING: Variant = Variant::String(String::new());
+fn fallback_default_value(rbx_type: VariantType) -> Option<&'static Variant> {
+    static DEFAULT_BINARYSTRING: Variant = Variant::BinaryString(BinaryString::new());
+    static DEFAULT_BOOL: Variant = Variant::Bool(false);
+    static DEFAULT_INT32: Variant = Variant::Int32(0);
+    static DEFAULT_FLOAT32: Variant = Variant::Float32(0.0);
+    static DEFAULT_FLOAT64: Variant = Variant::Float64(0.0);
+    static DEFAULT_UDIM: Variant = Variant::UDim(UDim::new(0.0, 0));
+    static DEFAULT_UDIM2: Variant =
+        Variant::UDim2(UDim2::new(UDim::new(0.0, 0), UDim::new(0.0, 0)));
+    static DEFAULT_RAY: Variant = Variant::Ray(Ray::new(
+        Vector3::new(0.0, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, 0.0),
+    ));
+    static DEFAULT_FACES: Variant = Variant::Faces(Faces::from_bits(0).unwrap());
+    static DEFAULT_AXES: Variant = Variant::Axes(Axes::from_bits(0).unwrap());
+    static DEFAULT_BRICKCOLOR: Variant = Variant::BrickColor(BrickColor::MediumStoneGrey);
+    static DEFAULT_CFRAME: Variant = Variant::CFrame(CFrame::new(
+        Vector3::new(0.0, 0.0, 0.0),
+        Matrix3::identity(),
+    ));
+    static DEFAULT_ENUM: Variant = Variant::Enum(Enum::from_u32(u32::MAX));
+    static DEFAULT_COLOR3: Variant = Variant::Color3(Color3::new(0.0, 0.0, 0.0));
+    static DEFAULT_VECTOR2: Variant = Variant::Vector2(Vector2::new(0.0, 0.0));
+    static DEFAULT_VECTOR3: Variant = Variant::Vector3(Vector3::new(0.0, 0.0, 0.0));
+    static DEFAULT_REF: Variant = Variant::Ref(Ref::none());
+    static DEFAULT_VECTOR3INT16: Variant = Variant::Vector3int16(Vector3int16::new(0, 0, 0));
+    lazy_static::lazy_static! {
+        static ref DEFAULT_NUMBERSEQUENCE: Variant = Variant::NumberSequence(NumberSequence {
+            keypoints: vec![
+                NumberSequenceKeypoint::new(0.0, 0.0, 0.0),
+                NumberSequenceKeypoint::new(0.0, 0.0, 0.0),
+            ],
+        });
     }
+    lazy_static::lazy_static! {
+        static ref DEFAULT_COLORSEQUENCE: Variant = Variant::ColorSequence(ColorSequence {
+            keypoints: vec![
+                ColorSequenceKeypoint::new(0.0, Color3::new(0.0, 0.0, 0.0)),
+                ColorSequenceKeypoint::new(0.0, Color3::new(0.0, 0.0, 0.0)),
+            ],
+        });
+    }
+    static DEFAULT_NUMBERRANGE: Variant = Variant::NumberRange(NumberRange::new(0.0, 0.0));
+    static DEFAULT_RECT: Variant =
+        Variant::Rect(Rect::new(Vector2::new(0.0, 0.0), Vector2::new(0.0, 0.0)));
+    static DEFAULT_PHYSICALPROPERTIES: Variant =
+        Variant::PhysicalProperties(PhysicalProperties::Default);
+    static DEFAULT_COLOR3UINT8: Variant = Variant::Color3uint8(Color3uint8::new(0, 0, 0));
+    static DEFAULT_INT64: Variant = Variant::Int64(0);
+    lazy_static::lazy_static! {
+        static ref DEFAULT_SHAREDSTRING: Variant =
+            Variant::SharedString(SharedString::new(Vec::new()));
+    }
+    static DEFAULT_OPTIONALCFRAME: Variant = Variant::OptionalCFrame(None);
+    static DEFAULT_TAGS: Variant = Variant::Tags(Tags::new());
+    static DEFAULT_CONTENTID: Variant = Variant::ContentId(ContentId::new());
+    static DEFAULT_ATTRIBUTES: Variant = Variant::Attributes(Attributes::new());
+    static DEFAULT_UNIQUEID: Variant = Variant::UniqueId(UniqueId::nil());
+    lazy_static::lazy_static! {
+        static ref DEFAULT_FONT: Variant = Variant::Font(Font::default());
+    }
+    static DEFAULT_MATERIALCOLORS: Variant = Variant::MaterialColors(MaterialColors::new());
+    static DEFAULT_SECURITYCAPABILITIES: Variant =
+        Variant::SecurityCapabilities(SecurityCapabilities::from_bits(0));
+    static DEFAULT_CONTENT: Variant = Variant::Content(Content::none());
+    Some(match rbx_type {
+        VariantType::String => &DEFAULT_STRING,
+        VariantType::BinaryString => &DEFAULT_BINARYSTRING,
+        VariantType::Bool => &DEFAULT_BOOL,
+        VariantType::Int32 => &DEFAULT_INT32,
+        VariantType::Float32 => &DEFAULT_FLOAT32,
+        VariantType::Float64 => &DEFAULT_FLOAT64,
+        VariantType::UDim => &DEFAULT_UDIM,
+        VariantType::UDim2 => &DEFAULT_UDIM2,
+        VariantType::Ray => &DEFAULT_RAY,
+        VariantType::Faces => &DEFAULT_FACES,
+        VariantType::Axes => &DEFAULT_AXES,
+        VariantType::BrickColor => &DEFAULT_BRICKCOLOR,
+        VariantType::CFrame => &DEFAULT_CFRAME,
+        VariantType::Enum => &DEFAULT_ENUM,
+        VariantType::Color3 => &DEFAULT_COLOR3,
+        VariantType::Vector2 => &DEFAULT_VECTOR2,
+        VariantType::Vector3 => &DEFAULT_VECTOR3,
+        VariantType::Ref => &DEFAULT_REF,
+        VariantType::Vector3int16 => &DEFAULT_VECTOR3INT16,
+        VariantType::NumberSequence => &DEFAULT_NUMBERSEQUENCE,
+        VariantType::ColorSequence => &DEFAULT_COLORSEQUENCE,
+        VariantType::NumberRange => &DEFAULT_NUMBERRANGE,
+        VariantType::Rect => &DEFAULT_RECT,
+        VariantType::PhysicalProperties => &DEFAULT_PHYSICALPROPERTIES,
+        VariantType::Color3uint8 => &DEFAULT_COLOR3UINT8,
+        VariantType::Int64 => &DEFAULT_INT64,
+        VariantType::SharedString => &DEFAULT_SHAREDSTRING,
+        VariantType::OptionalCFrame => &DEFAULT_OPTIONALCFRAME,
+        VariantType::Tags => &DEFAULT_TAGS,
+        VariantType::ContentId => &DEFAULT_CONTENTID,
+        VariantType::Attributes => &DEFAULT_ATTRIBUTES,
+        VariantType::UniqueId => &DEFAULT_UNIQUEID,
+        VariantType::Font => &DEFAULT_FONT,
+        VariantType::MaterialColors => &DEFAULT_MATERIALCOLORS,
+        VariantType::SecurityCapabilities => &DEFAULT_SECURITYCAPABILITIES,
+        VariantType::Content => &DEFAULT_CONTENT,
+        _ => return None,
+    })
 }

--- a/rbx_types/src/attributes/mod.rs
+++ b/rbx_types/src/attributes/mod.rs
@@ -34,8 +34,10 @@ pub struct Attributes {
 
 impl Attributes {
     /// Creates an empty `Attributes` struct
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            data: BTreeMap::new(),
+        }
     }
 
     /// Reads from a serialized attributes string, and produces a new `Attributes` from it.

--- a/rbx_types/src/axes.rs
+++ b/rbx_types/src/axes.rs
@@ -54,8 +54,11 @@ impl Axes {
         self.flags.bits()
     }
 
-    pub fn from_bits(bits: u8) -> Option<Self> {
-        AxisFlags::from_bits(bits).map(|flags| Self { flags })
+    pub const fn from_bits(bits: u8) -> Option<Self> {
+        match AxisFlags::from_bits(bits) {
+            Some(flags) => Some(Self { flags }),
+            None => None,
+        }
     }
 
     #[cfg(feature = "serde")]

--- a/rbx_types/src/basic_types.rs
+++ b/rbx_types/src/basic_types.rs
@@ -20,7 +20,7 @@ pub struct Enum {
 }
 
 impl Enum {
-    pub fn from_u32(value: u32) -> Self {
+    pub const fn from_u32(value: u32) -> Self {
         Self { value }
     }
 
@@ -61,7 +61,7 @@ pub struct Vector2 {
 }
 
 impl Vector2 {
-    pub fn new(x: f32, y: f32) -> Self {
+    pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 }
@@ -109,7 +109,7 @@ fn approx_unit_or_zero(value: f32) -> Option<i32> {
 }
 
 impl Vector3 {
-    pub fn new(x: f32, y: f32, z: f32) -> Self {
+    pub const fn new(x: f32, y: f32, z: f32) -> Self {
         Self { x, y, z }
     }
 
@@ -163,7 +163,7 @@ pub struct Vector3int16 {
 }
 
 impl Vector3int16 {
-    pub fn new(x: i16, y: i16, z: i16) -> Self {
+    pub const fn new(x: i16, y: i16, z: i16) -> Self {
         Self { x, y, z }
     }
 }
@@ -184,7 +184,7 @@ pub struct CFrame {
 }
 
 impl CFrame {
-    pub fn new(position: Vector3, orientation: Matrix3) -> Self {
+    pub const fn new(position: Vector3, orientation: Matrix3) -> Self {
         Self {
             position,
             orientation,
@@ -208,11 +208,11 @@ pub(crate) enum Matrix3Error {
 }
 
 impl Matrix3 {
-    pub fn new(x: Vector3, y: Vector3, z: Vector3) -> Self {
+    pub const fn new(x: Vector3, y: Vector3, z: Vector3) -> Self {
         Self { x, y, z }
     }
 
-    pub fn identity() -> Self {
+    pub const fn identity() -> Self {
         Self {
             x: Vector3::new(1.0, 0.0, 0.0),
             y: Vector3::new(0.0, 1.0, 0.0),
@@ -388,7 +388,7 @@ pub struct Color3 {
 }
 
 impl Color3 {
-    pub fn new(r: f32, g: f32, b: f32) -> Self {
+    pub const fn new(r: f32, g: f32, b: f32) -> Self {
         Self { r, g, b }
     }
 }
@@ -421,7 +421,7 @@ pub struct Color3uint8 {
 }
 
 impl Color3uint8 {
-    pub fn new(r: u8, g: u8, b: u8) -> Self {
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }
     }
 }
@@ -456,7 +456,7 @@ pub struct Ray {
 }
 
 impl Ray {
-    pub fn new(origin: Vector3, direction: Vector3) -> Self {
+    pub const fn new(origin: Vector3, direction: Vector3) -> Self {
         Self { origin, direction }
     }
 }
@@ -509,7 +509,7 @@ pub struct Rect {
 }
 
 impl Rect {
-    pub fn new(min: Vector2, max: Vector2) -> Self {
+    pub const fn new(min: Vector2, max: Vector2) -> Self {
         Self { min, max }
     }
 }
@@ -526,7 +526,7 @@ pub struct UDim {
 }
 
 impl UDim {
-    pub fn new(scale: f32, offset: i32) -> Self {
+    pub const fn new(scale: f32, offset: i32) -> Self {
         Self { scale, offset }
     }
 }
@@ -543,7 +543,7 @@ pub struct UDim2 {
 }
 
 impl UDim2 {
-    pub fn new(x: UDim, y: UDim) -> Self {
+    pub const fn new(x: UDim, y: UDim) -> Self {
         Self { x, y }
     }
 }
@@ -559,7 +559,7 @@ pub struct NumberRange {
 }
 
 impl NumberRange {
-    pub fn new(min: f32, max: f32) -> Self {
+    pub const fn new(min: f32, max: f32) -> Self {
         Self { min, max }
     }
 }
@@ -596,7 +596,7 @@ pub struct ColorSequenceKeypoint {
 }
 
 impl ColorSequenceKeypoint {
-    pub fn new(time: f32, color: Color3) -> Self {
+    pub const fn new(time: f32, color: Color3) -> Self {
         Self { time, color }
     }
 }
@@ -636,7 +636,7 @@ pub struct NumberSequenceKeypoint {
 }
 
 impl NumberSequenceKeypoint {
-    pub fn new(time: f32, value: f32, envelope: f32) -> Self {
+    pub const fn new(time: f32, value: f32, envelope: f32) -> Self {
         Self {
             time,
             value,

--- a/rbx_types/src/binary_string.rs
+++ b/rbx_types/src/binary_string.rs
@@ -10,7 +10,7 @@ pub struct BinaryString {
 
 impl BinaryString {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { buffer: Vec::new() }
     }
 

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -23,7 +23,7 @@ pub enum ContentType {
 impl Content {
     /// Constructs an empty `Content`.
     #[inline]
-    pub fn none() -> Self {
+    pub const fn none() -> Self {
         Self(ContentType::None)
     }
 
@@ -103,7 +103,7 @@ pub struct ContentId {
 impl ContentId {
     /// Constructs an empty new `ContentId`.
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         ContentId { url: String::new() }
     }
 

--- a/rbx_types/src/faces.rs
+++ b/rbx_types/src/faces.rs
@@ -69,8 +69,11 @@ impl Faces {
         self.flags.bits()
     }
 
-    pub fn from_bits(bits: u8) -> Option<Self> {
-        FaceFlags::from_bits(bits).map(|flags| Self { flags })
+    pub const fn from_bits(bits: u8) -> Option<Self> {
+        match FaceFlags::from_bits(bits) {
+            Some(flags) => Some(Self { flags }),
+            None => None,
+        }
     }
 
     #[cfg(feature = "serde")]

--- a/rbx_types/src/material_colors.rs
+++ b/rbx_types/src/material_colors.rs
@@ -23,7 +23,7 @@ impl MaterialColors {
     /// Constructs a new `MaterialColors` where all colors are their default
     /// values.
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             inner: BTreeMap::new(),
         }

--- a/rbx_types/src/security_capabilities.rs
+++ b/rbx_types/src/security_capabilities.rs
@@ -9,7 +9,7 @@ pub struct SecurityCapabilities {
 }
 
 impl SecurityCapabilities {
-    pub fn from_bits(value: u64) -> Self {
+    pub const fn from_bits(value: u64) -> Self {
         SecurityCapabilities { value }
     }
 

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -18,7 +18,7 @@ pub struct Tags {
 
 impl Tags {
     /// Create a new `Tags` empty container.
-    pub fn new() -> Tags {
+    pub const fn new() -> Tags {
         Self {
             members: Vec::new(),
         }

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -50,7 +50,7 @@ static INDEX: AtomicU32 = AtomicU32::new(0);
 impl UniqueId {
     /// Returns a 'nil' `UniqueId` that has every field set to `0`.
     /// This value may appear multiple times in a Roblox file safely.
-    pub fn nil() -> Self {
+    pub const fn nil() -> Self {
         Self {
             index: 0,
             time: 0,


### PR DESCRIPTION
Depends on #543 for fallback `&'static Variant` references.

I identified a performance issue observed in #533, and found that it is applicable to the serializer in general.

According to the benchmarks, this improves serializer throughput by +37%.  Deserialization is not touched and is within noise, ±3%.

The core concept behind this change is to collect references to property values in `collect_type_info`, and then use those references in `serialize_properties` instead of having to scan the instances for the properties again.  The code organization can probably be substantially improved, but I don't have any ideas at the moment so please do advise me.  The giant function signatures are not nice and control flow is particularly twisted in `serialize_properties`.

There are four previous incarnations of this at various stages because there is truly a lot of conflicting requirements to be met for everything to work correctly...  Notably migration is at odds with taking Variant references, and interleaved bytes is at odds with building prop chunks procedurally.  I wouldn't have been able to pull this off without the excellent testing suite.