### PR TITLE
rbx_binary: Clear ustr cache in benches

### DIFF
--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -39,6 +39,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 rbx_reflection_database = { path = "../rbx_reflection_database", features = [
     "debug_always_use_bundled",
 ] }
+ustr = "1.1.0"
 
 [[bench]]
 name = "suite"

--- a/rbx_binary/benches/suite/util.rs
+++ b/rbx_binary/benches/suite/util.rs
@@ -35,8 +35,10 @@ fn deserialize_bench<T: Measurement>(group: &mut BenchmarkGroup<T>, buffer: &[u8
     group
         .throughput(Throughput::Bytes(buffer.len() as u64))
         .bench_function("Deserialize", |bencher| {
-            bencher.iter(|| {
-                rbx_binary::from_reader(buffer).unwrap();
-            });
+            bencher.iter_batched(
+                || unsafe { ustr::_clear_cache() },
+                |_| rbx_binary::from_reader(buffer).unwrap(),
+                BatchSize::SmallInput,
+            );
         });
 }


### PR DESCRIPTION
The ustr cache warming up causes subsequent runs to neither hash nor allocate new strings, leading to an unfair comparison to the first cold run, which is a more typical usage scenario.  The cache cannot be cleared during the serialize tests because the tree used to serialize contains Ustr strings. The performance should have gone down... is it just me or does this _increase_ the benchmark performance???