### PR TITLE
Fix Rust 1.96 Clippy Lints

### DIFF
--- a/rbx_dom_weak/src/dom.rs
+++ b/rbx_dom_weak/src/dom.rs
@@ -55,7 +55,6 @@ impl WeakDom {
         let mut unique_ids = AHashSet::with_capacity(instances.len());
         for inst in instances.values() {
             // This `if` cannot be collapsed into the match with an if guard.
-            #[expect(clippy::collapsible_match)]
             match inst.properties.get(&ustr("UniqueId")) {
                 Some(Variant::UniqueId(id)) => {
                     if !unique_ids.insert(*id) {


### PR DESCRIPTION
Looks like this lint with an incorrect suggestion in 1.95 was fixed in 1.96.