### PR TITLE
Make clippy shut up about `uninlined_format_args`

### DIFF
--- a/rbx_binary/src/chunk.rs
+++ b/rbx_binary/src/chunk.rs
@@ -23,7 +23,7 @@ impl Chunk {
     pub fn decode<R: Read>(mut reader: R) -> io::Result<Chunk> {
         let header = decode_chunk_header(&mut reader)?;
 
-        log::trace!("{}", header);
+        log::trace!("{header}");
 
         let data = if header.compressed_len == 0 {
             log::trace!("No compression");

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -85,7 +85,7 @@ impl<'db> Deserializer<'db> {
                     break;
                 }
                 _ => match str::from_utf8(&chunk.name) {
-                    Ok(name) => log::info!("Unknown binary chunk name {}", name),
+                    Ok(name) => log::info!("Unknown binary chunk name {name}"),
                     Err(_) => log::info!("Unknown binary chunk name {:?}", chunk.name),
                 },
             }

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -145,10 +145,7 @@ fn find_canonical_property<'de>(
             };
 
             log::trace!(
-                "Known prop, canonical name {} and type {:?}, with {:?} migration",
-                canonical_name,
-                canonical_type,
-                migration,
+                "Known prop, canonical name {canonical_name} and type {canonical_type:?}, with {migration:?} migration",
             );
 
             Some(CanonicalProperty {
@@ -161,12 +158,12 @@ fn find_canonical_property<'de>(
             let canonical_type = match binary_type.to_default_rbx_type() {
                 Some(rbx_type) => rbx_type,
                 None => {
-                    log::warn!("Unsupported prop type {:?}, skipping property", binary_type);
+                    log::warn!("Unsupported prop type {binary_type:?}, skipping property");
                     return None;
                 }
             };
 
-            log::trace!("Unknown prop, using type {:?}", canonical_type);
+            log::trace!("Unknown prop, using type {canonical_type:?}");
 
             Some(CanonicalProperty {
                 name: prop_name,
@@ -281,11 +278,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
         let number_instances = chunk.read_le_u32()?;
 
         log::trace!(
-            "INST chunk (type ID {}, type name {}, format {}, {} instances)",
-            type_id,
-            type_name,
-            object_format,
-            number_instances,
+            "INST chunk (type ID {type_id}, type name {type_name}, format {object_format}, {number_instances} instances)",
         );
 
         let mut referents = vec![0; number_instances as usize];
@@ -526,7 +519,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         prop_name,
                         valid_type_names:
                             "String, ContentId, Content, Tags, Attributes, or BinaryString",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -543,7 +536,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Bool",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -575,7 +568,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Int32",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -594,7 +587,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Float32",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -624,7 +617,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Float64",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -651,7 +644,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "UDim",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -690,7 +683,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "UDim2",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -722,7 +715,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Ray",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -747,7 +740,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Faces",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -773,7 +766,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Axes",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -803,7 +796,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "BrickColor",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -833,7 +826,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Color3",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -857,7 +850,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Vector2",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -887,7 +880,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Vector3",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -953,7 +946,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "CFrame",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -972,7 +965,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Enum",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -997,7 +990,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Ref",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1022,7 +1015,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Vector3int16",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1060,7 +1053,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Font",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1087,7 +1080,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "NumberSequence",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1120,7 +1113,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "ColorSequence",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1140,7 +1133,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "NumberRange",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1173,7 +1166,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Rect",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1203,7 +1196,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "PhysicalProperties",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1234,7 +1227,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Color3",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1253,7 +1246,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Int64",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1269,7 +1262,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                                     type_name: type_info.type_name.to_string(),
                                     prop_name: prop_name.clone(),
                                     valid_value: "a valid SharedString",
-                                    actual_value: format!("{:?}", value),
+                                    actual_value: format!("{value:?}"),
                                 }
                             })?;
 
@@ -1283,7 +1276,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "SharedString",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     })
                 }
             },
@@ -1379,7 +1372,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "OptionalCFrame",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1409,7 +1402,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "UniqueId",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1434,7 +1427,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "SecurityCapabilities",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1485,7 +1478,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         type_name: type_info.type_name.to_string(),
                         prop_name,
                         valid_type_names: "Content",
-                        actual_type_name: format!("{:?}", invalid_type),
+                        actual_type_name: format!("{invalid_type:?}"),
                     });
                 }
             },
