### PR TITLE
Instance Slices (+29%)

### DIFF
--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1443,7 +1443,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
             if parent_ref == -1 {
                 self.root_instance_refs.push(id);
             } else {
-                let instance_key = self.instance_key_by_ref.get_mut(&parent_ref).unwrap();
+                let instance_key = self.instance_key_by_ref.get(&parent_ref).unwrap();
                 let instance = self.instances.get_mut(instance_key.key).unwrap();
                 instance.children.push(id);
             }

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -87,7 +87,8 @@ struct InstanceKey {
 /// instance. Incrementally built up by the deserializer as we decode different
 /// chunks.
 struct Instance {
-    /// The ref_id for this instance
+    /// The ref_id for this instance.  This is only used in one place,
+    /// so may be a good place to look for inspiration for a refactor.
     referent: i32,
 
     /// A work-in-progress builder that will be used to construct this instance.

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -68,7 +68,7 @@ struct TypeInfo<'db> {
     /// The common name for this type like `Folder` or `UserInputService`.
     type_name: Ustr,
 
-    /// A slice of instances_by_ref which contains every instance of this class.
+    /// A slice of `instances` which contains every instance of this class.
     instances_slice: core::ops::Range<usize>,
 
     /// A reference to the type's class descriptor from rbx_reflection, if this

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -69,7 +69,7 @@ struct TypeInfo<'db> {
     type_name: Ustr,
 
     /// A slice of `instances` which contains every instance of this class.
-    instances_slice: core::ops::Range<usize>,
+    instances: core::ops::Range<usize>,
 
     /// A reference to the type's class descriptor from rbx_reflection, if this
     /// is a known class.
@@ -328,7 +328,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
             type_id,
             TypeInfo {
                 type_name: type_name.into(),
-                instances_slice: start..end,
+                instances: start..end,
                 class_descriptor,
             },
         );
@@ -382,8 +382,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
             type_id
         );
 
-        let instances =
-            &mut self.instances[type_info.instances_slice.start..type_info.instances_slice.end];
+        let instances = &mut self.instances[type_info.instances.start..type_info.instances.end];
 
         // The `Name` prop is special and is routed to a different spot for
         // rbx_dom_weak, so we handle it specially here.

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -929,12 +929,11 @@ rbx-dom may require changes to fully support this property. Please open an issue
                     let values = chunk.read_referent_array(instances.len())?;
 
                     for (value, instance) in values.zip(instances) {
-                        let rbx_value =
-                            if let Some(instance_key) = self.instance_key_by_ref.get(&value) {
-                                instance_key.referent
-                            } else {
-                                Ref::none()
-                            };
+                        let rbx_value = if let Some(key) = self.instance_key_by_ref.get(&value) {
+                            key.referent
+                        } else {
+                            Ref::none()
+                        };
                         add_property(instance, &property, rbx_value.into());
                     }
                 }
