### PR TITLE
Fix binary serializer writing XYX instead of XYZ for Ray directions

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1060,7 +1060,7 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                                 chunk.write_le_f32(value.origin.z)?;
                                 chunk.write_le_f32(value.direction.x)?;
                                 chunk.write_le_f32(value.direction.y)?;
-                                chunk.write_le_f32(value.direction.x)?;
+                                chunk.write_le_f32(value.direction.z)?;
                             } else {
                                 return type_mismatch(i, rbx_value, "Ray");
                             }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-ray-values__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__two-ray-values__encoded.snap
@@ -52,7 +52,7 @@ chunks:
           direction:
             - -4
             - -5
-            - -4
+            - -6
         - origin:
             - inf
             - -inf
@@ -60,7 +60,7 @@ chunks:
           direction:
             - 0.5
             - 0.15625
-            - 0.5
+            - 0.1
   - Prnt:
       version: 0
       links:
@@ -69,4 +69,3 @@ chunks:
         - - 1
           - -1
   - End
-


### PR DESCRIPTION
Fix for an issue brought to my attention by https://github.com/Starfruit-Studios/rbx-dom, and one that I'm not surprised has laid dormant for so long. Pretty simple: we made a copy-paste error when we implemented binary Ray serialization. 