### PR TITLE
Fix Rust 1.95 Clippy Lints

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -54,6 +54,8 @@ impl WeakDom {
         );
         let mut unique_ids = AHashSet::with_capacity(instances.len());
         for inst in instances.values() {
+            // This `if` cannot be collapsed into the match with an if guard.
+            #[expect(clippy::collapsible_match)]
             match inst.properties.get(&ustr("UniqueId")) {
                 Some(Variant::UniqueId(id)) => {
                     if !unique_ids.insert(*id) {

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -343,14 +343,9 @@ fn deserialize_root<R: Read>(
                     }
                 }
             }
-            XmlReadEvent::EndElement { name } => {
-                if name.local_name == "roblox" {
-                    reader.expect_next().unwrap();
-                    break;
-                } else {
-                    let event = reader.expect_next().unwrap();
-                    return Err(reader.error(DecodeErrorKind::UnexpectedXmlEvent(event)));
-                }
+            XmlReadEvent::EndElement { name } if name.local_name == "roblox" => {
+                reader.expect_next().unwrap();
+                break;
             }
             XmlReadEvent::EndDocument => break,
             _ => {
@@ -396,21 +391,11 @@ fn deserialize_shared_string_dict<R: Read>(
 
     loop {
         match reader.expect_peek()? {
-            XmlReadEvent::StartElement { name, .. } => {
-                if name.local_name == "SharedString" {
-                    deserialize_shared_string(reader, state)?;
-                } else {
-                    let event = reader.expect_next().unwrap();
-                    return Err(reader.error(DecodeErrorKind::UnexpectedXmlEvent(event)));
-                }
+            XmlReadEvent::StartElement { name, .. } if name.local_name == "SharedString" => {
+                deserialize_shared_string(reader, state)?;
             }
-            XmlReadEvent::EndElement { name } => {
-                if name.local_name == "SharedStrings" {
-                    break;
-                } else {
-                    let event = reader.expect_next().unwrap();
-                    return Err(reader.error(DecodeErrorKind::UnexpectedXmlEvent(event)));
-                }
+            XmlReadEvent::EndElement { name } if name.local_name == "SharedStrings" => {
+                break;
             }
             _ => {
                 let event = reader.expect_next().unwrap();
@@ -584,14 +569,9 @@ fn deserialize_properties<R: Read>(
 
                     (name.local_name.to_owned(), xml_property_name)
                 }
-                XmlReadEvent::EndElement { name } => {
-                    if name.local_name == "Properties" {
-                        reader.expect_next()?;
-                        return Ok(());
-                    } else {
-                        let err = DecodeErrorKind::UnexpectedXmlEvent(reader.expect_next()?);
-                        return Err(reader.error(err));
-                    }
+                XmlReadEvent::EndElement { name } if name.local_name == "Properties" => {
+                    reader.expect_next()?;
+                    return Ok(());
                 }
                 _ => {
                     let err = DecodeErrorKind::UnexpectedXmlEvent(reader.expect_next()?);


### PR DESCRIPTION
Nice lints.

Note that this lint is silenced, since the else case does not panic:
<img width="1822" height="928" alt="image" src="https://github.com/user-attachments/assets/d83b7de2-4647-48b7-a8d7-ee7cfc822bec" />
