### PR TITLE
Convert Lister To Use Iterators

### DIFF
--- a/rbx_types/Cargo.toml
+++ b/rbx_types/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/rojo-rbx/rbx-dom"
 [dependencies]
 base64 = "0.13.0"
 blake3 = "1.3.1"
-bitflags = "1.3.2"
+bitflags = "2.9.1"
 lazy_static = "1.4.0"
 rand = "0.8.5"
 thiserror = "1.0.31"

--- a/rbx_types/src/axes.rs
+++ b/rbx_types/src/axes.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::lister::Lister;
+use crate::lister::write_comma_separated;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -67,21 +67,13 @@ impl Axes {
 
 impl fmt::Debug for Axes {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        let mut list = Lister::new();
-
         write!(out, "Axes(")?;
 
-        if self.contains(Self::X) {
-            list.write(out, "X")?;
-        }
-
-        if self.contains(Self::Y) {
-            list.write(out, "Y")?;
-        }
-
-        if self.contains(Self::Z) {
-            list.write(out, "Z")?;
-        }
+        write_comma_separated(
+            out,
+            self.flags.iter_names().map(|(name, _)| name),
+            |f, name| write!(f, "{name}"),
+        )?;
 
         write!(out, ")")
     }

--- a/rbx_types/src/axes.rs
+++ b/rbx_types/src/axes.rs
@@ -69,11 +69,7 @@ impl fmt::Debug for Axes {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         write!(out, "Axes(")?;
 
-        write_comma_separated(
-            out,
-            self.flags.iter_names().map(|(name, _)| name),
-            |f, name| write!(f, "{name}"),
-        )?;
+        write_comma_separated(out, self.flags.iter_names().map(|(name, _)| name))?;
 
         write!(out, ")")
     }

--- a/rbx_types/src/axes.rs
+++ b/rbx_types/src/axes.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use crate::lister::Lister;
 
 bitflags::bitflags! {
+    #[derive(Clone, Copy, PartialEq, Eq)]
     struct AxisFlags: u8 {
         const X = 1;
         const Y = 2;

--- a/rbx_types/src/faces.rs
+++ b/rbx_types/src/faces.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use crate::lister::Lister;
 
 bitflags::bitflags! {
+    #[derive(Clone, Copy, PartialEq, Eq)]
     struct FaceFlags: u8 {
         const RIGHT = 1;
         const TOP = 2;

--- a/rbx_types/src/faces.rs
+++ b/rbx_types/src/faces.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::lister::Lister;
+use crate::lister::write_comma_separated;
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -82,33 +82,13 @@ impl Faces {
 
 impl fmt::Debug for Faces {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        let mut list = Lister::new();
-
         write!(out, "Faces(")?;
 
-        if self.contains(Faces::RIGHT) {
-            list.write(out, "Right")?;
-        }
-
-        if self.contains(Faces::TOP) {
-            list.write(out, "Top")?;
-        }
-
-        if self.contains(Faces::BACK) {
-            list.write(out, "Back")?;
-        }
-
-        if self.contains(Faces::LEFT) {
-            list.write(out, "Left")?;
-        }
-
-        if self.contains(Faces::BOTTOM) {
-            list.write(out, "Bottom")?;
-        }
-
-        if self.contains(Faces::FRONT) {
-            list.write(out, "Front")?;
-        }
+        write_comma_separated(
+            out,
+            self.flags.iter_names().map(|(name, _)| name),
+            |f, name| write!(f, "{name}"),
+        )?;
 
         write!(out, ")")
     }

--- a/rbx_types/src/faces.rs
+++ b/rbx_types/src/faces.rs
@@ -84,11 +84,7 @@ impl fmt::Debug for Faces {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         write!(out, "Faces(")?;
 
-        write_comma_separated(
-            out,
-            self.flags.iter_names().map(|(name, _)| name),
-            |f, name| write!(f, "{name}"),
-        )?;
+        write_comma_separated(out, self.flags.iter_names().map(|(name, _)| name))?;
 
         write!(out, ")")
     }

--- a/rbx_types/src/lister.rs
+++ b/rbx_types/src/lister.rs
@@ -1,18 +1,16 @@
 use std::fmt;
 
 /// Small utility to write lists of things.
-pub fn write_comma_separated<D, I, F>(f: &mut fmt::Formatter, iter: I, mut writer: F) -> fmt::Result
+pub fn write_comma_separated<D, I>(f: &mut fmt::Formatter, iter: I) -> fmt::Result
 where
     D: fmt::Display,
     I: IntoIterator<Item = D>,
-    F: FnMut(&mut fmt::Formatter, D) -> fmt::Result,
 {
     let mut it = iter.into_iter();
     if let Some(first) = it.next() {
-        writer(f, first)?;
+        write!(f, "{first}")?;
         for item in it {
-            write!(f, ", ")?;
-            writer(f, item)?;
+            write!(f, ", {item}")?;
         }
     }
     Ok(())

--- a/rbx_types/src/lister.rs
+++ b/rbx_types/src/lister.rs
@@ -1,21 +1,19 @@
 use std::fmt;
 
-/// Small utility to write formatting functions for lists of things.
-pub(crate) struct Lister {
-    first: bool,
-}
-
-impl Lister {
-    pub fn new() -> Self {
-        Self { first: true }
-    }
-
-    pub fn write(&mut self, out: &mut fmt::Formatter, label: impl fmt::Display) -> fmt::Result {
-        if self.first {
-            self.first = false;
-            write!(out, "{}", label)
-        } else {
-            write!(out, ", {}", label)
+/// Small utility to write lists of things.
+pub fn write_comma_separated<D, I, F>(f: &mut fmt::Formatter, iter: I, mut writer: F) -> fmt::Result
+where
+    D: fmt::Display,
+    I: IntoIterator<Item = D>,
+    F: FnMut(&mut fmt::Formatter, D) -> fmt::Result,
+{
+    let mut it = iter.into_iter();
+    if let Some(first) = it.next() {
+        writer(f, first)?;
+        for item in it {
+            write!(f, ", ")?;
+            writer(f, item)?;
         }
     }
+    Ok(())
 }


### PR DESCRIPTION
Not the most important part of rbx-dom, but hey it's -38 loc.   The only functional difference should be that the faces are printed in all caps.  Updating bitflags shouldn't be a breaking change because it's a private type in a private field.