### PR TITLE
Refactor Tags to String

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -920,7 +920,7 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                                 }
                                 Variant::Tags(value) => {
                                     let buf = value.encode();
-                                    chunk.write_binary_string(&buf)?;
+                                    chunk.write_binary_string(buf)?;
                                 }
                                 Variant::Attributes(value) => {
                                     let mut buf = Vec::new();

--- a/rbx_reflector/src/cli/values.rs
+++ b/rbx_reflector/src/cli/values.rs
@@ -152,12 +152,7 @@ impl ValuesSubcommand {
         );
         values.insert(
             "Tags",
-            Tags::from(vec![
-                "foo".to_owned(),
-                "con'fusion?!".to_owned(),
-                "bar".to_owned(),
-            ])
-            .into(),
+            Tags::from_iter(["foo", "con'fusion?!", "bar"]).into(),
         );
         values.insert("OptionalCFrame-None", Variant::OptionalCFrame(None));
         values.insert(

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -169,6 +169,7 @@ mod test {
             };
         }
 
+        // decode input, expected encode, expected iter
         test!(b"", b"", []);
         test!(b"\0", b"", []);
         test!(b"\0ez", b"ez", ["ez"]);

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -165,6 +165,10 @@ mod test {
                 let array: [&str; _] = core::array::from_fn(|_| tags_iter.next().unwrap());
                 let expected_array: [&str; _] = $expected_array;
                 assert_eq!(array, expected_array, "decoded tags do not match expected");
+                assert!(
+                    tags_iter.next().is_none(),
+                    "TagsIter yielded too many items"
+                );
             };
         }
 

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -101,20 +101,30 @@ mod test {
     }
 
     #[test]
-    fn decode_encode() {
-        let value = b"ez\0pz";
-        let tags = Tags::decode(value).unwrap();
+    fn decode() {
+        macro_rules! test {
+            ($input:expr, $expected_encoded:expr, $expected_array:expr) => {
+                let tags = Tags::decode($input).unwrap();
+                assert_eq!(
+                    tags.encode(),
+                    $expected_encoded,
+                    "encoded tags does not match"
+                );
+                let mut tags_iter = tags.iter();
+                let array: [&str; _] = core::array::from_fn(|_| tags_iter.next().unwrap());
+                let expected_array: [&str; _] = $expected_array;
+                assert_eq!(array, expected_array, "tags do not match");
+            };
+        }
 
-        assert_eq!(tags.iter().collect::<Vec<_>>(), &["ez", "pz"]);
-        assert_eq!(tags.encode(), value);
-    }
-
-    #[test]
-    fn decode_empty() {
-        let input = b"";
-        let expected: &[String] = &[];
-        let result = Tags::decode(input).unwrap();
-
-        assert_eq!(result.iter().collect::<Vec<_>>(), expected);
+        test!(b"", b"", []);
+        test!(b"\0", b"", []);
+        test!(b"\0ez", b"ez", ["ez"]);
+        test!(b"\0ez\0", b"ez", ["ez"]);
+        test!(b"ez", b"ez", ["ez"]);
+        test!(b"ez\0", b"ez", ["ez"]);
+        test!(b"ez\0pz", b"ez\0pz", ["ez", "pz"]);
+        test!(b"ez\0\0pz", b"ez\0pz", ["ez", "pz"]);
+        test!(b"ez\0\0\0pz", b"ez\0pz", ["ez", "pz"]);
     }
 }

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -25,9 +25,7 @@ impl Tags {
 
     /// Returns an iterator over all of the tags in the container.
     pub fn iter(&self) -> TagsIter<'_> {
-        TagsIter {
-            internal: self.members.split('\0'),
-        }
+        TagsIter::new(&self.members)
     }
 
     /// Decodes tags from a buffer containing `\0`-delimited tag names.
@@ -73,10 +71,24 @@ impl<'a> core::iter::FromIterator<&'a str> for Tags {
         tags
     }
 }