@@ -1410,10 +1409,8 @@ rbx-dom may require changes to fully support this property. Please open an issue
                             1 => Content::from_uri(uris.pop_back().unwrap()),
                             2 => {
                                 let read_value = objects.pop_back().unwrap();
-                                if let Some(instance_key) =
-                                    self.instance_key_by_ref.get(&read_value)
-                                {
-                                    Content::from_referent(instance_key.referent)
+                                if let Some(key) = self.instance_key_by_ref.get(&read_value) {
+                                    Content::from_referent(key.referent)
                                 } else {
                                     Content::none()
                                 }

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -301,29 +301,6 @@ impl<'db, R: Read> DeserializerState<'db, R> {
         // TODO: Check object_format and check for service markers if it's 1?
 
         let start = self.instances.len();
-        // Y no work?
-        // (&mut self.instance_key_by_ref, &mut self.instances).extend(
-        //     chunk
-        //         .read_referent_array(number_instances as usize)?
-        //         .enumerate()
-        //         .map(|(key, referent)| {
-        //             let builder =
-        //                 InstanceBuilder::with_property_capacity(type_name.as_str(), prop_capacity);
-        //             (
-        //                 (
-        //                     referent,
-        //                     InstanceKey {
-        //                         key: start + key,
-        //                         referent: builder.referent(),
-        //                     },
-        //                 ),
-        //                 Instance {
-        //                     builder,
-        //                     children: Vec::new(),
-        //                 },
-        //             )
-        //         }),
-        // );
         for (key, referent) in chunk
             .read_referent_array(number_instances as usize)?
             .enumerate()

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1491,8 +1491,9 @@ rbx-dom may require changes to fully support this property. Please open an issue
         }
 
         while let Some((referent, parent_ref)) = instances_to_construct.pop_front() {
-            let instance_key = self.instance_key_by_ref.remove(&referent).unwrap().key;
             // Replace each instance with an impostor!
+            // We guarantee this is done once by removing the key from `instance_key_by_ref`.
+            let instance_key = self.instance_key_by_ref.remove(&referent).unwrap().key;
             let instance = core::mem::replace(&mut self.instances[instance_key], Instance::empty());
             let id = self.tree.insert(parent_ref, instance.builder);
 

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -75,11 +75,6 @@ struct TypeInfo<'db> {
     /// is a known class.
     class_descriptor: Option<&'db ClassDescriptor<'db>>,
 }
-impl TypeInfo<'_> {
-    const fn instances_slice(&self) -> core::ops::Range<usize> {
-        self.instances_slice.start..self.instances_slice.end
-    }
-}
 
 /// A key into an array of instances which also contains the instance ref
 /// to sidestep mutable + immutable aliasing.
@@ -410,7 +405,8 @@ impl<'db, R: Read> DeserializerState<'db, R> {
             type_id
         );
 
-        let instances = &mut self.instances[type_info.instances_slice()];
+        let instances =
+            &mut self.instances[type_info.instances_slice.start..type_info.instances_slice.end];
 
         // The `Name` prop is special and is routed to a different spot for
         // rbx_dom_weak, so we handle it specially here.

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1443,9 +1443,8 @@ rbx-dom may require changes to fully support this property. Please open an issue
             if parent_ref == -1 {
                 self.root_instance_refs.push(id);
             } else {
-                let instance_key = self.instance_key_by_ref.get(&parent_ref).unwrap();
-                let instance = self.instances.get_mut(instance_key.key).unwrap();
-                instance.children.push(id);
+                let instance_key = self.instance_key_by_ref[&parent_ref].key;
+                self.instances[instance_key].children.push(id);
             }
         }
 

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1503,8 +1503,8 @@ rbx-dom may require changes to fully support this property. Please open an issue
             // We need to keep `instance_key_by_ref` up to date with the swaps as they happen.
             let instance_key = self.instance_key_by_ref.get(&referent).unwrap().key;
             if let Some(last) = self.instances.last() {
-                let last_instance = self.instance_key_by_ref.get_mut(&last.referent).unwrap();
-                last_instance.key = instance_key;
+                let last_instance_key = self.instance_key_by_ref.get_mut(&last.referent).unwrap();
+                last_instance_key.key = instance_key;
             }
             let instance = self.instances.swap_remove(instance_key);
             let id = self.tree.insert(parent_ref, instance.builder);

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -291,6 +291,8 @@ impl<'db, R: Read> DeserializerState<'db, R> {
             "INST chunk (type ID {type_id}, type name {type_name}, format {object_format}, {number_instances} instances)",
         );
 
