### PR TITLE
Migrate Content properties added since v684

### DIFF
--- a/patches/audio-player.yml
+++ b/patches/audio-player.yml
@@ -1,0 +1,7 @@
+Change:
+  AudioPlayer:
+    Asset:
+      Serialization:
+        Type: Migrate
+        To: AudioContent
+        Migration: ContentIdToContent

--- a/patches/backpack-item.yml
+++ b/patches/backpack-item.yml
@@ -1,0 +1,7 @@
+Change:
+  BackpackItem:
+    TextureId:
+      Serialization:
+        Type: Migrate
+        To: TextureContent
+        Migration: ContentIdToContent

--- a/patches/click-detector.yml
+++ b/patches/click-detector.yml
@@ -1,0 +1,13 @@
+Change:
+  ClickDetector:
+    CursorIcon:
+      Serialization:
+        Type: Migrate
+        To: CursorIconContent
+        Migration: ContentIdToContent
+  DragDetector: # DragDetector inherits from ClickDetector
+    ActivatedCursorIcon:
+      Serialization:
+        Type: Migrate
+        To: ActivatedCursorIconContent
+        Migration: ContentIdToContent

--- a/patches/decal.yml
+++ b/patches/decal.yml
@@ -20,3 +20,8 @@ Change:
         Type: Migrate
         To: RoughnessMapContent
         Migration: ContentIdToContent
+    ColorMap:
+      Serialization:
+        Type: Migrate
+        To: ColorMapContent
+        Migration: ContentIdToContent

--- a/patches/mouse.yml
+++ b/patches/mouse.yml
@@ -1,0 +1,7 @@
+Change:
+  Mouse:
+    Icon:
+      Serialization:
+        Type: Migrate
+        To: IconContent
+        Migration: ContentIdToContent

--- a/patches/sound.yml
+++ b/patches/sound.yml
@@ -20,3 +20,10 @@ Change:
         As: xmlRead_MaxDistance_3
     xmlRead_MaxDistance_3:
       AliasFor: RollOffMaxDistance
+
+    SoundId:
+      Serialization:
+        Type: Migrate
+        To: AudioContent
+        Migration: ContentIdToContent
+

--- a/patches/ui-drag-detector.yml
+++ b/patches/ui-drag-detector.yml
@@ -1,0 +1,12 @@
+Change:
+  UIDragDetector:
+    ActivatedCursorIcon:
+      Serialization:
+        Type: Migrate
+        To: ActivatedCursorIconContent
+        Migration: ContentIdToContent
+    CursorIcon:
+      Serialization:
+        Type: Migrate
+        To: CursorIconContent
+        Migration: ContentIdToContent

--- a/patches/user-input-service.yml
+++ b/patches/user-input-service.yml
@@ -1,0 +1,7 @@
+Change:
+  UserInputService:
+    MouseIcon:
+      Serialization:
+        Type: Migrate
+        To: MouseIconContent
+        Migration: ContentIdToContent


### PR DESCRIPTION
- Migrates `BackpackItem.TextureId` to `TextureContent`
- Migrates `ClickDetector.CursorIcon` to `CursorIconContent`
- Migrates `DragDetector.ActivatedCursorIcon` to `ActivatedCursorIconContent`
- Migrates `Decal.ColorMap` to `ColorMapContent` (just in case, as they don't serialize but Roblox could change that)
- Migrates `Mouse.Icon` to `IconContent`
- Migrates `UIDragDetector.ActivatedCursorIcon` to `ActivatedCursorIconContent`
- Migrates `UIDragDetector.CursorIcon` to `CursorIconContent`
- Migrates `UserInputService.MouseIcon` to `MouseIconContent`