+impl<'a> IntoIterator for &'a Tags {
+    type Item = &'a str;
+    type IntoIter = TagsIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
 
 /// See [`Tags::iter`].
 pub struct TagsIter<'a> {
     internal: core::str::Split<'a, char>,
+}
+impl<'a> TagsIter<'a> {
+    fn new(members: &'a str) -> Self {
+        TagsIter {
+            internal: members.split('\0'),
+        }
+    }
 }
 
 impl<'a> Iterator for TagsIter<'a> {
@@ -96,7 +108,7 @@ impl serde::Serialize for Tags {
         use serde::ser::SerializeSeq;
 
         let mut seq = serializer.serialize_seq(None)?;
-        for tag in self.iter() {
+        for tag in self {
             seq.serialize_element(tag)?;
         }
         seq.end()

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -1,4 +1,4 @@
-use std::string::FromUtf8Error;
+use core::str::Utf8Error;
 
 /// Contains a list of tags that can be applied to an instance.
 ///
@@ -31,8 +31,18 @@ impl Tags {
     }
 
     /// Decodes tags from a buffer containing `\0`-delimited tag names.
-    pub fn decode(buf: &[u8]) -> Result<Self, FromUtf8Error> {
-        let members = String::from_utf8(buf.to_owned())?;
+    pub fn decode(buf: &[u8]) -> Result<Self, Utf8Error> {
+        let str = str::from_utf8(buf)?;
+        // trim '\0's from beginning and end
+        let trimmed = str.trim_matches('\0');
+        if trimmed.is_empty() {
+            let members = String::new();
+            return Ok(Self { members });
+        }
+        let mut members = String::with_capacity(trimmed.len() + 1);
+        members.push_str(trimmed);
+        // encode expects '\0' postfix
+        members.push('\0');
         Ok(Self { members })
     }
 

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -175,7 +175,7 @@ mod test {
         test!(b"ez", b"ez", ["ez"]);
         test!(b"ez\0", b"ez", ["ez"]);
         test!(b"ez\0pz", b"ez\0pz", ["ez", "pz"]);
-        test!(b"ez\0\0pz", b"ez\0pz", ["ez", "pz"]);
-        test!(b"ez\0\0\0pz", b"ez\0pz", ["ez", "pz"]);
+        test!(b"ez\0\0pz", b"ez\0\0pz", ["ez", "pz"]);
+        test!(b"ez\0\0\0pz", b"ez\0\0\0pz", ["ez", "pz"]);
     }
 }

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -48,12 +48,9 @@ impl Tags {
 
     /// Get the encoded representation of the tags
     pub fn encode(&self) -> &[u8] {
-        if self.is_empty() {
-            self.members.as_bytes()
-        } else {
-            // Chop off '\0' postfix
-            &self.members.as_bytes()[..self.members.len() - 1]
-        }
+        // Chop off '\0' postfix when it exists
+        let postfix_offset = !self.is_empty() as usize;
+        &self.members.as_bytes()[..self.members.len() - postfix_offset]
     }
 
     /// Returns the number of strings stored within this `Tags`.

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -152,19 +152,19 @@ mod test {
     }
 
     #[test]
-    fn decode() {
+    fn decode_encode() {
         macro_rules! test {
             ($input:expr, $expected_encoded:expr, $expected_array:expr) => {
                 let tags = Tags::decode($input).unwrap();
                 assert_eq!(
                     tags.encode(),
                     $expected_encoded,
-                    "encoded tags does not match"
+                    "encoded tags do not match expected"
                 );
                 let mut tags_iter = tags.iter();
                 let array: [&str; _] = core::array::from_fn(|_| tags_iter.next().unwrap());
                 let expected_array: [&str; _] = $expected_array;
-                assert_eq!(array, expected_array, "tags do not match");
+                assert_eq!(array, expected_array, "decoded tags do not match expected");
             };
         }
 

--- a/rbx_types/src/tags.rs
+++ b/rbx_types/src/tags.rs
@@ -23,7 +23,7 @@ impl Tags {
         self.members.push('\0');
     }
 
-    /// Returns an iterator over all of the tags in the container.
+    /// Returns an iterator over non-empty tags in the container.
     pub fn iter(&self) -> TagsIter<'_> {
         TagsIter::new(&self.members)
     }
@@ -79,7 +79,7 @@ impl<'a> IntoIterator for &'a Tags {
     }
 }
 
-/// See [`Tags::iter`].
+/// An iterator over non-empty tags.
 pub struct TagsIter<'a> {
     internal: core::str::Split<'a, char>,
 }


### PR DESCRIPTION
A comment in tags.rs says:
https://github.com/rojo-rbx/rbx-dom/blob/7ef7d448ba6d30c4cb217b228d5c22c6f5ac07f3/rbx_types/src/tags.rs#L14-L15

This does exactly that.

### Design Choices
- `Tags::push` can be called many times, whereas `Tags::encode` is only called once, so I've opted to include a '\0' postfixing every tag to move branching on is_empty() from push into encode.

### Changed Behaviour
- '\0's are trimmed from the beginning and end of the buffer, but are no longer trimmed from the middle.  This is to keep the decode function as close to extend_from_slice (push_str) as possible.  If needed, this can be remedied by making decode slower (`TagsIter::new(str).collect()`)
- Empty strings pushed into tags will be skipped when iterating.  The old behaviour was to iterate over all elements of the inner Vec.   If needed, this can be remedied by adding a special case for empty tags to the iterator, since .split('\0') returns an iterator which yields one element for an empty string.

### Changed Interfaces
- `Tags::decode`'s Result::Err is changed from `FromUTF8Error` to `UTF8Error`.  All call sites in rbx-dom throw away this error value.  The old error value can be hobbled together with a duplicated UTF8 check if we don't want to change this public interface.
- `Tags::encode` return value is changed from `Vec<u8>` to `&[u8]`.  It would be a waste to make an intermediate allocation here.

### Performance
I measured no significant change to performance.

### New Tests
- Tags encode/decode behaviour is tested more extensively. Yay!