### PR TITLE
Add PRNT chunk ordering notes to binary format docs

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -235,7 +235,7 @@ There should be exactly one `PRNT` chunk.
 
 **Instance Count** should be equal to the number of instances in the file header chunk, since each object should have a parent.
 
-**Child Referents** and **Parent Referents** should both have length equal to **Instance Count**. The parent of the ID at position *N* in **Child Referents** is a child of the ID at position *N* in **Parent Referents**.
+**Child Referents** and **Parent Referents** should both have length equal to **Instance Count**. The instance identified by the referent at position *N* in **Child Referents** has the parent instance identified by the referent at position *N* in **Parent Referents**.
 
 A null parent referent (`-1`) indicates that the object is a root instance. In a place, that means the object is a child of `DataModel`. In a model, that means the object should be placed directly under the object the model is being inserted into.
 
@@ -255,12 +255,11 @@ For example, given referents arranged as the following tree:
 └── 4
     └── 7
 ```
-Roblox Studio has been observed to write the child side of the PRNT links in
-this order:
+Roblox Studio has been observed to write the child referents in this order:
 ```text
 2, 5, 6, 3, 7, 4, 1
 ```
-With corresponding parents:
+And write the parent referents in this order:
 ```text
 1, 3, 3, 1, 4, 1, -1
 ```

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -239,6 +239,34 @@ There should be exactly one `PRNT` chunk.
 
 A null parent referent (`-1`) indicates that the object is a root instance. In a place, that means the object is a child of `DataModel`. In a model, that means the object should be placed directly under the object the model is being inserted into.
 
+#### Ordering
+
+Although the `PRNT` chunk can be interpreted as a set of child-parent relationships, in practice, Roblox Studio appears to apply the relationships in the order stored in the chunk. This order can affect load-time behavior for some instance types, because parenting an instance may trigger engine side effects.
+
+For best compatibility with Roblox Studio, serializers should write `PRNT` entries in depth-first post-order over the instance tree: recursively write all children of an instance before writing the instance itself, preserving sibling order. This means that descendants are parented before their ancestors.
+
+For example, given referents arranged as the following tree:
+```text
+1
+├── 2
+├── 3
+│   ├── 5
+│   └── 6
+└── 4
+    └── 7
+```
+Roblox Studio has been observed to write the child side of the PRNT links in
+this order:
+```text
+2, 5, 6, 3, 7, 4, 1
+```
+With corresponding parents:
+```text
+1, 3, 3, 1, 4, 1, -1
+```
+
+Decoders should still treat the child and parent arrays as paired arrays. A file should not be rejected solely because its PRNT entries are not in this order, but serializers targeting Roblox Studio compatibility should follow this order.
+
 ### `END` Chunk
 The `END` chunk has this layout:
 


### PR DESCRIPTION
In the binary format docs, this PR adds a section under the PRNT chunk header explaining the importance of the ordering of the PRNT chunk, informed by findings from #411 and #432. I also updated the wording of the sentence explaining the relationship between the parent/child referent arrays because I found it a bit hard to understand. 