### PR TITLE
SomeRef v1 Part 1: Introduce SomeRef

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -592,7 +592,7 @@ mod test {
         let target = InstanceBuilder::new("Folder")
             .with_name("Target")
             .with_child(InstanceBuilder::new("Part").with_name("Some Child"));
-        let target_ref = target.referent;
+        let target_ref = target.referent();
 
         let mut source = WeakDom::new(InstanceBuilder::new("Folder").with_child(target));
         let mut dest = WeakDom::new(InstanceBuilder::new("DataModel"));
@@ -618,14 +618,14 @@ mod test {
         let subject = InstanceBuilder::new("Folder")
             .with_name("Root")
             .with_child(InstanceBuilder::new("SpawnLocation"));
-        let subject_ref = subject.referent;
+        let subject_ref = subject.referent();
 
         let source_parent = InstanceBuilder::new("Folder")
             .with_name("Source")
             .with_child(subject);
 
         let dest_parent = InstanceBuilder::new("Folder").with_name("Dest");
-        let dest_parent_ref = dest_parent.referent;
+        let dest_parent_ref = dest_parent.referent();
 
         let mut dom = WeakDom::new(
             InstanceBuilder::new("Folder")
@@ -647,7 +647,7 @@ mod test {
     #[test]
     fn clone_within() {
         let mut child1 = InstanceBuilder::new("Part").with_name("Child1");
-        let child1_ref = child1.referent;
+        let child1_ref = child1.referent();
 
         let mut dom = {
             let root = InstanceBuilder::new("Folder").with_name("Root");
@@ -666,7 +666,7 @@ mod test {
             "parent of cloned subtree root should be none directly after a clone"
         );
 
-        dom.transfer_within(cloned_child1_ref, dom.root_ref);
+        dom.transfer_within(cloned_child1_ref, dom.root_ref());
 
         // This snapshot should have a clone of the Child1 subtree under the
         // root Folder, with Child2's ref property pointing to the cloned
@@ -694,14 +694,14 @@ mod test {
         };
 
         let mut other_dom = WeakDom::new(InstanceBuilder::new("DataModel"));
-        let cloned_root = dom.clone_into_external(dom.root_ref, &mut other_dom);
+        let cloned_root = dom.clone_into_external(dom.root_ref(), &mut other_dom);
 
         assert!(
             other_dom.get_by_ref(cloned_root).unwrap().parent.is_none(),
             "parent of cloned subtree root should be none directly after a clone"
         );
 
-        other_dom.transfer_within(cloned_root, other_dom.root_ref);
+        other_dom.transfer_within(cloned_root, other_dom.root_ref());
 
         let mut viewer = DomViewer::new();
 
@@ -745,8 +745,8 @@ mod test {
             "parent of cloned subtree root should be none directly after a clone"
         );
 
-        other_dom.transfer_within(cloned[0], other_dom.root_ref);
-        other_dom.transfer_within(cloned[1], other_dom.root_ref);
+        other_dom.transfer_within(cloned[0], other_dom.root_ref());
+        other_dom.transfer_within(cloned[1], other_dom.root_ref());
 
         let mut viewer = DomViewer::new();
 
@@ -908,7 +908,7 @@ mod test {
     fn from_raw() {
         let mut dom = WeakDom::new(InstanceBuilder::new("ROOT"));
 
-        let parent = dom.insert(dom.root_ref, InstanceBuilder::new("Folder"));
+        let parent = dom.insert(dom.root_ref(), InstanceBuilder::new("Folder"));
         let child_1 = dom.insert(
             parent,
             InstanceBuilder::new("ObjectValue").with_property("Value", parent),

--- a/rbx_types/src/content.rs
+++ b/rbx_types/src/content.rs
@@ -1,4 +1,4 @@
-use crate::Ref;
+use crate::referent::{Ref, SomeRef};
 
 /// A reference to a Roblox asset.
 ///
@@ -36,6 +36,12 @@ impl Content {
     #[inline]
     pub fn from_referent(referent: Ref) -> Self {
         Self(ContentType::Object(referent))
+    }
+
+    /// Constructs a `Content` from the provided referent.
+    #[inline]
+    pub const fn from_some_ref(referent: SomeRef) -> Self {
+        Self(ContentType::Object(referent.to_optional_ref()))
     }
 
     /// Returns the underlying value of the `Content`.
@@ -86,6 +92,25 @@ impl From<&'_ str> for Content {
         Self(ContentType::Uri(url.to_owned()))
     }
 }
+
+impl From<Ref> for Content {
+    fn from(referent: Ref) -> Self {
+        Self::from_referent(referent)
+    }
+}
+
+impl From<SomeRef> for Content {
+    fn from(referent: SomeRef) -> Self {
+        Self::from_some_ref(referent)
+    }
+}
+
+impl From<Option<SomeRef>> for Content {
+    fn from(value: Option<SomeRef>) -> Self {
+        Self::from_referent(value.into())
+    }
+}
+
 /// A reference to a Roblox asset.
 ///
 /// When exposed to Luau, this is just a string. For the modern userdata type,

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -5,24 +5,58 @@ use std::fmt;
 use std::num::NonZeroU128;
 use std::str::FromStr;
 
-/// An universally unique, optional reference to a Roblox instance.
+/// A universally unique reference to a Roblox instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Ref(Option<NonZeroU128>);
+pub struct SomeRef(NonZeroU128);
 
-impl Ref {
-    /// Generate a new random `Ref`.
+impl SomeRef {
+    /// Generate a new random `SomeRef`.
+    #[inline]
+    pub fn new_random() -> Self {
+        Self(rand::random())
+    }
+
+    /// Construct a `SomeRef`.
+    #[inline]
+    pub const fn new(value: u128) -> Option<Self> {
+        match NonZeroU128::new(value) {
+            Some(value) => Some(SomeRef(value)),
+            None => None,
+        }
+    }
+
+    #[inline]
+    pub const fn to_optional_ref(&self) -> OptionalRef {
+        OptionalRef(Some(*self))
+    }
+
+    const fn value(&self) -> u128 {
+        self.0.get()
+    }
+}
+
+/// A universally unique, optional reference to a Roblox instance.
+/// This is a type alias, the type has been renamed to `OptionalRef`.
+pub type Ref = OptionalRef;
+
+/// A universally unique, optional reference to a Roblox instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OptionalRef(Option<SomeRef>);
+
+impl OptionalRef {
+    /// Generate a new random non-nil `Ref`.
     #[inline]
     pub fn new() -> Self {
-        Ref(Some(rand::random()))
+        OptionalRef(Some(SomeRef::new_random()))
     }
 
-    /// Generate a `Ref` that points to nothing.
+    /// Construct a `Ref` that points to nothing.
     #[inline]
     pub const fn none() -> Self {
-        Ref(None)
+        OptionalRef(None)
     }
 
-    /// Generate a `Ref` that points to something.
+    /// Construct a `Ref` that points to something.
     ///
     /// ## Panics
     /// Panics if `value` is 0. Use the Ref::none()
@@ -30,7 +64,7 @@ impl Ref {
     /// points to nothing.
     #[inline]
     pub const fn some(value: u128) -> Self {
-        Ref(Some(NonZeroU128::new(value).expect("Ref value is 0")))
+        OptionalRef(Some(SomeRef::new(value).expect("Ref value is 0")))
     }
 
     /// Tells whether this `Ref` points to something.
@@ -45,28 +79,67 @@ impl Ref {
         self.0.is_none()
     }
 
-    fn value(&self) -> u128 {
+    #[inline]
+    pub const fn to_some_ref(&self) -> Option<SomeRef> {
+        self.0
+    }
+
+    const fn new_value(value: u128) -> Self {
+        OptionalRef(SomeRef::new(value))
+    }
+
+    const fn value(&self) -> u128 {
         match self.0 {
-            Some(value) => value.get(),
+            Some(value) => value.value(),
             None => 0,
         }
     }
 }
 
-impl fmt::Display for Ref {
+impl fmt::Display for OptionalRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{:032x}", self.value())
+    }
+}
+impl fmt::Display for SomeRef {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "{:032x}", self.value())
     }
 }
 
-impl FromStr for Ref {
+impl FromStr for OptionalRef {
     type Err = std::num::ParseIntError;
 
     #[inline]
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let value = u128::from_str_radix(input, 16)?;
 
-        Ok(Ref(NonZeroU128::new(value)))
+        Ok(OptionalRef::new_value(value))
+    }
+}
+impl FromStr for SomeRef {
+    type Err = std::num::ParseIntError;
+
+    #[inline]
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let value = u128::from_str_radix(input, 16)?;
+
+        Self::new(value).ok_or_else(|| {
+            // from_str_radix does not support NonZeroU128 so
+            // generate a ParseIntError with IntErrorKind::Zero
+            "0".parse::<NonZeroU128>().err().unwrap()
+        })
+    }
+}
+
+impl From<Option<SomeRef>> for OptionalRef {
+    fn from(value: Option<SomeRef>) -> Self {
+        OptionalRef(value)
+    }
+}
+impl From<SomeRef> for OptionalRef {
+    fn from(value: SomeRef) -> Self {
+        value.to_optional_ref()
     }
 }
 
@@ -81,7 +154,7 @@ mod serde_impl {
         Deserialize, Deserializer, Serialize, Serializer,
     };
 
-    impl Serialize for Ref {
+    impl Serialize for SomeRef {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -94,34 +167,79 @@ mod serde_impl {
         }
     }
 
-    struct RefVisitor;
+    struct SomeRefVisitor;
 
-    impl Visitor<'_> for RefVisitor {
-        type Value = Ref;
+    impl Visitor<'_> for SomeRefVisitor {
+        type Value = SomeRef;
+
+        fn expecting(&self, out: &mut fmt::Formatter) -> fmt::Result {
+            write!(out, "a non-nil Roblox referent")
+        }
+
+        fn visit_u128<E: Error>(self, value: u128) -> Result<Self::Value, E> {
+            SomeRef::new(value).ok_or_else(|| E::custom("SomeRef value is 0"))
+        }
+
+        fn visit_str<E: Error>(self, ref_str: &str) -> Result<Self::Value, E> {
+            let ref_value = u128::from_str_radix(ref_str, 16).map_err(E::custom)?;
+            SomeRef::new(ref_value).ok_or_else(|| E::custom("SomeRef value is 0"))
+        }
+    }
+
+    impl<'de> Deserialize<'de> for SomeRef {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            if deserializer.is_human_readable() {
+                deserializer.deserialize_str(SomeRefVisitor)
+            } else {
+                deserializer.deserialize_u128(SomeRefVisitor)
+            }
+        }
+    }
+
+    impl Serialize for OptionalRef {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if serializer.is_human_readable() {
+                serializer.serialize_str(&format!("{:032x}", self.value()))
+            } else {
+                serializer.serialize_u128(self.value())
+            }
+        }
+    }
+
+    struct OptionalRefVisitor;
+
+    impl Visitor<'_> for OptionalRefVisitor {
+        type Value = OptionalRef;
 
         fn expecting(&self, out: &mut fmt::Formatter) -> fmt::Result {
             write!(out, "a Roblox referent")
         }
 
         fn visit_u128<E: Error>(self, value: u128) -> Result<Self::Value, E> {
-            Ok(Ref(NonZeroU128::new(value)))
+            Ok(OptionalRef::new_value(value))
         }
 
         fn visit_str<E: Error>(self, ref_str: &str) -> Result<Self::Value, E> {
             let ref_value = u128::from_str_radix(ref_str, 16).map_err(E::custom)?;
-            Ok(Ref(NonZeroU128::new(ref_value)))
+            Ok(OptionalRef::new_value(ref_value))
         }
     }
 
-    impl<'de> Deserialize<'de> for Ref {
+    impl<'de> Deserialize<'de> for OptionalRef {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                deserializer.deserialize_str(RefVisitor)
+                deserializer.deserialize_str(OptionalRefVisitor)
             } else {
-                deserializer.deserialize_u128(RefVisitor)
+                deserializer.deserialize_u128(OptionalRefVisitor)
             }
         }
     }
@@ -133,36 +251,42 @@ mod test {
 
     #[test]
     fn display() {
-        assert_eq!(Ref::none().to_string(), "00000000000000000000000000000000");
+        assert_eq!(
+            OptionalRef::none().to_string(),
+            "00000000000000000000000000000000"
+        );
 
-        let thirty = Ref(NonZeroU128::new(30));
+        let thirty = OptionalRef::new_value(30);
         assert_eq!(thirty.to_string(), "0000000000000000000000000000001e");
 
-        let max = Ref(NonZeroU128::new(u128::MAX));
+        let max = OptionalRef::new_value(u128::MAX);
         assert_eq!(max.to_string(), "ffffffffffffffffffffffffffffffff");
     }
 
     #[test]
     fn from_str() {
         assert_eq!(
-            Ref::from_str("00000000000000000000000000000000").unwrap(),
-            Ref::none()
+            OptionalRef::from_str("00000000000000000000000000000000").unwrap(),
+            OptionalRef::none()
         );
 
         assert_eq!(
-            Ref::from_str("00000000300000e00f00000000000001").unwrap(),
-            Ref(NonZeroU128::new(14855284604576099720297971713))
+            OptionalRef::from_str("00000000300000e00f00000000000001").unwrap(),
+            OptionalRef::new_value(14855284604576099720297971713)
         );
 
         assert_eq!(
-            Ref::from_str("ffffffffffffffffffffffffffffffff").unwrap(),
-            Ref(NonZeroU128::new(u128::MAX))
+            OptionalRef::from_str("ffffffffffffffffffffffffffffffff").unwrap(),
+            OptionalRef::new_value(u128::MAX)
         );
     }
 
     #[test]
     fn size() {
-        assert_eq!(std::mem::size_of::<Ref>(), std::mem::size_of::<u128>());
+        assert_eq!(
+            std::mem::size_of::<OptionalRef>(),
+            std::mem::size_of::<u128>()
+        );
     }
 }
 
@@ -172,19 +296,19 @@ mod serde_test {
 
     #[test]
     fn human_none() {
-        let value = Ref::none();
+        let value = OptionalRef::none();
 
         let ser = serde_json::to_string(&value).unwrap();
         assert_eq!(ser, "\"00000000000000000000000000000000\"");
 
-        let de: Ref = serde_json::from_str(&ser).unwrap();
+        let de: OptionalRef = serde_json::from_str(&ser).unwrap();
 
         assert_eq!(value, de);
     }
 
     #[test]
     fn human() {
-        let value = Ref::new();
+        let value = OptionalRef::new();
 
         let ser = serde_json::to_string(&value).unwrap();
         let de = serde_json::from_str(&ser).unwrap();
@@ -194,7 +318,7 @@ mod serde_test {
 
     #[test]
     fn non_human() {
-        let value = Ref::new();
+        let value = OptionalRef::new();
 
         let ser = bincode::serialize(&value).unwrap();
         let de = bincode::deserialize(&ser).unwrap();

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -122,10 +122,11 @@ impl FromStr for SomeRef {
 
     #[inline]
     fn from_str(input: &str) -> Result<Self, Self::Err> {
+        // TODO: use NonZero::from_str_radix when it is stabilized in Rust 1.95
+        // https://github.com/rust-lang/rust/pull/151945
         let value = u128::from_str_radix(input, 16)?;
 
         Self::new(value).ok_or_else(|| {
-            // from_str_radix does not support NonZeroU128 so
             // generate a ParseIntError with IntErrorKind::Zero
             "0".parse::<NonZeroU128>().err().unwrap()
         })

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -123,7 +123,7 @@ impl FromStr for SomeRef {
     #[inline]
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         // TODO: use NonZero::from_str_radix when it is stabilized in Rust 1.95
-        // https://github.com/rust-lang/rust/pull/151945
+        // https://github.com/rust-lang/rust/issues/152193
         let value = u128::from_str_radix(input, 16)?;
 
         Self::new(value).ok_or_else(|| {

--- a/rbx_types/src/variant.rs
+++ b/rbx_types/src/variant.rs
@@ -2,8 +2,8 @@ use crate::{
     Attributes, Axes, BinaryString, BrickColor, CFrame, Color3, Color3uint8, ColorSequence,
     Content, ContentId, Enum, EnumItem, Faces, Font, MaterialColors, NetAssetRef, NumberRange,
     NumberSequence, PhysicalProperties, Ray, Rect, Ref, Region3, Region3int16,
-    SecurityCapabilities, SharedString, Tags, UDim, UDim2, UniqueId, Vector2, Vector2int16,
-    Vector3, Vector3int16,
+    SecurityCapabilities, SharedString, SomeRef, Tags, UDim, UDim2, UniqueId, Vector2,
+    Vector2int16, Vector3, Vector3int16,
 };
 
 /// Reduces boilerplate from listing different values of Variant by wrapping
@@ -138,6 +138,18 @@ make_variant! {
 impl From<&'_ str> for Variant {
     fn from(value: &str) -> Self {
         Self::String(value.to_owned())
+    }
+}
+
+impl From<SomeRef> for Variant {
+    fn from(value: SomeRef) -> Self {
+        Self::Ref(value.to_optional_ref())
+    }
+}
+
+impl From<Option<SomeRef>> for Variant {
+    fn from(value: Option<SomeRef>) -> Self {
+        Self::Ref(value.into())
     }
 }
 


### PR DESCRIPTION
Adds a new type `SomeRef(NonZeroU128)` as described in #581.  The new type signature of Ref reads as follows: `OptionalRef(Option<SomeRef>)`. The names are open to debate.  Many Ref values passed as function arguments should never be allowed to be null, but this is not reflected by the data model.  This series implements the new type in 3 stages:
1. Introduce just the new type and its bells and whistles, no code is broken.
2. Implement the new type internally within the library with minimal public interface changes.
3. Implement the new type where applicable in public interfaces.

Some tests are modified to use the public interface of the things being tested, because in part 2 the public interface is not supposed to change, but the internals do change.

Notes:
- Content is given a new function `from_some_ref`, but does not use the new type internally.  That change is in part 2.
- Ref is renamed to OptionalRef to more accurately describe it, and a type alias for `Ref` is created.