### PR TITLE
Replace "Fast Path" with Explicit Function Call

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -266,7 +266,8 @@ impl WeakDom {
         }
 
         let mut to_remove = VecDeque::new();
-        to_remove.push_back(referent);
+        let instance = self.inner_remove(referent);
+        to_remove.extend(instance.children);
 
         while let Some(referent) = to_remove.pop_front() {
             let instance = self.inner_remove(referent);


### PR DESCRIPTION
In #463, a "fast path" is introduced by making an optional queue argument to avoid a heap allocation.  The heap allocation can instead be avoided by using `VecDeque::new()` and directly calling `insert`, which also means the `if let Some(queue) = queue` in `insert` can be removed. This change effectively unrolls the first loop iteration. 