### PR TITLE
Update implementation of `PhysicalProperties` to include new `AcousticAbsorption` field

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -586,7 +586,7 @@ Two encoded `Rect` values with values `Rect.new(-1, -10, 8, 9)` and `Rect.new(0,
 ### PhysicalProperties
 **Type ID `0x19`**
 
-The `PhysicalProperties` type contains a bitfield which indicates whether the value is custom, along with whether it has an `AudioAbsorption` field. This flag is a single byte. These bits are described below, where bit `0` is the least-significant bit.
+The `PhysicalProperties` type contains a bitfield which indicates whether the value is custom, along with whether it has an `AudioAbsorption` field. This flag is a single byte. These bits are described below, where bit `0` is the least-significant bit. When there are multiple `PhysicalProperties` present, they are stored in sequence with no transformations or interleaving.
 
 | Bit Number | Purpose                                                                    |
 |:-----------|:---------------------------------------------------------------------------|
@@ -606,9 +606,9 @@ If bit `0` is set, then the value is followed by a `CustomPhysicalProperties`. T
 
 The `AcousticAbsorption` field is only present if bit `1` is set. Otherwise, it is left out and may be assumed to be `1.0` when deserializing a `CustomPhysicalProperties`.
 
-If bit `0` is not set, but bit `1` is set, the is no `CustomPhysicalProperties` present.
+If bit `0` is not set, but bit `1` is set, there is no `CustomPhysicalProperties` present.
 
-The `PhysicalProperties` type is stored as a `u8` representing the bitfield, followed by a `CustomPhysicalProperties` if bit `0` is set. When there are multiple `PhysicalProperties` present, they are stored in sequence with no transformations or interleaving.
+The `PhysicalProperties` type is stored as a `u8` representing the bitfield, followed by a `CustomPhysicalProperties` if bit `0` is set.
 
 
 If you had 4 physical properties with the following characteristics:

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -586,19 +586,43 @@ Two encoded `Rect` values with values `Rect.new(-1, -10, 8, 9)` and `Rect.new(0,
 ### PhysicalProperties
 **Type ID `0x19`**
 
-The `PhysicalProperties` type contains a flag which may be followed by a `CustomPhysicalProperties` value. `CustomPhysicalProperties` is a struct composed of five `f32` values:
+The `PhysicalProperties` type contains a bitfield which indicates whether the value is custom, along with whether it has an `AudioAbsorption` field. This flag is a single byte. These bits are described below, where bit `0` is the least-significant bit.
 
-| Field Name       | Format | Value                                                        |
-|:-----------------|:-------|:-------------------------------------------------------------|
-| Density          | `f32`  | The density set for the custom physical properties           |
-| Friction         | `f32`  | The friction set for the custom physical properties          |
-| Elasticity       | `f32`  | The elasticity set for the custom physical properties        |
-| FrictionWeight   | `f32`  | The friction weight set for the custom physical properties   |
-| ElasticityWeight | `f32`  | The elasticity weight set for the custom physical properties |
+| Bit Number | Purpose                                                                    |
+|:-----------|:---------------------------------------------------------------------------|
+| `0`        | Whether the value is custom or not                                         |
+| `1`        | Whether the value has `AcousticAbsorption` or not                          |
 
-If there is no `CustomPhysicalProperties` value, a `PhysicalProperties` is stored as a single byte of value `0`. Otherwise, it is stored as a byte of value `1` immediately followed by a `CustomPhysicalProperties` stored as little-endian floats (in the same order as the above table). When there are multiple `PhysicalProperties` present, they are stored in sequence with no transformations or interleaving.
+If bit `0` is set, then the value is followed by a `CustomPhysicalProperties`. This is a struct of 6 `f32` values:
 
-A default `PhysicalProperties` (i.e. no custom properties set) followed by a `PhysicalProperties` of value `PhysicalProperties.new(0.7, 0.3, 0.5, 1, 1)` looks like this: `00 01 33 33 33 3f 9a 99 99 3e 00 00 00 3f 00 00 80 3f 00 00 80 3f`.
+| Field Name         | Format | Value                                                          |
+|:-------------------|:-------|:---------------------------------------------------------------|
+| Density            | `f32`  | The density set for the custom physical properties             |
+| Friction           | `f32`  | The friction set for the custom physical properties            |
+| Elasticity         | `f32`  | The elasticity set for the custom physical properties          |
+| FrictionWeight     | `f32`  | The friction weight set for the custom physical properties     |
+| ElasticityWeight   | `f32`  | The elasticity weight set for the custom physical properties   |
+| AcousticAbsorption | `f32`  | The acoustic absorption set for the custom physical properties |
+
+The `AcousticAbsorption` field is only present if bit `1` is set. Otherwise, it is left out and may be assumed to be `1.0` when deserializing a `CustomPhysicalProperties`.
+
+If bit `0` is not set, but bit `1` is set, the is no `CustomPhysicalProperties` present.
+
+The `PhysicalProperties` type is stored as a `u8` representing the bitfield, followed by a `CustomPhysicalProperties` if bit `0` is set. When there are multiple `PhysicalProperties` present, they are stored in sequence with no transformations or interleaving.
+
+
+If you had 4 physical properties with the following characteristics:
+1. No custom properties set, no `AcousticAbsorption`
+2. `PhysicalProperties.new(0.7, 0.3, 0.5, 1, 1)`, no `AcousticAbsorption`
+3. No custom properties set, has `AcousticAbsorption`
+3. `PhysicalProperties.new(0.25, 0.5, 0.125, 1, 0.25, 0.5)`, has `AcousticAbsorption`
+
+They would be serialized as follows: `00 01 33 33 33 3f 9a 99 99 3e 00 00 00 3f 00 00 80 3f 00 00 80 3f 02 03 00 00 80 3e 00 00 00 3f 00 00 00 3e 00 00 80 3f 00 00 80 3e 00 00 00 3f`.
+
+1. is represented as `00`
+2. is represented as `01 33 33 33 3f 9a 99 99 3e 00 00 00 3f 00 00 80 3f 00 00 80 3f`
+3. is represented as `02`
+4. is represented as `03 00 00 80 3e 00 00 00 3f 00 00 00 3e 00 00 80 3f 00 00 80 3e 00 00 00 3f`
 
 ### Color3uint8
 **Type ID `0x1a`**

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -489,14 +489,16 @@ An `Optional<CoordinateFrame>` where the value was `0, 0, 0, 1, 0, 0, 0, 1, 0, 0
 
 The `PhysicalProperties` data type is represented as a sequence of either one or six child elements. The first child element is named `CustomPhysics` and is a [`bool`](#bool) value indicating whether the data type is custom or not.
 
-If `CustomPhysics` is `true`, then there will be an additional `5` child elements. They are named `Density`, `Friction`, `Elasticity`, `FrictionWeight`, and `ElasticityWeight` and represent the respective components of the value. Each of these child elements is a [`float`](#float) value.
+If `CustomPhysics` is `true`, then there will be an additional `6` child elements. They are named `Density`, `Friction`, `Elasticity`, `FrictionWeight`, `ElasticityWeight`, and `AcousticAbsorption` and represent the respective components of the value. Each of these child elements is a [`float`](#float) value.
+
+`AcousticAbsorption` was introduced at a later date and MAY be missing from older files. If it is not present in a custom `PhysicalProperties`, it can either be ignored or assumed to be a default value of `1.0`.
 
 If `CustomPhysics` is `false`, then it will be the only child element present.
 
 A custom `PhysicalProperties` created with this constructor:
 
 ```lua
-PhysicalProperties.new(1, 2, 3, 0.15625, 1.25)
+PhysicalProperties.new(1, 2, 3, 0.15625, 1.25, 1)
 ```
 
 Appears as follows:
@@ -509,6 +511,7 @@ Appears as follows:
 	<Elasticity>1</Elasticity>
 	<FrictionWeight>0.15625</FrictionWeight>
 	<ElasticityWeight>1.25</ElasticityWeight>
+	<AcousticAbsorption>1</AcousticAbsorption>
 </PhysicalProperties>
 ```
 

--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,7 +1,9 @@
 # rbx_binary Changelog
 
 ## Unreleased
-* Implement support for `AcousticAbsorption` in `PhysicalProperties`.
+* Implement support for `AcousticAbsorption` in `PhysicalProperties`. ([#556])
+
+[#556]: https://github.com/rojo-rbx/rbx-dom/pull/556
 
 ## 1.0.0 (2025-03-28)
 * Dramatically improved performance of serializer and deserializer by using `Ustr` to represent property and class names ([#462]).

--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_binary Changelog
 
 ## Unreleased
+* Implement support for `AcousticAbsorption` in `PhysicalProperties`.
 
 ## 1.0.0 (2025-03-28)
 * Dramatically improved performance of serializer and deserializer by using `Ustr` to represent property and class names ([#462]).

--- a/rbx_binary/src/deserializer/error.rs
+++ b/rbx_binary/src/deserializer/error.rs
@@ -82,4 +82,7 @@ pub(crate) enum InnerError {
 
     #[error("'Content' type {0} is not implemented")]
     BadContentType(i32),
+
+    #[error("'PhysicalProperties' discriminator {0:b} is not supported")]
+    BadPhysicalPropertiesType(u8),
 }

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1184,7 +1184,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                                     chunk.read_le_f32()?,
                                     chunk.read_le_f32()?,
                                     chunk.read_le_f32()?,
-                                    None,
+                                    1.0,
                                 ),
                             )),
                             0b11 => Variant::PhysicalProperties(PhysicalProperties::Custom(
@@ -1194,7 +1194,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                                     chunk.read_le_f32()?,
                                     chunk.read_le_f32()?,
                                     chunk.read_le_f32()?,
-                                    Some(chunk.read_le_f32()?),
+                                    chunk.read_le_f32()?,
                                 ),
                             )),
                             _ => return Err(InnerError::BadPhysicalPropertiesType(discriminator)),

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1077,14 +1077,21 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                         for (i, rbx_value) in values {
                             if let Variant::PhysicalProperties(value) = rbx_value.as_ref() {
                                 if let PhysicalProperties::Custom(props) = value {
-                                    chunk.write_u8(1)?;
-                                    chunk.write_le_f32(props.density)?;
-                                    chunk.write_le_f32(props.friction)?;
-                                    chunk.write_le_f32(props.elasticity)?;
-                                    chunk.write_le_f32(props.friction_weight)?;
-                                    chunk.write_le_f32(props.elasticity_weight)?;
+                                    chunk.write_u8(if props.acoustic_absorption().is_some() {
+                                        0b11
+                                    } else {
+                                        0b01
+                                    })?;
+                                    chunk.write_le_f32(props.density())?;
+                                    chunk.write_le_f32(props.friction())?;
+                                    chunk.write_le_f32(props.elasticity())?;
+                                    chunk.write_le_f32(props.friction_weight())?;
+                                    chunk.write_le_f32(props.elasticity_weight())?;
+                                    if let Some(absorption) = props.acoustic_absorption() {
+                                        chunk.write_le_f32(absorption)?;
+                                    }
                                 } else {
-                                    chunk.write_u8(0)?;
+                                    chunk.write_u8(0b00)?;
                                 }
                             } else {
                                 return type_mismatch(i, &rbx_value, "PhysicalProperties");

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1085,7 +1085,7 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                                     chunk.write_le_f32(props.elasticity_weight())?;
                                     chunk.write_le_f32(props.acoustic_absorption())?;
                                 } else {
-                                    chunk.write_u8(0b00)?;
+                                    chunk.write_u8(0b10)?;
                                 }
                             } else {
                                 return type_mismatch(i, &rbx_value, "PhysicalProperties");

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1077,19 +1077,13 @@ impl<'dom, 'db, W: Write> SerializerState<'dom, 'db, W> {
                         for (i, rbx_value) in values {
                             if let Variant::PhysicalProperties(value) = rbx_value.as_ref() {
                                 if let PhysicalProperties::Custom(props) = value {
-                                    chunk.write_u8(if props.acoustic_absorption().is_some() {
-                                        0b11
-                                    } else {
-                                        0b01
-                                    })?;
+                                    chunk.write_u8(0b11)?;
                                     chunk.write_le_f32(props.density())?;
                                     chunk.write_le_f32(props.friction())?;
                                     chunk.write_le_f32(props.elasticity())?;
                                     chunk.write_le_f32(props.friction_weight())?;
                                     chunk.write_le_f32(props.elasticity_weight())?;
-                                    if let Some(absorption) = props.acoustic_absorption() {
-                                        chunk.write_le_f32(absorption)?;
-                                    }
+                                    chunk.write_le_f32(props.acoustic_absorption())?;
                                 } else {
                                     chunk.write_u8(0b00)?;
                                 }

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -69,4 +69,5 @@ binary_tests! {
     folder_with_enum_attribute,
     imagelabel_content,
     content_mixed,
+    physical_properties_acoustics,
 }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__physical-properties-acoustics__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__physical-properties-acoustics__decoded.snap
@@ -3,13 +3,15 @@ source: rbx_binary/src/tests/util.rs
 expression: decoded_viewed
 ---
 - referent: referent-0
-  name: Brush your teeth
+  name: CustomProperties
   class: Part
   properties:
     Anchored:
       Bool: false
     Attributes:
       Attributes: {}
+    AudioCanCollide:
+      Bool: true
     BackParamA:
       Float32: -0.5
     BackParamB:
@@ -29,9 +31,9 @@ expression: decoded_viewed
     CFrame:
       CFrame:
         position:
-          - -5.5
-          - 4
-          - -12.5
+          - 0.6
+          - 0.500013
+          - 0.8
         orientation:
           - - 1
             - 0
@@ -44,17 +46,33 @@ expression: decoded_viewed
             - 1
     CanCollide:
       Bool: true
+    CanQuery:
+      Bool: true
+    CanTouch:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
     CastShadow:
       Bool: true
+    CollisionGroup:
+      String: Default
     CollisionGroupId:
       Int32: 0
     Color:
       Color3uint8:
-        - 0
-        - 255
-        - 255
+        - 163
+        - 162
+        - 165
     CustomPhysicalProperties:
-      PhysicalProperties: Default
+      PhysicalProperties:
+        density: 0.25
+        friction: 0.5
+        elasticity: 0.125
+        frictionWeight: 1
+        elasticityWeight: 0.25
+        acousticAbsorption: 0.5
+    EnableFluidForces:
+      Bool: true
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -79,6 +97,24 @@ expression: decoded_viewed
       Bool: false
     Material:
       Enum: 256
+    MaterialVariant:
+      String: ""
+    PivotOffset:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
     Reflectance:
       Float32: 0
     RightParamA:
@@ -96,13 +132,15 @@ expression: decoded_viewed
         - 0
         - 0
         - 0
+    Sandboxed:
+      Bool: false
     Shape:
       Enum: 1
     Size:
       Vector3:
+        - 4
         - 1
         - 2
-        - 3
     SourceAssetId:
       Int64: -1
     Tags:
@@ -124,13 +162,15 @@ expression: decoded_viewed
         - 0
   children: []
 - referent: referent-1
-  name: Eat your greens
+  name: NoCustomProperties
   class: Part
   properties:
     Anchored:
       Bool: false
     Attributes:
       Attributes: {}
+    AudioCanCollide:
+      Bool: true
     BackParamA:
       Float32: -0.5
     BackParamB:
@@ -150,9 +190,9 @@ expression: decoded_viewed
     CFrame:
       CFrame:
         position:
-          - -11.5
-          - -0.499993
-          - -17.5
+          - 0.5999999
+          - 1.500013
+          - 0.79999995
         orientation:
           - - 1
             - 0
@@ -165,23 +205,27 @@ expression: decoded_viewed
             - 1
     CanCollide:
       Bool: true
+    CanQuery:
+      Bool: true
+    CanTouch:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
     CastShadow:
       Bool: true
+    CollisionGroup:
+      String: Default
     CollisionGroupId:
       Int32: 0
     Color:
       Color3uint8:
-        - 44
-        - 101
-        - 29
+        - 163
+        - 162
+        - 165
     CustomPhysicalProperties:
-      PhysicalProperties:
-        density: 0.7
-        friction: 0.3
-        elasticity: 0.5
-        frictionWeight: 1
-        elasticityWeight: 1
-        acousticAbsorption: ~
+      PhysicalProperties: Default
+    EnableFluidForces:
+      Bool: true
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -206,6 +250,24 @@ expression: decoded_viewed
       Bool: false
     Material:
       Enum: 256
+    MaterialVariant:
+      String: ""
+    PivotOffset:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
     Reflectance:
       Float32: 0
     RightParamA:
@@ -223,140 +285,15 @@ expression: decoded_viewed
         - 0
         - 0
         - 0
+    Sandboxed:
+      Bool: false
     Shape:
       Enum: 1
     Size:
       Vector3:
         - 4
-        - 5
-        - 6
-    SourceAssetId:
-      Int64: -1
-    Tags:
-      Tags: []
-    TopParamA:
-      Float32: -0.5
-    TopParamB:
-      Float32: 0.5
-    TopSurface:
-      Enum: 0
-    TopSurfaceInput:
-      Enum: 0
-    Transparency:
-      Float32: 0
-    Velocity:
-      Vector3:
-        - 0
-        - 0
-        - 0
-  children: []
-- referent: referent-2
-  name: Live wildly
-  class: Part
-  properties:
-    Anchored:
-      Bool: false
-    Attributes:
-      Attributes: {}
-    BackParamA:
-      Float32: -0.5
-    BackParamB:
-      Float32: 0.5
-    BackSurface:
-      Enum: 0
-    BackSurfaceInput:
-      Enum: 0
-    BottomParamA:
-      Float32: -0.5
-    BottomParamB:
-      Float32: 0.5
-    BottomSurface:
-      Enum: 0
-    BottomSurfaceInput:
-      Enum: 0
-    CFrame:
-      CFrame:
-        position:
-          - 5.5
-          - 8.5
-          - -25.5
-        orientation:
-          - - 1
-            - 0
-            - 0
-          - - 0
-            - 1
-            - 0
-          - - 0
-            - 0
-            - 1
-    CanCollide:
-      Bool: true
-    CastShadow:
-      Bool: true
-    CollisionGroupId:
-      Int32: 0
-    Color:
-      Color3uint8:
-        - 255
-        - 0
-        - 191
-    CustomPhysicalProperties:
-      PhysicalProperties:
-        density: 90.66
-        friction: 1.44
-        elasticity: 0.65
-        frictionWeight: 50.5
-        elasticityWeight: 40.5
-        acousticAbsorption: ~
-    FormFactor:
-      Enum: 1
-    FrontParamA:
-      Float32: -0.5
-    FrontParamB:
-      Float32: 0.5
-    FrontSurface:
-      Enum: 0
-    FrontSurfaceInput:
-      Enum: 0
-    LeftParamA:
-      Float32: -0.5
-    LeftParamB:
-      Float32: 0.5
-    LeftSurface:
-      Enum: 0
-    LeftSurfaceInput:
-      Enum: 0
-    Locked:
-      Bool: false
-    Massless:
-      Bool: false
-    Material:
-      Enum: 256
-    Reflectance:
-      Float32: 0
-    RightParamA:
-      Float32: -0.5
-    RightParamB:
-      Float32: 0.5
-    RightSurface:
-      Enum: 0
-    RightSurfaceInput:
-      Enum: 0
-    RootPriority:
-      Int32: 0
-    RotVelocity:
-      Vector3:
-        - 0
-        - 0
-        - 0
-    Shape:
-      Enum: 1
-    Size:
-      Vector3:
-        - 7
-        - 8
-        - 9
+        - 1
+        - 2
     SourceAssetId:
       Int64: -1
     Tags:

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__physical-properties-acoustics__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__physical-properties-acoustics__encoded.snap
@@ -3,7 +3,7 @@ source: rbx_binary/src/tests/util.rs
 expression: text_roundtrip
 ---
 num_types: 1
-num_instances: 3
+num_instances: 2
 chunks:
   - Inst:
       type_id: 0
@@ -12,13 +12,11 @@ chunks:
       referents:
         - 0
         - 1
-        - 2
   - Prop:
       type_id: 0
       prop_name: Anchored
       prop_type: Bool
       values:
-        - false
         - false
         - false
   - Prop:
@@ -28,13 +26,18 @@ chunks:
       values:
         - ""
         - ""
-        - ""
+  - Prop:
+      type_id: 0
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
   - Prop:
       type_id: 0
       prop_name: BackParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -44,13 +47,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: BackSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -60,13 +61,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: BottomParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -76,13 +75,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: BottomSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -92,16 +89,15 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: CFrame
       prop_type: CFrame
       values:
         - position:
-            - -5.5
-            - 4
-            - -12.5
+            - 0.6
+            - 0.500013
+            - 0.8
           orientation:
             - - 1
               - 0
@@ -113,23 +109,9 @@ chunks:
               - 0
               - 1
         - position:
-            - -11.5
-            - -0.499993
-            - -17.5
-          orientation:
-            - - 1
-              - 0
-              - 0
-            - - 0
-              - 1
-              - 0
-            - - 0
-              - 0
-              - 1
-        - position:
-            - 5.5
-            - 8.5
-            - -25.5
+            - 0.5999999
+            - 1.500013
+            - 0.79999995
           orientation:
             - - 1
               - 0
@@ -147,7 +129,27 @@ chunks:
       values:
         - true
         - true
+  - Prop:
+      type_id: 0
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
         - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+        - 0
   - Prop:
       type_id: 0
       prop_name: CastShadow
@@ -155,7 +157,13 @@ chunks:
       values:
         - true
         - true
-        - true
+  - Prop:
+      type_id: 0
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+        - Default
   - Prop:
       type_id: 0
       prop_name: CollisionGroupId
@@ -163,45 +171,41 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: Color3uint8
       prop_type: Color3uint8
       values:
-        - - 0
-          - 255
-          - 255
-        - - 44
-          - 101
-          - 29
-        - - 255
-          - 0
-          - 191
+        - - 163
+          - 162
+          - 165
+        - - 163
+          - 162
+          - 165
   - Prop:
       type_id: 0
       prop_name: CustomPhysicalProperties
       prop_type: PhysicalProperties
       values:
-        - Default
-        - density: 0.7
-          friction: 0.3
-          elasticity: 0.5
+        - density: 0.25
+          friction: 0.5
+          elasticity: 0.125
           frictionWeight: 1
-          elasticityWeight: 1
-          acousticAbsorption: ~
-        - density: 90.66
-          friction: 1.44
-          elasticity: 0.65
-          frictionWeight: 50.5
-          elasticityWeight: 40.5
-          acousticAbsorption: ~
+          elasticityWeight: 0.25
+          acousticAbsorption: 0.5
+        - Default
+  - Prop:
+      type_id: 0
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+        - true
   - Prop:
       type_id: 0
       prop_name: formFactorRaw
       prop_type: Enum
       values:
-        - 1
         - 1
         - 1
   - Prop:
@@ -211,13 +215,11 @@ chunks:
       values:
         - -0.5
         - -0.5
-        - -0.5
   - Prop:
       type_id: 0
       prop_name: FrontParamB
       prop_type: Float32
       values:
-        - 0.5
         - 0.5
         - 0.5
   - Prop:
@@ -227,13 +229,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: FrontSurfaceInput
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -243,13 +243,11 @@ chunks:
       values:
         - -0.5
         - -0.5
-        - -0.5
   - Prop:
       type_id: 0
       prop_name: LeftParamB
       prop_type: Float32
       values:
-        - 0.5
         - 0.5
         - 0.5
   - Prop:
@@ -259,13 +257,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: LeftSurfaceInput
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -275,13 +271,11 @@ chunks:
       values:
         - false
         - false
-        - false
   - Prop:
       type_id: 0
       prop_name: Massless
       prop_type: Bool
       values:
-        - false
         - false
         - false
   - Prop:
@@ -291,21 +285,58 @@ chunks:
       values:
         - 256
         - 256
-        - 256
+  - Prop:
+      type_id: 0
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+        - ""
   - Prop:
       type_id: 0
       prop_name: Name
       prop_type: String
       values:
-        - Brush your teeth
-        - Eat your greens
-        - Live wildly
+        - CustomProperties
+        - NoCustomProperties
+  - Prop:
+      type_id: 0
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
   - Prop:
       type_id: 0
       prop_name: Reflectance
       prop_type: Float32
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -315,13 +346,11 @@ chunks:
       values:
         - -0.5
         - -0.5
-        - -0.5
   - Prop:
       type_id: 0
       prop_name: RightParamB
       prop_type: Float32
       values:
-        - 0.5
         - 0.5
         - 0.5
   - Prop:
@@ -331,7 +360,6 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: RightSurfaceInput
@@ -339,13 +367,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: RootPriority
       prop_type: Int32
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -359,9 +385,13 @@ chunks:
         - - 0
           - 0
           - 0
-        - - 0
-          - 0
-          - 0
+  - Prop:
+      type_id: 0
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+        - false
   - Prop:
       type_id: 0
       prop_name: shape
@@ -369,27 +399,22 @@ chunks:
       values:
         - 1
         - 1
-        - 1
   - Prop:
       type_id: 0
       prop_name: size
       prop_type: Vector3
       values:
-        - - 1
-          - 2
-          - 3
         - - 4
-          - 5
-          - 6
-        - - 7
-          - 8
-          - 9
+          - 1
+          - 2
+        - - 4
+          - 1
+          - 2
   - Prop:
       type_id: 0
       prop_name: SourceAssetId
       prop_type: Int64
       values:
-        - -1
         - -1
         - -1
   - Prop:
@@ -399,13 +424,11 @@ chunks:
       values:
         - ""
         - ""
-        - ""
   - Prop:
       type_id: 0
       prop_name: TopParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -415,13 +438,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: TopSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -431,13 +452,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: Transparency
       prop_type: Float32
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -451,16 +470,11 @@ chunks:
         - - 0
           - 0
           - 0
-        - - 0
-          - 0
-          - 0
   - Prnt:
       version: 0
       links:
         - - 0
           - -1
         - - 1
-          - -1
-        - - 2
           - -1
   - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__physical-properties-acoustics__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__physical-properties-acoustics__input.snap
@@ -1,10 +1,14 @@
 ---
 source: rbx_binary/src/tests/util.rs
-expression: text_roundtrip
+expression: text_decoded
 ---
 num_types: 1
-num_instances: 3
+num_instances: 2
 chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
   - Inst:
       type_id: 0
       type_name: Part
@@ -12,13 +16,11 @@ chunks:
       referents:
         - 0
         - 1
-        - 2
   - Prop:
       type_id: 0
       prop_name: Anchored
       prop_type: Bool
       values:
-        - false
         - false
         - false
   - Prop:
@@ -28,13 +30,18 @@ chunks:
       values:
         - ""
         - ""
-        - ""
+  - Prop:
+      type_id: 0
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
   - Prop:
       type_id: 0
       prop_name: BackParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -44,13 +51,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: BackSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -60,13 +65,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: BottomParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -76,13 +79,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: BottomSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -92,16 +93,15 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: CFrame
       prop_type: CFrame
       values:
         - position:
-            - -5.5
-            - 4
-            - -12.5
+            - 0.6
+            - 0.500013
+            - 0.8
           orientation:
             - - 1
               - 0
@@ -113,23 +113,9 @@ chunks:
               - 0
               - 1
         - position:
-            - -11.5
-            - -0.499993
-            - -17.5
-          orientation:
-            - - 1
-              - 0
-              - 0
-            - - 0
-              - 1
-              - 0
-            - - 0
-              - 0
-              - 1
-        - position:
-            - 5.5
-            - 8.5
-            - -25.5
+            - 0.5999999
+            - 1.500013
+            - 0.79999995
           orientation:
             - - 1
               - 0
@@ -147,7 +133,27 @@ chunks:
       values:
         - true
         - true
+  - Prop:
+      type_id: 0
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
         - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+        - 0
   - Prop:
       type_id: 0
       prop_name: CastShadow
@@ -155,7 +161,13 @@ chunks:
       values:
         - true
         - true
-        - true
+  - Prop:
+      type_id: 0
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+        - Default
   - Prop:
       type_id: 0
       prop_name: CollisionGroupId
@@ -163,53 +175,48 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: Color3uint8
       prop_type: Color3uint8
       values:
-        - - 0
-          - 255
-          - 255
-        - - 44
-          - 101
-          - 29
-        - - 255
-          - 0
-          - 191
+        - - 163
+          - 162
+          - 165
+        - - 163
+          - 162
+          - 165
   - Prop:
       type_id: 0
       prop_name: CustomPhysicalProperties
       prop_type: PhysicalProperties
       values:
-        - Default
-        - density: 0.7
-          friction: 0.3
-          elasticity: 0.5
+        - density: 0.25
+          friction: 0.5
+          elasticity: 0.125
           frictionWeight: 1
-          elasticityWeight: 1
-          acousticAbsorption: ~
-        - density: 90.66
-          friction: 1.44
-          elasticity: 0.65
-          frictionWeight: 50.5
-          elasticityWeight: 40.5
-          acousticAbsorption: ~
+          elasticityWeight: 0.25
+          acousticAbsorption: 0.5
+        - Default
   - Prop:
       type_id: 0
-      prop_name: formFactorRaw
-      prop_type: Enum
+      prop_name: DefinesCapabilities
+      prop_type: Bool
       values:
-        - 1
-        - 1
-        - 1
+        - false
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+        - true
   - Prop:
       type_id: 0
       prop_name: FrontParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -219,13 +226,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: FrontSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -235,13 +240,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: LeftParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -251,13 +254,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: LeftSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -267,13 +268,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: Locked
       prop_type: Bool
       values:
-        - false
         - false
         - false
   - Prop:
@@ -283,7 +282,6 @@ chunks:
       values:
         - false
         - false
-        - false
   - Prop:
       type_id: 0
       prop_name: Material
@@ -291,21 +289,58 @@ chunks:
       values:
         - 256
         - 256
-        - 256
+  - Prop:
+      type_id: 0
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+        - ""
   - Prop:
       type_id: 0
       prop_name: Name
       prop_type: String
       values:
-        - Brush your teeth
-        - Eat your greens
-        - Live wildly
+        - CustomProperties
+        - NoCustomProperties
+  - Prop:
+      type_id: 0
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
   - Prop:
       type_id: 0
       prop_name: Reflectance
       prop_type: Float32
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -315,13 +350,11 @@ chunks:
       values:
         - -0.5
         - -0.5
-        - -0.5
   - Prop:
       type_id: 0
       prop_name: RightParamB
       prop_type: Float32
       values:
-        - 0.5
         - 0.5
         - 0.5
   - Prop:
@@ -331,7 +364,6 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: RightSurfaceInput
@@ -339,13 +371,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: RootPriority
       prop_type: Int32
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -359,37 +389,11 @@ chunks:
         - - 0
           - 0
           - 0
-        - - 0
-          - 0
-          - 0
-  - Prop:
-      type_id: 0
-      prop_name: shape
-      prop_type: Enum
-      values:
-        - 1
-        - 1
-        - 1
-  - Prop:
-      type_id: 0
-      prop_name: size
-      prop_type: Vector3
-      values:
-        - - 1
-          - 2
-          - 3
-        - - 4
-          - 5
-          - 6
-        - - 7
-          - 8
-          - 9
   - Prop:
       type_id: 0
       prop_name: SourceAssetId
       prop_type: Int64
       values:
-        - -1
         - -1
         - -1
   - Prop:
@@ -399,13 +403,11 @@ chunks:
       values:
         - ""
         - ""
-        - ""
   - Prop:
       type_id: 0
       prop_name: TopParamA
       prop_type: Float32
       values:
-        - -0.5
         - -0.5
         - -0.5
   - Prop:
@@ -415,13 +417,11 @@ chunks:
       values:
         - 0.5
         - 0.5
-        - 0.5
   - Prop:
       type_id: 0
       prop_name: TopSurface
       prop_type: Enum
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -431,13 +431,11 @@ chunks:
       values:
         - 0
         - 0
-        - 0
   - Prop:
       type_id: 0
       prop_name: Transparency
       prop_type: Float32
       values:
-        - 0
         - 0
         - 0
   - Prop:
@@ -451,16 +449,36 @@ chunks:
         - - 0
           - 0
           - 0
-        - - 0
-          - 0
-          - 0
+  - Prop:
+      type_id: 0
+      prop_name: formFactorRaw
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: shape
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 4
+          - 1
+          - 2
+        - - 4
+          - 1
+          - 2
   - Prnt:
       version: 0
       links:
         - - 0
           - -1
         - - 1
-          - -1
-        - - 2
           - -1
   - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__decoded.snap
@@ -181,7 +181,7 @@ expression: decoded_viewed
         elasticity: 0.5
         frictionWeight: 1
         elasticityWeight: 1
-        acousticAbsorption: ~
+        acousticAbsorption: 1
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -308,7 +308,7 @@ expression: decoded_viewed
         elasticity: 0.65
         frictionWeight: 50.5
         elasticityWeight: 40.5
-        acousticAbsorption: ~
+        acousticAbsorption: 1
     FormFactor:
       Enum: 1
     FrontParamA:

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__encoded.snap
@@ -189,13 +189,13 @@ chunks:
           elasticity: 0.5
           frictionWeight: 1
           elasticityWeight: 1
-          acousticAbsorption: ~
+          acousticAbsorption: 1
         - density: 90.66
           friction: 1.44
           elasticity: 0.65
           frictionWeight: 50.5
           elasticityWeight: 40.5
-          acousticAbsorption: ~
+          acousticAbsorption: 1
   - Prop:
       type_id: 0
       prop_name: formFactorRaw

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__input.snap
@@ -193,13 +193,13 @@ chunks:
           elasticity: 0.5
           frictionWeight: 1
           elasticityWeight: 1
-          acousticAbsorption: ~
+          acousticAbsorption: 1
         - density: 90.66
           friction: 1.44
           elasticity: 0.65
           frictionWeight: 50.5
           elasticityWeight: 40.5
-          acousticAbsorption: ~
+          acousticAbsorption: 1
   - Prop:
       type_id: 0
       prop_name: FrontParamA

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-unique-parts__input.snap
@@ -193,11 +193,13 @@ chunks:
           elasticity: 0.5
           frictionWeight: 1
           elasticityWeight: 1
+          acousticAbsorption: ~
         - density: 90.66
           friction: 1.44
           elasticity: 0.65
           frictionWeight: 50.5
           elasticityWeight: 40.5
+          acousticAbsorption: ~
   - Prop:
       type_id: 0
       prop_name: FrontParamA
@@ -466,4 +468,3 @@ chunks:
         - - 2
           - -1
   - End
-

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -611,7 +611,7 @@ impl DecodedValues {
                             reader.read_le_f32().unwrap(),
                             reader.read_le_f32().unwrap(),
                             reader.read_le_f32().unwrap(),
-                            None,
+                            1.0,
                         )),
                         0b11 => PhysicalProperties::Custom(CustomPhysicalProperties::new(
                             reader.read_le_f32().unwrap(),
@@ -619,7 +619,7 @@ impl DecodedValues {
                             reader.read_le_f32().unwrap(),
                             reader.read_le_f32().unwrap(),
                             reader.read_le_f32().unwrap(),
-                            Some(reader.read_le_f32().unwrap()),
+                            reader.read_le_f32().unwrap(),
                         )),
                         _ => panic!(
                             "cannot read PhysicalProperties with discriminator 0b{:b}",

--- a/rbx_dom_lua/src/EncodedValue.lua
+++ b/rbx_dom_lua/src/EncodedValue.lua
@@ -378,13 +378,26 @@ types = {
 			if pod == "Default" then
 				return nil
 			else
-				return PhysicalProperties.new(
-					pod.density,
-					pod.friction,
-					pod.elasticity,
-					pod.frictionWeight,
-					pod.elasticityWeight
-				)
+				-- Passing `nil` instead of not passing anything gives
+				-- different results, so we have to branch here.
+				if pod.acousticAbsorption then
+					return (PhysicalProperties.new :: any)(
+						pod.density,
+						pod.friction,
+						pod.elasticity,
+						pod.frictionWeight,
+						pod.elasticityWeight,
+						pod.acousticAbsorption
+					)
+				else
+					return PhysicalProperties.new(
+						pod.density,
+						pod.friction,
+						pod.elasticity,
+						pod.frictionWeight,
+						pod.elasticityWeight
+					)
+				end
 			end
 		end,
 
@@ -398,6 +411,7 @@ types = {
 					elasticity = roblox.Elasticity,
 					frictionWeight = roblox.FrictionWeight,
 					elasticityWeight = roblox.ElasticityWeight,
+					acousticAbsorption = roblox.AcousticAbsorption,
 				}
 			end
 		end,

--- a/rbx_dom_lua/src/allValues.json
+++ b/rbx_dom_lua/src/allValues.json
@@ -441,7 +441,8 @@
         "friction": 1.0,
         "elasticity": 0.0,
         "frictionWeight": 50.0,
-        "elasticityWeight": 25.0
+        "elasticityWeight": 25.0,
+        "acousticAbsorption": 0.15625
       }
     },
     "ty": "PhysicalProperties"

--- a/rbx_reflector/src/cli/values.rs
+++ b/rbx_reflector/src/cli/values.rs
@@ -170,12 +170,7 @@ impl ValuesSubcommand {
         values.insert(
             "PhysicalProperties-Custom",
             PhysicalProperties::Custom(CustomPhysicalProperties::new(
-                0.5,
-                1.0,
-                0.0,
-                50.0,
-                25.0,
-                Some(0.15625),
+                0.5, 1.0, 0.0, 50.0, 25.0, 0.15625,
             ))
             .into(),
         );

--- a/rbx_reflector/src/cli/values.rs
+++ b/rbx_reflector/src/cli/values.rs
@@ -169,13 +169,14 @@ impl ValuesSubcommand {
         );
         values.insert(
             "PhysicalProperties-Custom",
-            PhysicalProperties::Custom(CustomPhysicalProperties {
-                density: 0.5,
-                friction: 1.0,
-                elasticity: 0.0,
-                friction_weight: 50.0,
-                elasticity_weight: 25.0,
-            })
+            PhysicalProperties::Custom(CustomPhysicalProperties::new(
+                0.5,
+                1.0,
+                0.0,
+                50.0,
+                25.0,
+                Some(0.15625),
+            ))
             .into(),
         );
         values.insert(

--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased Changes
 
-* Reworked `PhysicalProperties` type to support `AudioAbsorption`. This is a breaking change, though it is minor. This change makes `PhysicalProperties` non-exhaustive, makes the fields private, and adds setters/getters for them instead. 
-
+* Reworked `PhysicalProperties` type to support `AudioAbsorption`. This is a breaking change, though it is minor. This change makes `PhysicalProperties` non-exhaustive, makes the fields private, and adds setters/getters for them instead. ([#556])
 * Added `Ref::some` to construct a Ref from a u128. ([#516])
 * Added `Content::as_object` and `Content::as_uri` to assume the respective type (optional value). ([#511])
 * Added `Content::into_value` to support converting a `Content` into its underlying value. ([#507])
 
 [#507]: https://github.com/rojo-rbx/rbx-dom/pull/507
+[#556]: https://github.com/rojo-rbx/rbx-dom/pull/556
 
 ## 2.0.0 (2025-03-28)
 * Changed `Content` to more closely align with Roblox's new `Content` type. This is a breaking change. ([#495])

--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+* Reworked `PhysicalProperties` type to support `AudioAbsorption`. This is a breaking change, though it is minor. This change makes `PhysicalProperties` non-exhaustive, makes the fields private, and adds setters/getters for them instead. 
+
 * Added `Ref::some` to construct a Ref from a u128. ([#516])
 * Added `Content::as_object` and `Content::as_uri` to assume the respective type (optional value). ([#511])
 * Added `Content::into_value` to support converting a `Content` into its underlying value. ([#507])

--- a/rbx_types/src/physical_properties.rs
+++ b/rbx_types/src/physical_properties.rs
@@ -36,7 +36,7 @@ pub struct CustomPhysicalProperties {
     elasticity: f32,
     friction_weight: f32,
     elasticity_weight: f32,
-    acoustic_absorption: Option<f32>,
+    acoustic_absorption: f32,
 }
 
 impl CustomPhysicalProperties {
@@ -46,7 +46,7 @@ impl CustomPhysicalProperties {
         elasticity: f32,
         friction_weight: f32,
         elasticity_weight: f32,
-        acoustic_absorption: Option<f32>,
+        acoustic_absorption: f32,
     ) -> Self {
         Self {
             density,
@@ -109,12 +109,12 @@ impl CustomPhysicalProperties {
     }
 
     #[inline]
-    pub fn acoustic_absorption(&self) -> Option<f32> {
+    pub fn acoustic_absorption(&self) -> f32 {
         self.acoustic_absorption
     }
 
     #[inline]
-    pub fn set_acoustic_absorption(&mut self, acoustic_absorption: Option<f32>) {
+    pub fn set_acoustic_absorption(&mut self, acoustic_absorption: f32) {
         self.acoustic_absorption = acoustic_absorption
     }
 }
@@ -224,11 +224,11 @@ mod serde_test {
             elasticity: 0.0,
             elasticity_weight: 5.0,
             friction_weight: 6.0,
-            acoustic_absorption: None,
+            acoustic_absorption: 1.0,
         });
 
         let ser = serde_json::to_string(&custom).unwrap();
-        assert_eq!(ser, "{\"density\":1.0,\"friction\":0.5,\"elasticity\":0.0,\"frictionWeight\":6.0,\"elasticityWeight\":5.0,\"acousticAbsorption\":null}");
+        assert_eq!(ser, "{\"density\":1.0,\"friction\":0.5,\"elasticity\":0.0,\"frictionWeight\":6.0,\"elasticityWeight\":5.0,\"acousticAbsorption\":1.0}");
 
         let de: PhysicalProperties = serde_json::from_str(&ser).unwrap();
         assert_eq!(de, custom);
@@ -242,7 +242,7 @@ mod serde_test {
             elasticity: 0.0,
             elasticity_weight: 5.0,
             friction_weight: 6.0,
-            acoustic_absorption: Some(1337.0),
+            acoustic_absorption: 1337.0,
         });
 
         let ser = serde_json::to_string(&custom).unwrap();
@@ -270,7 +270,7 @@ mod serde_test {
             elasticity: 0.0,
             elasticity_weight: 5.0,
             friction_weight: 6.0,
-            acoustic_absorption: None,
+            acoustic_absorption: 1.0,
         });
 
         let ser = bincode::serialize(&custom).unwrap();

--- a/rbx_types/src/physical_properties.rs
+++ b/rbx_types/src/physical_properties.rs
@@ -29,12 +29,94 @@ impl From<CustomPhysicalProperties> for PhysicalProperties {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[non_exhaustive]
 pub struct CustomPhysicalProperties {
-    pub density: f32,
-    pub friction: f32,
-    pub elasticity: f32,
-    pub friction_weight: f32,
-    pub elasticity_weight: f32,
+    density: f32,
+    friction: f32,
+    elasticity: f32,
+    friction_weight: f32,
+    elasticity_weight: f32,
+    acoustic_absorption: Option<f32>,
+}
+
+impl CustomPhysicalProperties {
+    pub fn new(
+        density: f32,
+        friction: f32,
+        elasticity: f32,
+        friction_weight: f32,
+        elasticity_weight: f32,
+        acoustic_absorption: Option<f32>,
+    ) -> Self {
+        Self {
+            density,
+            friction,
+            elasticity,
+            friction_weight,
+            elasticity_weight,
+            acoustic_absorption,
+        }
+    }
+
+    #[inline]
+    pub fn density(&self) -> f32 {
+        self.density
+    }
+
+    #[inline]
+    pub fn set_density(&mut self, density: f32) {
+        self.density = density
+    }
+
+    #[inline]
+    pub fn friction(&self) -> f32 {
+        self.friction
+    }
+
+    #[inline]
+    pub fn set_friction(&mut self, friction: f32) {
+        self.friction = friction
+    }
+
+    #[inline]
+    pub fn elasticity(&self) -> f32 {
+        self.elasticity
+    }
+
+    #[inline]
+    pub fn set_elasticity(&mut self, elasticity: f32) {
+        self.elasticity = elasticity
+    }
+
+    #[inline]
+    pub fn friction_weight(&self) -> f32 {
+        self.friction_weight
+    }
+
+    #[inline]
+    pub fn set_friction_weight(&mut self, friction_weight: f32) {
+        self.friction_weight = friction_weight
+    }
+
+    #[inline]
+    pub fn elasticity_weight(&self) -> f32 {
+        self.elasticity_weight
+    }
+
+    #[inline]
+    pub fn set_elasticity_weight(&mut self, elasticity_weight: f32) {
+        self.elasticity_weight = elasticity_weight
+    }
+
+    #[inline]
+    pub fn acoustic_absorption(&self) -> Option<f32> {
+        self.acoustic_absorption
+    }
+
+    #[inline]
+    pub fn set_acoustic_absorption(&mut self, acoustic_absorption: Option<f32>) {
+        self.acoustic_absorption = acoustic_absorption
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -142,10 +224,29 @@ mod serde_test {
             elasticity: 0.0,
             elasticity_weight: 5.0,
             friction_weight: 6.0,
+            acoustic_absorption: None,
         });
 
         let ser = serde_json::to_string(&custom).unwrap();
-        assert_eq!(ser, "{\"density\":1.0,\"friction\":0.5,\"elasticity\":0.0,\"frictionWeight\":6.0,\"elasticityWeight\":5.0}");
+        assert_eq!(ser, "{\"density\":1.0,\"friction\":0.5,\"elasticity\":0.0,\"frictionWeight\":6.0,\"elasticityWeight\":5.0,\"acousticAbsorption\":null}");
+
+        let de: PhysicalProperties = serde_json::from_str(&ser).unwrap();
+        assert_eq!(de, custom);
+    }
+
+    #[test]
+    fn json_custom_acoustic() {
+        let custom = PhysicalProperties::Custom(CustomPhysicalProperties {
+            density: 1.0,
+            friction: 0.5,
+            elasticity: 0.0,
+            elasticity_weight: 5.0,
+            friction_weight: 6.0,
+            acoustic_absorption: Some(1337.0),
+        });
+
+        let ser = serde_json::to_string(&custom).unwrap();
+        assert_eq!(ser, "{\"density\":1.0,\"friction\":0.5,\"elasticity\":0.0,\"frictionWeight\":6.0,\"elasticityWeight\":5.0,\"acousticAbsorption\":1337.0}");
 
         let de: PhysicalProperties = serde_json::from_str(&ser).unwrap();
         assert_eq!(de, custom);
@@ -169,6 +270,7 @@ mod serde_test {
             elasticity: 0.0,
             elasticity_weight: 5.0,
             friction_weight: 6.0,
+            acoustic_absorption: None,
         });
 
         let ser = bincode::serialize(&custom).unwrap();

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* Implement support for `AcousticAbsorption` in `PhysicalProperties`
 
 ## 1.0.0 (2025-03-28)
 * Improved performance of serializer and deserializer by using `Ustr` to represent property and class names ([#462]).

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,7 +1,9 @@
 # rbx_xml Changelog
 
 ## Unreleased
-* Implement support for `AcousticAbsorption` in `PhysicalProperties`
+* Implement support for `AcousticAbsorption` in `PhysicalProperties` ([#556])
+
+[#556]: https://github.com/rojo-rbx/rbx-dom/pull/556
 
 ## 1.0.0 (2025-03-28)
 * Improved performance of serializer and deserializer by using `Ustr` to represent property and class names ([#462]).

--- a/rbx_xml/src/tests/formatting.rs
+++ b/rbx_xml/src/tests/formatting.rs
@@ -83,6 +83,15 @@ const INPUT: &str = r#"<roblox version="4">
                         <FrictionWeight>-0.15625</FrictionWeight>
                         <ElasticityWeight>NAN</ElasticityWeight>
                     </PhysicalProperties>
+                    <PhysicalProperties name="TestPhysicalProperties3">
+                        <CustomPhysics>true</CustomPhysics>
+                        <Density>1</Density>
+                        <Friction>-1</Friction>
+                        <Elasticity>0.15625</Elasticity>
+                        <FrictionWeight>-0.15625</FrictionWeight>
+                        <ElasticityWeight>NAN</ElasticityWeight>
+                        <AcousticAbsorption>1337</AcousticAbsorption>
+                    </PhysicalProperties>
                     <ProtectedString name="TestProtectedString">Hello world, again!</ProtectedString>
                     <Ray name="TestRay">
                         <origin>

--- a/rbx_xml/src/tests/models.rs
+++ b/rbx_xml/src/tests/models.rs
@@ -70,4 +70,5 @@ model_tests! {
     folder_with_enum_attribute,
     imagelabel_content,
     content_mixed,
+    physical_properties_acoustics,
 }

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__deserialized.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__deserialized.snap
@@ -133,7 +133,15 @@ expression: "DomViewer::new().view_children(&de)"
                 elasticity: 0.15625
                 frictionWeight: -0.15625
                 elasticityWeight: NaN
-                acousticAbsorption: ~
+                acousticAbsorption: 1
+            TestPhysicalProperties3:
+              PhysicalProperties:
+                density: 1
+                friction: -1
+                elasticity: 0.15625
+                frictionWeight: -0.15625
+                elasticityWeight: NaN
+                acousticAbsorption: 1337
             TestProtectedString:
               String: "Hello world, again!"
             TestRay:

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__deserialized.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__deserialized.snap
@@ -133,6 +133,7 @@ expression: "DomViewer::new().view_children(&de)"
                 elasticity: 0.15625
                 frictionWeight: -0.15625
                 elasticityWeight: NaN
+                acousticAbsorption: ~
             TestProtectedString:
               String: "Hello world, again!"
             TestRay:
@@ -187,4 +188,3 @@ expression: "DomViewer::new().view_children(&de)"
                 - 0
                 - 10
           children: []
-

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__serialized.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__formatting__serialized.snap
@@ -107,6 +107,16 @@ expression: ser_str
             <Elasticity>0.15625</Elasticity>
             <FrictionWeight>-0.15625</FrictionWeight>
             <ElasticityWeight>NAN</ElasticityWeight>
+            <AcousticAbsorption>1</AcousticAbsorption>
+          </PhysicalProperties>
+          <PhysicalProperties name="TestPhysicalProperties3">
+            <CustomPhysics>true</CustomPhysics>
+            <Density>1</Density>
+            <Friction>-1</Friction>
+            <Elasticity>0.15625</Elasticity>
+            <FrictionWeight>-0.15625</FrictionWeight>
+            <ElasticityWeight>NAN</ElasticityWeight>
+            <AcousticAbsorption>1337</AcousticAbsorption>
           </PhysicalProperties>
           <string name="TestProtectedString">Hello world, again!</string>
           <Ray name="TestRay">

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__physical-properties-acoustics__decoded.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__physical-properties-acoustics__decoded.snap
@@ -3,13 +3,15 @@ source: rbx_xml/src/tests/mod.rs
 expression: "DomViewer::new().view_children(&decoded)"
 ---
 - referent: referent-0
-  name: Brush your teeth
+  name: CustomProperties
   class: Part
   properties:
     Anchored:
       Bool: false
     Attributes:
       Attributes: {}
+    AudioCanCollide:
+      Bool: true
     BackParamA:
       Float32: -0.5
     BackParamB:
@@ -29,9 +31,9 @@ expression: "DomViewer::new().view_children(&decoded)"
     CFrame:
       CFrame:
         position:
-          - -5.5
-          - 4
-          - -12.5
+          - 0.6
+          - 0.500013
+          - 0.8
         orientation:
           - - 1
             - 0
@@ -44,17 +46,33 @@ expression: "DomViewer::new().view_children(&decoded)"
             - 1
     CanCollide:
       Bool: true
+    CanQuery:
+      Bool: true
+    CanTouch:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
     CastShadow:
       Bool: true
+    CollisionGroup:
+      String: Default
     CollisionGroupId:
       Int32: 0
     Color:
       Color3uint8:
-        - 0
-        - 255
-        - 255
+        - 163
+        - 162
+        - 165
     CustomPhysicalProperties:
-      PhysicalProperties: Default
+      PhysicalProperties:
+        density: 0.25
+        friction: 0.5
+        elasticity: 0.125
+        frictionWeight: 1
+        elasticityWeight: 0.25
+        acousticAbsorption: 0.5
+    EnableFluidForces:
+      Bool: true
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -79,6 +97,24 @@ expression: "DomViewer::new().view_children(&decoded)"
       Bool: false
     Material:
       Enum: 256
+    MaterialVariant:
+      String: ""
+    PivotOffset:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
     Reflectance:
       Float32: 0
     RightParamA:
@@ -96,13 +132,15 @@ expression: "DomViewer::new().view_children(&decoded)"
         - 0
         - 0
         - 0
+    Sandboxed:
+      Bool: false
     Shape:
       Enum: 1
     Size:
       Vector3:
+        - 4
         - 1
         - 2
-        - 3
     SourceAssetId:
       Int64: -1
     Tags:
@@ -124,13 +162,15 @@ expression: "DomViewer::new().view_children(&decoded)"
         - 0
   children: []
 - referent: referent-1
-  name: Eat your greens
+  name: NoCustomProperties
   class: Part
   properties:
     Anchored:
       Bool: false
     Attributes:
       Attributes: {}
+    AudioCanCollide:
+      Bool: true
     BackParamA:
       Float32: -0.5
     BackParamB:
@@ -150,9 +190,9 @@ expression: "DomViewer::new().view_children(&decoded)"
     CFrame:
       CFrame:
         position:
-          - -11.5
-          - -0.499993
-          - -17.5
+          - 0.5999999
+          - 1.500013
+          - 0.79999995
         orientation:
           - - 1
             - 0
@@ -165,23 +205,27 @@ expression: "DomViewer::new().view_children(&decoded)"
             - 1
     CanCollide:
       Bool: true
+    CanQuery:
+      Bool: true
+    CanTouch:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
     CastShadow:
       Bool: true
+    CollisionGroup:
+      String: Default
     CollisionGroupId:
       Int32: 0
     Color:
       Color3uint8:
-        - 44
-        - 101
-        - 29
+        - 163
+        - 162
+        - 165
     CustomPhysicalProperties:
-      PhysicalProperties:
-        density: 0.7
-        friction: 0.3
-        elasticity: 0.5
-        frictionWeight: 1
-        elasticityWeight: 1
-        acousticAbsorption: ~
+      PhysicalProperties: Default
+    EnableFluidForces:
+      Bool: true
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -206,6 +250,24 @@ expression: "DomViewer::new().view_children(&decoded)"
       Bool: false
     Material:
       Enum: 256
+    MaterialVariant:
+      String: ""
+    PivotOffset:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
     Reflectance:
       Float32: 0
     RightParamA:
@@ -223,140 +285,15 @@ expression: "DomViewer::new().view_children(&decoded)"
         - 0
         - 0
         - 0
+    Sandboxed:
+      Bool: false
     Shape:
       Enum: 1
     Size:
       Vector3:
         - 4
-        - 5
-        - 6
-    SourceAssetId:
-      Int64: -1
-    Tags:
-      Tags: []
-    TopParamA:
-      Float32: -0.5
-    TopParamB:
-      Float32: 0.5
-    TopSurface:
-      Enum: 0
-    TopSurfaceInput:
-      Enum: 0
-    Transparency:
-      Float32: 0
-    Velocity:
-      Vector3:
-        - 0
-        - 0
-        - 0
-  children: []
-- referent: referent-2
-  name: Live wildly
-  class: Part
-  properties:
-    Anchored:
-      Bool: false
-    Attributes:
-      Attributes: {}
-    BackParamA:
-      Float32: -0.5
-    BackParamB:
-      Float32: 0.5
-    BackSurface:
-      Enum: 0
-    BackSurfaceInput:
-      Enum: 0
-    BottomParamA:
-      Float32: -0.5
-    BottomParamB:
-      Float32: 0.5
-    BottomSurface:
-      Enum: 0
-    BottomSurfaceInput:
-      Enum: 0
-    CFrame:
-      CFrame:
-        position:
-          - 5.5
-          - 8.5
-          - -25.5
-        orientation:
-          - - 1
-            - 0
-            - 0
-          - - 0
-            - 1
-            - 0
-          - - 0
-            - 0
-            - 1
-    CanCollide:
-      Bool: true
-    CastShadow:
-      Bool: true
-    CollisionGroupId:
-      Int32: 0
-    Color:
-      Color3uint8:
-        - 255
-        - 0
-        - 191
-    CustomPhysicalProperties:
-      PhysicalProperties:
-        density: 90.66
-        friction: 1.44
-        elasticity: 0.65
-        frictionWeight: 50.5
-        elasticityWeight: 40.5
-        acousticAbsorption: ~
-    FormFactor:
-      Enum: 1
-    FrontParamA:
-      Float32: -0.5
-    FrontParamB:
-      Float32: 0.5
-    FrontSurface:
-      Enum: 0
-    FrontSurfaceInput:
-      Enum: 0
-    LeftParamA:
-      Float32: -0.5
-    LeftParamB:
-      Float32: 0.5
-    LeftSurface:
-      Enum: 0
-    LeftSurfaceInput:
-      Enum: 0
-    Locked:
-      Bool: false
-    Massless:
-      Bool: false
-    Material:
-      Enum: 256
-    Reflectance:
-      Float32: 0
-    RightParamA:
-      Float32: -0.5
-    RightParamB:
-      Float32: 0.5
-    RightSurface:
-      Enum: 0
-    RightSurfaceInput:
-      Enum: 0
-    RootPriority:
-      Int32: 0
-    RotVelocity:
-      Vector3:
-        - 0
-        - 0
-        - 0
-    Shape:
-      Enum: 1
-    Size:
-      Vector3:
-        - 7
-        - 8
-        - 9
+        - 1
+        - 2
     SourceAssetId:
       Int64: -1
     Tags:

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__physical-properties-acoustics__roundtrip.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__physical-properties-acoustics__roundtrip.snap
@@ -1,15 +1,17 @@
 ---
 source: rbx_xml/src/tests/mod.rs
-expression: "DomViewer::new().view_children(&decoded)"
+expression: "DomViewer::new().view_children(&roundtrip)"
 ---
 - referent: referent-0
-  name: Brush your teeth
+  name: CustomProperties
   class: Part
   properties:
     Anchored:
       Bool: false
     Attributes:
       Attributes: {}
+    AudioCanCollide:
+      Bool: true
     BackParamA:
       Float32: -0.5
     BackParamB:
@@ -29,9 +31,9 @@ expression: "DomViewer::new().view_children(&decoded)"
     CFrame:
       CFrame:
         position:
-          - -5.5
-          - 4
-          - -12.5
+          - 0.6
+          - 0.500013
+          - 0.8
         orientation:
           - - 1
             - 0
@@ -44,17 +46,33 @@ expression: "DomViewer::new().view_children(&decoded)"
             - 1
     CanCollide:
       Bool: true
+    CanQuery:
+      Bool: true
+    CanTouch:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
     CastShadow:
       Bool: true
+    CollisionGroup:
+      String: Default
     CollisionGroupId:
       Int32: 0
     Color:
       Color3uint8:
-        - 0
-        - 255
-        - 255
+        - 163
+        - 162
+        - 165
     CustomPhysicalProperties:
-      PhysicalProperties: Default
+      PhysicalProperties:
+        density: 0.25
+        friction: 0.5
+        elasticity: 0.125
+        frictionWeight: 1
+        elasticityWeight: 0.25
+        acousticAbsorption: 0.5
+    EnableFluidForces:
+      Bool: true
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -79,6 +97,24 @@ expression: "DomViewer::new().view_children(&decoded)"
       Bool: false
     Material:
       Enum: 256
+    MaterialVariant:
+      String: ""
+    PivotOffset:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
     Reflectance:
       Float32: 0
     RightParamA:
@@ -96,13 +132,15 @@ expression: "DomViewer::new().view_children(&decoded)"
         - 0
         - 0
         - 0
+    Sandboxed:
+      Bool: false
     Shape:
       Enum: 1
     Size:
       Vector3:
+        - 4
         - 1
         - 2
-        - 3
     SourceAssetId:
       Int64: -1
     Tags:
@@ -124,13 +162,15 @@ expression: "DomViewer::new().view_children(&decoded)"
         - 0
   children: []
 - referent: referent-1
-  name: Eat your greens
+  name: NoCustomProperties
   class: Part
   properties:
     Anchored:
       Bool: false
     Attributes:
       Attributes: {}
+    AudioCanCollide:
+      Bool: true
     BackParamA:
       Float32: -0.5
     BackParamB:
@@ -150,9 +190,9 @@ expression: "DomViewer::new().view_children(&decoded)"
     CFrame:
       CFrame:
         position:
-          - -11.5
-          - -0.499993
-          - -17.5
+          - 0.5999999
+          - 1.500013
+          - 0.79999995
         orientation:
           - - 1
             - 0
@@ -165,23 +205,27 @@ expression: "DomViewer::new().view_children(&decoded)"
             - 1
     CanCollide:
       Bool: true
+    CanQuery:
+      Bool: true
+    CanTouch:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
     CastShadow:
       Bool: true
+    CollisionGroup:
+      String: Default
     CollisionGroupId:
       Int32: 0
     Color:
       Color3uint8:
-        - 44
-        - 101
-        - 29
+        - 163
+        - 162
+        - 165
     CustomPhysicalProperties:
-      PhysicalProperties:
-        density: 0.7
-        friction: 0.3
-        elasticity: 0.5
-        frictionWeight: 1
-        elasticityWeight: 1
-        acousticAbsorption: ~
+      PhysicalProperties: Default
+    EnableFluidForces:
+      Bool: true
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -206,6 +250,24 @@ expression: "DomViewer::new().view_children(&decoded)"
       Bool: false
     Material:
       Enum: 256
+    MaterialVariant:
+      String: ""
+    PivotOffset:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
     Reflectance:
       Float32: 0
     RightParamA:
@@ -223,140 +285,15 @@ expression: "DomViewer::new().view_children(&decoded)"
         - 0
         - 0
         - 0
+    Sandboxed:
+      Bool: false
     Shape:
       Enum: 1
     Size:
       Vector3:
         - 4
-        - 5
-        - 6
-    SourceAssetId:
-      Int64: -1
-    Tags:
-      Tags: []
-    TopParamA:
-      Float32: -0.5
-    TopParamB:
-      Float32: 0.5
-    TopSurface:
-      Enum: 0
-    TopSurfaceInput:
-      Enum: 0
-    Transparency:
-      Float32: 0
-    Velocity:
-      Vector3:
-        - 0
-        - 0
-        - 0
-  children: []
-- referent: referent-2
-  name: Live wildly
-  class: Part
-  properties:
-    Anchored:
-      Bool: false
-    Attributes:
-      Attributes: {}
-    BackParamA:
-      Float32: -0.5
-    BackParamB:
-      Float32: 0.5
-    BackSurface:
-      Enum: 0
-    BackSurfaceInput:
-      Enum: 0
-    BottomParamA:
-      Float32: -0.5
-    BottomParamB:
-      Float32: 0.5
-    BottomSurface:
-      Enum: 0
-    BottomSurfaceInput:
-      Enum: 0
-    CFrame:
-      CFrame:
-        position:
-          - 5.5
-          - 8.5
-          - -25.5
-        orientation:
-          - - 1
-            - 0
-            - 0
-          - - 0
-            - 1
-            - 0
-          - - 0
-            - 0
-            - 1
-    CanCollide:
-      Bool: true
-    CastShadow:
-      Bool: true
-    CollisionGroupId:
-      Int32: 0
-    Color:
-      Color3uint8:
-        - 255
-        - 0
-        - 191
-    CustomPhysicalProperties:
-      PhysicalProperties:
-        density: 90.66
-        friction: 1.44
-        elasticity: 0.65
-        frictionWeight: 50.5
-        elasticityWeight: 40.5
-        acousticAbsorption: ~
-    FormFactor:
-      Enum: 1
-    FrontParamA:
-      Float32: -0.5
-    FrontParamB:
-      Float32: 0.5
-    FrontSurface:
-      Enum: 0
-    FrontSurfaceInput:
-      Enum: 0
-    LeftParamA:
-      Float32: -0.5
-    LeftParamB:
-      Float32: 0.5
-    LeftSurface:
-      Enum: 0
-    LeftSurfaceInput:
-      Enum: 0
-    Locked:
-      Bool: false
-    Massless:
-      Bool: false
-    Material:
-      Enum: 256
-    Reflectance:
-      Float32: 0
-    RightParamA:
-      Float32: -0.5
-    RightParamB:
-      Float32: 0.5
-    RightSurface:
-      Enum: 0
-    RightSurfaceInput:
-      Enum: 0
-    RootPriority:
-      Int32: 0
-    RotVelocity:
-      Vector3:
-        - 0
-        - 0
-        - 0
-    Shape:
-      Enum: 1
-    Size:
-      Vector3:
-        - 7
-        - 8
-        - 9
+        - 1
+        - 2
     SourceAssetId:
       Int64: -1
     Tags:

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__three-unique-parts__decoded.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__three-unique-parts__decoded.snap
@@ -181,7 +181,7 @@ expression: "DomViewer::new().view_children(&decoded)"
         elasticity: 0.5
         frictionWeight: 1
         elasticityWeight: 1
-        acousticAbsorption: ~
+        acousticAbsorption: 1
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -308,7 +308,7 @@ expression: "DomViewer::new().view_children(&decoded)"
         elasticity: 0.65
         frictionWeight: 50.5
         elasticityWeight: 40.5
-        acousticAbsorption: ~
+        acousticAbsorption: 1
     FormFactor:
       Enum: 1
     FrontParamA:

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__three-unique-parts__roundtrip.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__three-unique-parts__roundtrip.snap
@@ -181,7 +181,7 @@ expression: "DomViewer::new().view_children(&roundtrip)"
         elasticity: 0.5
         frictionWeight: 1
         elasticityWeight: 1
-        acousticAbsorption: ~
+        acousticAbsorption: 1
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -308,7 +308,7 @@ expression: "DomViewer::new().view_children(&roundtrip)"
         elasticity: 0.65
         frictionWeight: 50.5
         elasticityWeight: 40.5
-        acousticAbsorption: ~
+        acousticAbsorption: 1
     FormFactor:
       Enum: 1
     FrontParamA:

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__three-unique-parts__roundtrip.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__three-unique-parts__roundtrip.snap
@@ -181,6 +181,7 @@ expression: "DomViewer::new().view_children(&roundtrip)"
         elasticity: 0.5
         frictionWeight: 1
         elasticityWeight: 1
+        acousticAbsorption: ~
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -307,6 +308,7 @@ expression: "DomViewer::new().view_children(&roundtrip)"
         elasticity: 0.65
         frictionWeight: 50.5
         elasticityWeight: 40.5
+        acousticAbsorption: ~
     FormFactor:
       Enum: 1
     FrontParamA:
@@ -375,4 +377,3 @@ expression: "DomViewer::new().view_children(&roundtrip)"
         - 0
         - 0
   children: []
-

--- a/rbx_xml/src/types/physical_properties.rs
+++ b/rbx_xml/src/types/physical_properties.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Write};
 
 use rbx_dom_weak::types::{CustomPhysicalProperties, PhysicalProperties};
+use xml::reader::XmlEvent;
 
 use crate::{
     core::XmlType,
@@ -16,11 +17,14 @@ impl XmlType for PhysicalProperties {
         match self {
             PhysicalProperties::Custom(properties) => {
                 writer.write_value_in_tag(&true, "CustomPhysics")?;
-                writer.write_value_in_tag(&properties.density, "Density")?;
-                writer.write_value_in_tag(&properties.friction, "Friction")?;
-                writer.write_value_in_tag(&properties.elasticity, "Elasticity")?;
-                writer.write_value_in_tag(&properties.friction_weight, "FrictionWeight")?;
-                writer.write_value_in_tag(&properties.elasticity_weight, "ElasticityWeight")?;
+                writer.write_value_in_tag(&properties.density(), "Density")?;
+                writer.write_value_in_tag(&properties.friction(), "Friction")?;
+                writer.write_value_in_tag(&properties.elasticity(), "Elasticity")?;
+                writer.write_value_in_tag(&properties.friction_weight(), "FrictionWeight")?;
+                writer.write_value_in_tag(&properties.elasticity_weight(), "ElasticityWeight")?;
+                if let Some(value) = properties.acoustic_absorption() {
+                    writer.write_value_in_tag(&value, "AcousticAbsorption")?;
+                }
             }
             PhysicalProperties::Default => {
                 writer.write_value_in_tag(&false, "CustomPhysics")?;
@@ -40,13 +44,21 @@ impl XmlType for PhysicalProperties {
             let friction_weight: f32 = reader.read_value_in_tag("FrictionWeight")?;
             let elasticity_weight: f32 = reader.read_value_in_tag("ElasticityWeight")?;
 
-            Ok(PhysicalProperties::Custom(CustomPhysicalProperties {
+            let acoustic_absorption: Option<f32> = match reader.expect_peek()? {
+                XmlEvent::StartElement { name, .. } if name.local_name == "AcousticAbsorption" => {
+                    Some(reader.read_value_in_tag("AcousticAbsorption")?)
+                }
+                _ => None,
+            };
+
+            Ok(PhysicalProperties::Custom(CustomPhysicalProperties::new(
                 density,
                 friction,
                 elasticity,
                 friction_weight,
                 elasticity_weight,
-            }))
+                acoustic_absorption,
+            )))
         } else {
             Ok(PhysicalProperties::Default)
         }
@@ -66,13 +78,9 @@ mod test {
 
     #[test]
     fn round_trip_physical_properties_custom() {
-        test_util::test_xml_round_trip(&PhysicalProperties::Custom(CustomPhysicalProperties {
-            density: 0.5,
-            friction: 1.0,
-            elasticity: 1.5,
-            friction_weight: 2.0,
-            elasticity_weight: 2.5,
-        }));
+        test_util::test_xml_round_trip(&PhysicalProperties::Custom(CustomPhysicalProperties::new(
+            0.5, 1.0, 1.5, 2.0, 2.5, None,
+        )));
     }
 
     #[test]
@@ -100,13 +108,9 @@ mod test {
                     <ElasticityWeight>2.5</ElasticityWeight>
                 </PhysicalProperties>
             "#,
-            &PhysicalProperties::Custom(CustomPhysicalProperties {
-                density: 0.5,
-                friction: 1.0,
-                elasticity: 1.5,
-                friction_weight: 2.0,
-                elasticity_weight: 2.5,
-            }),
+            &PhysicalProperties::Custom(CustomPhysicalProperties::new(
+                0.5, 1.0, 1.5, 2.0, 2.5, None,
+            )),
         );
     }
 
@@ -135,13 +139,9 @@ mod test {
                     <ElasticityWeight>2.5</ElasticityWeight>
                 </PhysicalProperties>
             "#,
-            &PhysicalProperties::Custom(CustomPhysicalProperties {
-                density: 0.5,
-                friction: 1.0,
-                elasticity: 1.5,
-                friction_weight: 2.0,
-                elasticity_weight: 2.5,
-            }),
+            &PhysicalProperties::Custom(CustomPhysicalProperties::new(
+                0.5, 1.0, 1.5, 2.0, 2.5, None,
+            )),
         );
     }
 }

--- a/rbx_xml/src/types/physical_properties.rs
+++ b/rbx_xml/src/types/physical_properties.rs
@@ -22,9 +22,8 @@ impl XmlType for PhysicalProperties {
                 writer.write_value_in_tag(&properties.elasticity(), "Elasticity")?;
                 writer.write_value_in_tag(&properties.friction_weight(), "FrictionWeight")?;
                 writer.write_value_in_tag(&properties.elasticity_weight(), "ElasticityWeight")?;
-                if let Some(value) = properties.acoustic_absorption() {
-                    writer.write_value_in_tag(&value, "AcousticAbsorption")?;
-                }
+                writer
+                    .write_value_in_tag(&properties.acoustic_absorption(), "AcousticAbsorption")?;
             }
             PhysicalProperties::Default => {
                 writer.write_value_in_tag(&false, "CustomPhysics")?;
@@ -44,11 +43,11 @@ impl XmlType for PhysicalProperties {
             let friction_weight: f32 = reader.read_value_in_tag("FrictionWeight")?;
             let elasticity_weight: f32 = reader.read_value_in_tag("ElasticityWeight")?;
 
-            let acoustic_absorption: Option<f32> = match reader.expect_peek()? {
+            let acoustic_absorption: f32 = match reader.expect_peek()? {
                 XmlEvent::StartElement { name, .. } if name.local_name == "AcousticAbsorption" => {
-                    Some(reader.read_value_in_tag("AcousticAbsorption")?)
+                    reader.read_value_in_tag("AcousticAbsorption")?
                 }
-                _ => None,
+                _ => 1.0,
             };
 
             Ok(PhysicalProperties::Custom(CustomPhysicalProperties::new(
@@ -79,7 +78,7 @@ mod test {
     #[test]
     fn round_trip_physical_properties_custom() {
         test_util::test_xml_round_trip(&PhysicalProperties::Custom(CustomPhysicalProperties::new(
-            0.5, 1.0, 1.5, 2.0, 2.5, None,
+            0.5, 1.0, 1.5, 2.0, 2.5, 1.0,
         )));
     }
 
@@ -109,7 +108,7 @@ mod test {
                 </PhysicalProperties>
             "#,
             &PhysicalProperties::Custom(CustomPhysicalProperties::new(
-                0.5, 1.0, 1.5, 2.0, 2.5, None,
+                0.5, 1.0, 1.5, 2.0, 2.5, 1.0,
             )),
         );
     }
@@ -137,10 +136,11 @@ mod test {
                     <Elasticity>1.5</Elasticity>
                     <FrictionWeight>2</FrictionWeight>
                     <ElasticityWeight>2.5</ElasticityWeight>
+                    <AcousticAbsorption>3</AcousticAbsorption>
                 </PhysicalProperties>
             "#,
             &PhysicalProperties::Custom(CustomPhysicalProperties::new(
-                0.5, 1.0, 1.5, 2.0, 2.5, None,
+                0.5, 1.0, 1.5, 2.0, 2.5, 3.0,
             )),
         );
     }


### PR DESCRIPTION
Roblox has added a new field to `CustomPhysicalProperties` called `AcousticAbsorption`. This PR adds support for that field in rbx_types, **which is breaking**.

It also implements support for reading and writing this new field to rbx_xml and rbx_binary. This is not breaking.

I have confirmed with two separate Roblox engineers working on the acoustics system that the default for `AcousticAbsorption` when reading an existing `CustomPhysicalProperties` is `1.0`, so it's what our implementation goes with rather than making the field optional.