### PR TITLE
Support SSTR chunk version 1

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -149,16 +149,16 @@ The `SSTR` chunk has this layout:
 
 | Field Name          | Format                | Value                                        |
 |:--------------------|:----------------------|:---------------------------------------------|
-| Version             | `u32`                 | The version of the `SSTR` chunk (always `0`) |
+| Version             | `u32`                 | The version of the `SSTR` chunk (`0` or `1`) |
 | Shared String Count | `u32`                 | The number of SharedStrings in the chunk     |
 | Strings             | Array(Shared Strings) | The actual shared string entries             |
 
 A shared string entry looks like this:
 
-| Field Name    | Format              | Value                                                                   |
-|:--------------|:--------------------|:------------------------------------------------------------------------|
-| MD5 Hash      | 16 bytes            | An [MD5](https://en.wikipedia.org/wiki/MD5) hash of the `Shared String` |
-| Shared String | [`String`](#string) | The string that's used by a later `PROP` chunk                          |
+| Field Name    | Format              | Value                                                                                                 |
+|:--------------|:--------------------|:------------------------------------------------------------------------------------------------------|
+| MD5 Hash      | 16 bytes            | An [MD5](https://en.wikipedia.org/wiki/MD5) hash of the `Shared String`, present only when Version=`0`|
+| Shared String | [`String`](#string) | The string that's used by a later `PROP` chunk                                                        |
 
 The Shared String chunk (`SSTR`) is an array of strings. It's used to reduce the overall size of a file by allowing large strings to be reused in [`PROP`](#prop-chunk) chunks. The `MD5 Hash` isn't used by Roblox Studio when loading the file.
 

--- a/docs/xml.md
+++ b/docs/xml.md
@@ -151,13 +151,13 @@ This element defines a single `SharedString` value for reference by [Type Elemen
 
 This element shares a name with a type element. That element is documented [here][SharedString-use].
 
-The following attributes are REQUIRED for this element:
+The following attributes MAY be present:
 
 | Name  | Contents                                                               |
 |:------|:-----------------------------------------------------------------------|
 | `md5` | A unique identifier for this element, for reference by a type element. |
 
-The value of `md5` MUST be unique across all `SharedString` definitions. Despite the name, the value does not have to be the MD5 hash of the `SharedString` contents.
+The value of `md5` MUST be unique across all `SharedString` definitions. Despite the name, the value does not have to be the MD5 hash of the `SharedString` contents. When this attribute is missing, it MUST be computed using 128 bit BLAKE2b hash. This identifier is used to reference the actual string.
 
 The content of `SharedString` elements MUST be Base64 encoded as per [RFC 2045](https://www.rfc-editor.org/rfc/rfc2045).
 

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -259,7 +259,7 @@ impl<'db, R: Read> DeserializerState<'db, R> {
     pub(super) fn decode_sstr_chunk(&mut self, mut chunk: &[u8]) -> Result<(), InnerError> {
         let version = chunk.read_le_u32()?;
 
-        if version != 0 {
+        if version > 1 {
             return Err(InnerError::UnknownChunkVersion {
                 chunk_name: "SSTR",
                 version,
@@ -269,7 +269,9 @@ impl<'db, R: Read> DeserializerState<'db, R> {
         let num_entries = chunk.read_le_u32()?;
 
         for _ in 0..num_entries {
-            chunk.read_exact(&mut [0; 16])?; // We don't do anything with the hash.
+            if version == 0 {
+                chunk.read_exact(&mut [0; 16])?; // We don't do anything with the hash.
+            }
             let data = chunk.read_binary_string()?;
             self.shared_strings.push(SharedString::new(data));
         }

--- a/rbx_xml/Cargo.toml
+++ b/rbx_xml/Cargo.toml
@@ -23,6 +23,7 @@ ahash = "0.8.11"
 base64 = "0.13.0"
 log = "0.4.17"
 xml-rs = "0.8.4"
+blake2 = "0.10.6"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -1,6 +1,7 @@
 use std::{collections::hash_map::Entry, io::Read};
 
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use blake2::{Blake2b, Digest};
 use log::trace;
 use rbx_dom_weak::{
     types::{Ref, SharedString, Variant},
@@ -422,10 +423,15 @@ fn deserialize_shared_string<R: Read>(
         }
     }
 
-    let md5_hash =
-        md5_hash.ok_or_else(|| reader.error(DecodeErrorKind::MissingAttribute("md5")))?;
-
     let buffer = reader.read_base64_characters()?;
+
+    let md5_hash =
+        md5_hash.unwrap_or_else(|| {
+            let mut blake2b = Blake2b::<blake2::digest::consts::U16>::new();
+            blake2b.update(buffer.as_slice());
+            base64::encode(blake2b.finalize())
+        }
+        );
 
     let value = SharedString::new(buffer);
 

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -425,13 +425,11 @@ fn deserialize_shared_string<R: Read>(
 
     let buffer = reader.read_base64_characters()?;
 
-    let md5_hash =
-        md5_hash.unwrap_or_else(|| {
-            let mut blake2b = Blake2b::<blake2::digest::consts::U16>::new();
-            blake2b.update(buffer.as_slice());
-            base64::encode(blake2b.finalize())
-        }
-        );
+    let md5_hash = md5_hash.unwrap_or_else(|| {
+        let mut blake2b = Blake2b::<blake2::digest::consts::U16>::new();
+        blake2b.update(buffer.as_slice());
+        base64::encode(blake2b.finalize())
+    });
 
     let value = SharedString::new(buffer);
 


### PR DESCRIPTION
Version 1 of the SSTR chunk does not have unused MD5 field.