### PR TITLE
Update Rust to latest stable version in actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
     - name: Setup Rust toolchain
       run: |
+        rustup update ${{ matrix.rust_version }}
         rustup default ${{ matrix.rust_version }}
         rustup component add rustfmt
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,6 +25,7 @@ jobs:
 
     - name: Setup Rust toolchain
       run: |
+        rustup update ${{ matrix.rust_version }}
         rustup default ${{ matrix.rust_version }}
         rustup component add clippy
 


### PR DESCRIPTION
GitHub actions runner images do not roll out all at the same time. This means that some runners can have different images with different versions of Rust. This PR changes the workflows to run `rustup update` before selecting the toolchain so that we're always on the latest stable.