@@ -1507,7 +1500,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
 
         let number_objects = chunk.read_le_u32()?;
 
-        log::trace!("PRNT chunk ({} instances)", number_objects);
+        log::trace!("PRNT chunk ({number_objects} instances)");
 
         let mut subjects = vec![0; number_objects as usize];
         let mut parents = vec![0; number_objects as usize];

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -188,7 +188,7 @@ impl<'dom, 'db> TypeInfos<'dom, 'db> {
             let is_service = if let Some(descriptor) = &class_descriptor {
                 descriptor.tags.contains(&ClassTag::Service)
             } else {
-                log::info!("The class {} is not known to rbx_binary", class);
+                log::info!("The class {class} is not known to rbx_binary");
                 false
             };
 
@@ -399,7 +399,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                             return Err(InnerError::UnsupportedPropType {
                                 type_name: instance.class.to_string(),
                                 prop_name: prop_name.to_string(),
-                                prop_type: format!("{:?}", unknown_ty),
+                                prop_type: format!("{unknown_ty:?}"),
                             });
                         }
                     };
@@ -427,7 +427,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                         InnerError::UnsupportedPropType {
                             type_name: instance.class.to_string(),
                             prop_name: canonical_name.to_string(),
-                            prop_type: format!("{:?}", serialized_ty),
+                            prop_type: format!("{serialized_ty:?}"),
                         }
                     })?;
 