+        let referents = chunk.read_referent_array(number_instances as usize)?;
+
         let (class_descriptor, prop_capacity) =
             if let Some(class) = self.deserializer.database.classes.get(type_name.as_str()) {
                 (Some(class), class.default_properties.len())
@@ -301,10 +303,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
         // TODO: Check object_format and check for service markers if it's 1?
 
         let start = self.instances.len();
-        for (key, referent) in chunk
-            .read_referent_array(number_instances as usize)?
-            .enumerate()
-        {
+        for (key, referent) in referents.enumerate() {
             let builder =
                 InstanceBuilder::with_property_capacity(type_name.as_str(), prop_capacity);
             // TODO: assert / error when the ref already exists.

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -455,17 +455,18 @@ This may cause unexpected or broken behavior in your final results if you rely o
                     }
                 }
                 VariantType::Tags => {
+                    let type_name = type_info.type_name;
                     for instance in instances {
                         let buffer = chunk.read_binary_string()?;
 
-                        let Ok(value) = Tags::decode(buffer.as_ref()) else {
-                            return Err(InnerError::InvalidPropData {
-                                type_name: type_info.type_name.to_string(),
+                        let value = Tags::decode(buffer.as_ref()).map_err(|_| {
+                            InnerError::InvalidPropData {
+                                type_name: type_name.to_string(),
                                 prop_name: prop_name.clone(),
                                 valid_value: "a list of valid null-delimited UTF-8 strings",
                                 actual_value: "invalid UTF-8".to_string(),
-                            });
-                        };
+                            }
+                        })?;
 
                         add_property(instance, &property, value.into());
                     }
@@ -702,16 +703,16 @@ rbx-dom may require changes to fully support this property. Please open an issue
             },
             Type::Faces => match canonical_type {
                 VariantType::Faces => {
+                    let type_name = type_info.type_name;
                     for instance in instances {
                         let value = chunk.read_u8()?;
-                        let Some(faces) = Faces::from_bits(value) else {
-                            return Err(InnerError::InvalidPropData {
-                                type_name: type_info.type_name.to_string(),
+                        let faces =
+                            Faces::from_bits(value).ok_or_else(|| InnerError::InvalidPropData {
+                                type_name: type_name.to_string(),
                                 prop_name: prop_name.clone(),
                                 valid_value: "less than 63",
                                 actual_value: value.to_string(),
-                            });
-                        };
+                            })?;
 
                         add_property(instance, &property, faces.into());
                     }
@@ -727,17 +728,17 @@ rbx-dom may require changes to fully support this property. Please open an issue
             },
             Type::Axes => match canonical_type {
                 VariantType::Axes => {
+                    let type_name = type_info.type_name;
                     for instance in instances {
                         let value = chunk.read_u8()?;
 
-                        let Some(axes) = Axes::from_bits(value) else {
-                            return Err(InnerError::InvalidPropData {
-                                type_name: type_info.type_name.to_string(),
+                        let axes =
+                            Axes::from_bits(value).ok_or_else(|| InnerError::InvalidPropData {
+                                type_name: type_name.to_string(),
                                 prop_name: prop_name.clone(),
                                 valid_value: "less than 7",
                                 actual_value: value.to_string(),
-                            });
-                        };
+                            })?;
 
                         add_property(instance, &property, axes.into());
                     }
@@ -755,16 +756,18 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 VariantType::BrickColor => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 
+                    let type_name = type_info.type_name;
                     for (value, instance) in values.zip(instances) {
-                        let Some(color) = value.try_into().ok().and_then(BrickColor::from_number)
-                        else {
-                            return Err(InnerError::InvalidPropData {
-                                type_name: type_info.type_name.to_string(),
+                        let color = value
+                            .try_into()
+                            .ok()
+                            .and_then(BrickColor::from_number)
+                            .ok_or_else(|| InnerError::InvalidPropData {
+                                type_name: type_name.to_string(),
                                 prop_name: prop_name.clone(),
                                 valid_value: "a valid BrickColor",
                                 actual_value: value.to_string(),
-                            });
-                        };
+                            })?;
 
                         add_property(instance, &property, color.into());
                     }
@@ -1194,15 +1197,17 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 VariantType::SharedString => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 
+                    let type_name = type_info.type_name;
                     for (value, instance) in values.zip(instances) {
-                        let Some(shared_string) = self.shared_strings.get(value as usize) else {
-                            return Err(InnerError::InvalidPropData {
-                                type_name: type_info.type_name.to_string(),
-                                prop_name: prop_name.clone(),
-                                valid_value: "a valid SharedString",
-                                actual_value: format!("{value:?}"),
-                            });
-                        };
+                        let shared_string =
+                            self.shared_strings.get(value as usize).ok_or_else(|| {
+                                InnerError::InvalidPropData {
+                                    type_name: type_name.to_string(),
+                                    prop_name: prop_name.clone(),
+                                    valid_value: "a valid SharedString",
+                                    actual_value: format!("{value:?}"),
+                                }
+                            })?;
 
                         add_property(instance, &property, shared_string.clone().into());
                     }
@@ -1210,16 +1215,19 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 VariantType::NetAssetRef => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 
+                    let type_name = type_info.type_name;
                     for (value, instance) in values.zip(instances) {
-                        let Some(shared_string) = self.shared_strings.get(value as usize) else {
-                            return Err(InnerError::InvalidPropData {
-                                type_name: type_info.type_name.to_string(),
-                                prop_name: prop_name.clone(),
-                                valid_value: "a valid NetAssetRef",
-                                actual_value: format!("{value:?}"),
-                            });
-                        };
-                        let net_asset = NetAssetRef::from(shared_string.clone());
+                        let net_asset = NetAssetRef::from(
+                            self.shared_strings
+                                .get(value as usize)
+                                .ok_or_else(|| InnerError::InvalidPropData {
+                                    type_name: type_name.to_string(),
+                                    prop_name: prop_name.clone(),
+                                    valid_value: "a valid NetAssetRef",
+                                    actual_value: format!("{value:?}"),
+                                })?
+                                .clone(),
+                        );
 
                         add_property(instance, &property, net_asset.into());
                     }

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -336,7 +336,11 @@ impl<'db, R: Read> DeserializerState<'db, R> {
         let type_id = chunk.read_le_u32()?;
         let prop_name = chunk.read_string()?;
 
-        let type_info = self
+        let &TypeInfo {
+            type_name,
+            ref instances,
+            class_descriptor,
+        } = self
             .type_infos
             .get(&type_id)
             .ok_or(InnerError::InvalidTypeId { type_id })?;
@@ -361,7 +365,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
                         "Unknown value type ID {byte:#04x} ({byte}) in Roblox \
                          binary model file. Found in property {class}.{prop}.",
                         byte = binary_type_byte,
-                        class = type_info.type_name,
+                        class = type_name,
                         prop = prop_name,
                     );
                 }
@@ -372,12 +376,12 @@ impl<'db, R: Read> DeserializerState<'db, R> {
 
         log::trace!(
             "PROP chunk ({}.{}, instance type {}",
-            type_info.type_name,
+            type_name,
             prop_name,
             type_id
         );
 
-        let instances = &mut self.instances[type_info.instances.start..type_info.instances.end];
+        let instances = &mut self.instances[instances.start..instances.end];
 
         // The `Name` prop is special and is routed to a different spot for
         // rbx_dom_weak, so we handle it specially here.
@@ -394,7 +398,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
                         log::warn!(
                             "Performing lossy string conversion on property {}.{} because it did not contain UTF-8.
 This may cause unexpected or broken behavior in your final results if you rely on this property being non UTF-8.",
-                            type_info.type_name,
+                            type_name,
                             prop_name
                         );
 
@@ -410,7 +414,7 @@ This may cause unexpected or broken behavior in your final results if you rely o
         let property = if let Some(property) = find_canonical_property(
             self.deserializer.database,
             binary_type,
-            type_info.class_descriptor,
+            class_descriptor,
             &prop_name,
         ) {
             property
@@ -431,7 +435,7 @@ This may cause unexpected or broken behavior in your final results if you rely o
                                 log::warn!(
                             "Performing lossy string conversion on property {}.{} because it did not contain UTF-8.
 This may cause unexpected or broken behavior in your final results if you rely on this property being non UTF-8.",
-                                    type_info.type_name,
+                                    type_name,
                                     property.name
                                 );
 
@@ -455,7 +459,6 @@ This may cause unexpected or broken behavior in your final results if you rely o
                     }
                 }
                 VariantType::Tags => {
-                    let type_name = type_info.type_name;
                     for instance in instances {
                         let buffer = chunk.read_binary_string()?;
 
@@ -484,7 +487,7 @@ This may cause unexpected or broken behavior in your final results if you rely o
                                     "Failed to parse Attributes on {} because {:?}; falling back to BinaryString.
 
 rbx-dom may require changes to fully support this property. Please open an issue at https://github.com/rojo-rbx/rbx-dom/issues and show this warning.",
-                                    type_info.type_name,
+                                    type_name,
                                     err
                                 );
 
@@ -507,7 +510,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                                     "Failed to parse MaterialColors on {} because {:?}; falling back to BinaryString.
 
 rbx-dom may require changes to fully support this property. Please open an issue at https://github.com/rojo-rbx/rbx-dom/issues and show this warning.",
-                                    type_info.type_name,
+                                    type_name,
                                     err
                                 );
 
@@ -522,7 +525,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names:
                             "String, ContentId, Content, Tags, Attributes, or BinaryString",
@@ -539,7 +542,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Bool",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -567,7 +570,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Int32",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -584,7 +587,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Float32",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -611,7 +614,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Float64",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -633,7 +636,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "UDim",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -664,7 +667,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "UDim2",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -694,7 +697,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Ray",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -703,7 +706,6 @@ rbx-dom may require changes to fully support this property. Please open an issue
             },
             Type::Faces => match canonical_type {
                 VariantType::Faces => {
-                    let type_name = type_info.type_name;
                     for instance in instances {
                         let value = chunk.read_u8()?;
                         let faces =
@@ -719,7 +721,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Faces",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -728,7 +730,6 @@ rbx-dom may require changes to fully support this property. Please open an issue
             },
             Type::Axes => match canonical_type {
                 VariantType::Axes => {
-                    let type_name = type_info.type_name;
                     for instance in instances {
                         let value = chunk.read_u8()?;
 
@@ -745,7 +746,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Axes",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -756,7 +757,6 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 VariantType::BrickColor => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 
-                    let type_name = type_info.type_name;
                     for (value, instance) in values.zip(instances) {
                         let color = value
                             .try_into()
@@ -774,7 +774,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "BrickColor",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -795,7 +795,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Color3",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -815,7 +815,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Vector2",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -836,7 +836,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Vector3",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -871,7 +871,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                             rotations.push(basic_rotation);
                         } else {
                             return Err(InnerError::BadRotationId {
-                                type_name: type_info.type_name.to_string(),
+                                type_name: type_name.to_string(),
                                 prop_name,
                                 id,
                             });
@@ -895,7 +895,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "CFrame",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -912,7 +912,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Enum",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -934,7 +934,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Ref",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -958,7 +958,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Vector3int16",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -994,7 +994,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Font",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1020,7 +1020,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "NumberSequence",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1052,7 +1052,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "ColorSequence",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1071,7 +1071,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "NumberRange",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1098,7 +1098,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Rect",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1139,7 +1139,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "PhysicalProperties",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1169,7 +1169,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Color3",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1186,7 +1186,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Int64",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1197,7 +1197,6 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 VariantType::SharedString => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 
-                    let type_name = type_info.type_name;
                     for (value, instance) in values.zip(instances) {
                         let shared_string =
                             self.shared_strings.get(value as usize).ok_or_else(|| {
@@ -1215,7 +1214,6 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 VariantType::NetAssetRef => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 
-                    let type_name = type_info.type_name;
                     for (value, instance) in values.zip(instances) {
                         let net_asset = NetAssetRef::from(
                             self.shared_strings
@@ -1234,7 +1232,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "SharedString",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1281,7 +1279,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                             rotations.push(basic_rotation);
                         } else {
                             return Err(InnerError::BadRotationId {
-                                type_name: type_info.type_name.to_string(),
+                                type_name: type_name.to_string(),
                                 prop_name,
                                 id,
                             });
@@ -1323,7 +1321,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "OptionalCFrame",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1351,7 +1349,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "UniqueId",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1370,7 +1368,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "SecurityCapabilities",
                         actual_type_name: format!("{invalid_type:?}"),
@@ -1417,7 +1415,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                 }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
-                        type_name: type_info.type_name.to_string(),
+                        type_name: type_name.to_string(),
                         prop_name,
                         valid_type_names: "Content",
                         actual_type_name: format!("{invalid_type:?}"),

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1485,7 +1485,8 @@ rbx-dom may require changes to fully support this property. Please open an issue
         let empty_ustr = Ustr::default();
 
         while let Some((referent, parent_ref)) = instances_to_construct.pop_front() {
-            // Replace each instance with an impostor!
+            // We need to drain the instances Vec in a random order without
+            // disturbing the indices. Replace each instance with an impostor!
             // We guarantee this is done once by removing the key from `instance_key_by_ref`.
             let instance_key = self.instance_key_by_ref.remove(&referent).unwrap().key;
             let impostor = Instance {


### PR DESCRIPTION
Push instances into a regular ol' Vec, and keep track of the inserted range in TypeInfo.  This means that all instances of a specific class are in a contiguous slice, and are also in the correct iteration order expected by the decode_prop_chunk loops.  No more `instances_by_ref.get_mut(referent).unwrap()`. A HashMap tracks which i32 ref id corresponds to which instance using indices.

### Performance
I observe a 29% improvement in throughput in the Miner's Haven deserialize benchmark.

### Ramblings

There's probably some more optimizations hiding in `DeserializerState::finish`.  ~~The algorithm is currently using Vec::swap_remove to remove the elements from the instances list.~~ (swap_remove removed in 695e88ef0212d6947aeeac4cef499457523d14d1) The `instances_to_construct` machinery can probably be combined with the instances_by_ref and PRNT chunk decode in some clever way to do even less work.

~~I wrote an unsafe version that avoids swap_remove here: 3df205bee0cefcdee65cd398ccbc036b0436b827 but there doesn't seem to be a significant impact.~~ I wrote a safe version using a similar technique. Theoretically it should be faster than the swap_remove method, but I haven't put it to the test and it's not the source of the major performance improvement. 

### Lore
The instances could be owned by type_info directly, I was able to run type_ids in parallel with rayon ([branch](https://github.com/krakow10/rbx-dom/tree/rayon)) using this method.  I got a 1% speedup!!! Wow!!!  Probably because it spent the entire time waiting for 36000 Parts to decode while every other class only has <2000 instances.  The InstanceKey technique would still work, but removing each instance in finish() would be triple indirection (key, type_id, index) instead of double indirection (key, index).

I was using the indexmap crate for the Vec + HashMap abomination several times, but it's better to implement separately because of the separable mutable + immutable aliasing over the Vec + HashMap  parts.

This has three previous incarnations:
- v1 https://github.com/krakow10/rbx-dom/compare/categorize-chunks...categorize-chunks2: Store instances in TypeInfo.  The problem with this is it's based on the nasty categorize-chunks branch.  At least I found the performance I was looking for.
- v2 https://github.com/krakow10/rbx-dom/compare/master...type_info-instances: better, but the design is recollecting instances twice - once into instances_by_ref and then again into the dom.
- v3 https://github.com/krakow10/rbx-dom/compare/typestate-de...instance-slices: A breakthrough design using a Vec to back the instances to avoid recollecting twice.  I thought the typestate pattern would make it easier to implement, but it turns out it was my past failings (v1 and v2) that were calling out for typestate.