@@ -448,7 +448,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                     InnerError::UnsupportedPropType {
                         type_name: instance.class.to_string(),
                         prop_name: serialized_name.to_string(),
-                        prop_type: format!("{:?}", serialized_ty),
+                        prop_type: format!("{serialized_ty:?}"),
                     }
                 })?;
 

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -868,7 +868,7 @@ where
     let mut state = serializer.serialize_seq(Some(values.len()))?;
     for value in values {
         for byte in value.hash().as_bytes() {
-            write!(hash, "{:02x}", byte).unwrap();
+            write!(hash, "{byte:02x}").unwrap();
         }
         state.serialize_element(&SerializedSharedString {
             len: value.data().len(),
@@ -909,9 +909,9 @@ mod unknown_buffer {
         fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             for (index, byte) in self.0.iter().enumerate() {
                 if index < self.0.len() - 1 {
-                    write!(formatter, "{:02x} ", byte)?;
+                    write!(formatter, "{byte:02x} ")?;
                 } else {
-                    write!(formatter, "{:02x}", byte)?;
+                    write!(formatter, "{byte:02x}")?;
                 }
             }
 

--- a/rbx_dom_weak/src/viewer.rs
+++ b/rbx_dom_weak/src/viewer.rs
@@ -57,7 +57,7 @@ impl DomViewer {
     fn populate_referent_map(&mut self, dom: &WeakDom, referent: Ref) {
         let next_id = &mut self.next_id;
         self.referent_to_id.entry(referent).or_insert_with(|| {
-            let name = format!("referent-{}", next_id);
+            let name = format!("referent-{next_id}");
             *next_id += 1;
             name
         });
@@ -101,7 +101,7 @@ impl DomViewer {
                         let mut hash_hex = String::with_capacity(hash.as_bytes().len() * 2);
 
                         for byte in hash.as_bytes() {
-                            write!(hash_hex, "{:02x}", byte).unwrap();
+                            write!(hash_hex, "{byte:02x}").unwrap();
                         }
                         ViewedValue::SharedString {
                             len: shared_string.data().len(),
@@ -172,8 +172,7 @@ mod test {
             InstanceBuilder::new("Folder")
                 .with_name("Root")
                 .with_children(
-                    (0..4)
-                        .map(|i| InstanceBuilder::new("Folder").with_name(format!("Child {}", i))),
+                    (0..4).map(|i| InstanceBuilder::new("Folder").with_name(format!("Child {i}"))),
                 ),
         );
 

--- a/rbx_reflector/src/cli/defaults_place.rs
+++ b/rbx_reflector/src/cli/defaults_place.rs
@@ -101,7 +101,7 @@ tell application "System Events"
     -- Studio process only has one window.
 
     -- This could be hazardous - for example, escape may not close every modal,
-    -- or Roblox Studio could one day gain more windows. So, we'll also cap the 
+    -- or Roblox Studio could one day gain more windows. So, we'll also cap the
     -- number of times this loop can execute to 100.
     set attemptCount to 0
     repeat until count of windows of robloxStudio is 1 or attemptCount >= 100
@@ -203,7 +203,7 @@ fn generate_place_with_all_classes(path: &PathBuf, dump: &Dump) -> anyhow::Resul
             _ => {}
         }
 
-        write!(place_contents, "{}", instance).unwrap();
+        write!(place_contents, "{instance}").unwrap();
     }
 
     writeln!(place_contents, "</roblox>").unwrap();
@@ -240,7 +240,7 @@ impl fmt::Display for Instance<'_> {
         )?;
 
         for child in &self.children {
-            write!(f, "{}", child)?;
+            write!(f, "{child}")?;
         }
 
         writeln!(f, "</Item>")?;

--- a/rbx_reflector/src/main.rs
+++ b/rbx_reflector/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         .init();
 
     if let Err(err) = args.run() {
-        eprintln!("Error: {:?}", err);
+        eprintln!("Error: {err:?}");
         std::process::exit(1);
     }
 }

--- a/rbx_types/src/axes.rs
+++ b/rbx_types/src/axes.rs
@@ -140,7 +140,7 @@ mod serde_impl {
                     "Y" => flags |= AxisFlags::Y,
                     "Z" => flags |= AxisFlags::Z,
                     _ => {
-                        return Err(A::Error::custom(format!("invalid axis '{}'", axis_str)));
+                        return Err(A::Error::custom(format!("invalid axis '{axis_str}'")));
                     }
                 }
             }

--- a/rbx_types/src/faces.rs
+++ b/rbx_types/src/faces.rs
@@ -182,7 +182,7 @@ mod serde_impl {
                     "Bottom" => flags |= FaceFlags::BOTTOM,
                     "Front" => flags |= FaceFlags::FRONT,
                     _ => {
-                        return Err(A::Error::custom(format!("invalid face '{}'", face_str)));
+                        return Err(A::Error::custom(format!("invalid face '{face_str}'")));
                     }
                 }
             }

--- a/rbx_types/src/lister.rs
+++ b/rbx_types/src/lister.rs
@@ -13,9 +13,9 @@ impl Lister {
     pub fn write(&mut self, out: &mut fmt::Formatter, label: impl fmt::Display) -> fmt::Result {
         if self.first {
             self.first = false;
-            write!(out, "{}", label)
+            write!(out, "{label}")
         } else {
-            write!(out, ", {}", label)
+            write!(out, ", {label}")
         }
     }
 }

--- a/rbx_util/src/main.rs
+++ b/rbx_util/src/main.rs
@@ -87,7 +87,7 @@ fn main() {
         .init();
 
     if let Err(err) = options.run() {
-        eprintln!("{:?}", err);
+        eprintln!("{err:?}");
         process::exit(1);
     }
 }

--- a/rbx_xml/src/conversion.rs
+++ b/rbx_xml/src/conversion.rs
@@ -48,11 +48,11 @@ impl ConvertVariant for Variant {
             }
             (Variant::Int32(value), VariantType::BrickColor) => {
                 let narrowed: u16 = (*value).try_into().map_err(|_| {
-                    format!("Value {} is not in the range of a valid BrickColor", value)
+                    format!("Value {value} is not in the range of a valid BrickColor")
                 })?;
 
                 BrickColor::from_number(narrowed)
-                    .ok_or_else(|| format!("{} is not a valid BrickColor number", value))
+                    .ok_or_else(|| format!("{value} is not a valid BrickColor number"))
                     .map(Into::into)
                     .map(Cow::Owned)
             }
@@ -70,11 +70,9 @@ impl ConvertVariant for Variant {
                     Ok(attributes) => Ok(Cow::Owned(attributes.into())),
                     Err(err) => {
                         log::warn!(
-                            "Failed to parse Attributes on {} because {:?}; falling back to BinaryString.
+                            "Failed to parse Attributes on {class_name} because {err:?}; falling back to BinaryString.
 
-rbx-dom may require changes to fully support this property. Please open an issue at https://github.com/rojo-rbx/rbx-dom/issues and show this warning.",
-                             class_name,
-                             err
+rbx-dom may require changes to fully support this property. Please open an issue at https://github.com/rojo-rbx/rbx-dom/issues and show this warning."
                         );
 
                         Ok(Cow::Owned(value.clone().into()))
@@ -86,11 +84,9 @@ rbx-dom may require changes to fully support this property. Please open an issue
                     Ok(material_colors) => Ok(Cow::Owned(material_colors.into())),
                     Err(err) => {
                         log::warn!(
-                            "Failed to parse MaterialColors on {} because {:?}; falling back to BinaryString.
+                            "Failed to parse MaterialColors on {class_name} because {err:?}; falling back to BinaryString.
 
-rbx-dom may require changes to fully support this property. Please open an issue at https://github.com/rojo-rbx/rbx-dom/issues and show this warning.",
-                            class_name,
-                            err
+rbx-dom may require changes to fully support this property. Please open an issue at https://github.com/rojo-rbx/rbx-dom/issues and show this warning."
                         );
 
                         Ok(Cow::Owned(value.clone().into()))

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -443,7 +443,7 @@ fn deserialize_instance<R: Read>(
         (class, referent)
     };
 
-    trace!("Class {} with referent {:?}", class_name, referent);
+    trace!("Class {class_name} with referent {referent:?}");
 
     let prop_capacity = state
         .options
@@ -527,9 +527,7 @@ fn deserialize_properties<R: Read>(
         .class;
 
     log::trace!(
-        "Deserializing properties for instance {:?}, whose ClassName is {}",
-        instance_id,
-        class_name
+        "Deserializing properties for instance {instance_id:?}, whose ClassName is {class_name}"
     );
 
     loop {
@@ -571,10 +569,7 @@ fn deserialize_properties<R: Read>(
         };
 
         log::trace!(
-            "Deserializing property {}.{}, of type {}",
-            class_name,
-            xml_property_name,
-            xml_type_name
+            "Deserializing property {class_name}.{xml_property_name}, of type {xml_type_name}"
         );
 
         let maybe_descriptor = if state.options.use_reflection() {

--- a/rbx_xml/src/deserializer_core.rs
+++ b/rbx_xml/src/deserializer_core.rs
@@ -281,11 +281,11 @@ impl<R: Read> XmlEventReader<R> {
         loop {
             match self.expect_next()? {
                 XmlReadEvent::StartElement { name, .. } => {
-                    trace!("Eat unknown start: {:?}", name);
+                    trace!("Eat unknown start: {name:?}");
                     depth += 1;
                 }
                 XmlReadEvent::EndElement { name } => {
-                    trace!("Eat unknown end: {:?}", name);
+                    trace!("Eat unknown end: {name:?}");
                     depth -= 1;
 
                     if depth == 0 {
@@ -294,7 +294,7 @@ impl<R: Read> XmlEventReader<R> {
                     }
                 }
                 other => {
-                    trace!("Eat unknown: {:?}", other);
+                    trace!("Eat unknown: {other:?}");
                 }
             }
         }

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -101,34 +101,29 @@ impl fmt::Display for DecodeErrorKind {
         use self::DecodeErrorKind::*;
 
         match self {
-            Xml(err) => write!(output, "{}", err),
-            ParseFloat(err) => write!(output, "{}", err),
-            ParseInt(err) => write!(output, "{}", err),
-            DecodeBase64(err) => write!(output, "{}", err),
-            MigrationError(err) => write!(output, "{}", err),
-            TypeError(err) => write!(output, "{}", err),
+            Xml(err) => write!(output, "{err}"),
+            ParseFloat(err) => write!(output, "{err}"),
+            ParseInt(err) => write!(output, "{err}"),
+            DecodeBase64(err) => write!(output, "{err}"),
+            MigrationError(err) => write!(output, "{err}"),
+            TypeError(err) => write!(output, "{err}"),
 
             WrongDocVersion(version) => {
-                write!(output, "Invalid version '{}', expected version 4", version)
+                write!(output, "Invalid version '{version}', expected version 4")
             }
             UnexpectedEof => write!(output, "Unexpected end-of-file"),
-            UnexpectedXmlEvent(event) => write!(output, "Unexpected XML event {:?}", event),
+            UnexpectedXmlEvent(event) => write!(output, "Unexpected XML event {event:?}"),
             MissingAttribute(attribute_name) => {
-                write!(output, "Missing attribute '{}'", attribute_name)
+                write!(output, "Missing attribute '{attribute_name}'")
             }
             UnknownProperty {
                 class_name,
                 property_name,
-            } => write!(
-                output,
-                "Property {}.{} is unknown",
-                class_name, property_name
-            ),
-            InvalidContent(explain) => write!(output, "Invalid text content: {}", explain),
+            } => write!(output, "Property {class_name}.{property_name} is unknown"),
+            InvalidContent(explain) => write!(output, "Invalid text content: {explain}"),
             NameMustBeString(ty) => write!(
                 output,
-                "The 'Name' property must be of type String, but it was {:?}",
-                ty
+                "The 'Name' property must be of type String, but it was {ty:?}"
             ),
             UnsupportedPropertyConversion {
                 class_name,
@@ -138,9 +133,8 @@ impl fmt::Display for DecodeErrorKind {
                 message,
             } => write!(
                 output,
-                "Property {}.{} is expected to be of type {:?}, but it was of type {:?} \
-                 When trying to convert, this error occured: {}",
-                class_name, property_name, expected_type, actual_type, message
+                "Property {class_name}.{property_name} is expected to be of type {expected_type:?}, but it was of type {actual_type:?} \
+                 When trying to convert, this error occured: {message}"
             ),
         }
     }
@@ -241,20 +235,16 @@ impl fmt::Display for EncodeErrorKind {
         use self::EncodeErrorKind::*;
 
         match self {
-            Io(err) => write!(output, "{}", err),
-            Xml(err) => write!(output, "{}", err),
-            Type(err) => write!(output, "{}", err),
+            Io(err) => write!(output, "{err}"),
+            Xml(err) => write!(output, "{err}"),
+            Type(err) => write!(output, "{err}"),
 
             UnknownProperty {
                 class_name,
                 property_name,
-            } => write!(
-                output,
-                "Property {}.{} is unknown",
-                class_name, property_name
-            ),
+            } => write!(output, "Property {class_name}.{property_name} is unknown"),
             UnsupportedPropertyType(ty) => {
-                write!(output, "Properties of type {:?} cannot be encoded yet", ty)
+                write!(output, "Properties of type {ty:?} cannot be encoded yet")
             }
             UnsupportedPropertyConversion {
                 class_name,
@@ -264,9 +254,8 @@ impl fmt::Display for EncodeErrorKind {
                 message,
             } => write!(
                 output,
-                "Property {}.{} is expected to be of type {:?}, but it was of type {:?} \
-                 When trying to convert the value, this error occured: {}",
-                class_name, property_name, expected_type, actual_type, message
+                "Property {class_name}.{property_name} is expected to be of type {expected_type:?}, but it was of type {actual_type:?} \
+                 When trying to convert the value, this error occured: {message}"
             ),
         }
     }

--- a/rbx_xml/src/serializer_core.rs
+++ b/rbx_xml/src/serializer_core.rs
@@ -60,7 +60,7 @@ impl<W: Write> XmlEventWriter<W> {
         &mut self,
         value: T,
     ) -> Result<(), NewEncodeError> {
-        write!(self.character_buffer, "{}", value).unwrap();
+        write!(self.character_buffer, "{value}").unwrap();
         write_characters_or_cdata(&mut self.inner, &self.character_buffer)?;
         self.character_buffer.clear();
 

--- a/rbx_xml/src/test_util.rs
+++ b/rbx_xml/src/test_util.rs
@@ -51,8 +51,8 @@ where
         match (expected.is_some(), actual.is_some()) {
             (true, true) => {
                 if expected != actual {
-                    println!("Expected event: {:#?}", expected);
-                    println!("Actual event: {:#?}", actual);
+                    println!("Expected event: {expected:#?}");
+                    println!("Actual event: {actual:#?}");
 
                     fail();
                 }

--- a/rbx_xml/src/types/strings.rs
+++ b/rbx_xml/src/types/strings.rs
@@ -78,9 +78,8 @@ mod test {
         let test_value = "Hello,\n\tworld!\n";
         let test_source = format!(
             r#"
-            <ProtectedString name="something">{}</ProtectedString>
-        "#,
-            test_value
+            <ProtectedString name="something">{test_value}</ProtectedString>
+        "#
         );
 
         test_util::test_xml_deserialize(&test_source, &ProtectedStringDummy(test_value.to_owned()));


### PR DESCRIPTION
I don't know who thought it was a good idea to make this lint a warning by default, but it's annoying. At least it gives us an excuse to clean up some code.