### PR TITLE
Use Entry to avoid navigating HashMap twice

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -396,16 +396,15 @@ fn get_or_create_prop_info<'dom, 'db: 'dom>(
         hash_map::Entry::Vacant(vacant_entry) => vacant_entry,
     };
 
-    let Some(prop_type) = Type::from_rbx_type(serialized_ty) else {
-        // This is a known value type, but rbx_binary doesn't have a
-        // binary type value for it. rbx_binary might be out of
-        // date?
-        return Err(InnerError::UnsupportedPropType {
+    // This is a known value type, but rbx_binary doesn't have a
+    // binary type value for it. rbx_binary might be out of
+    // date?
+    let prop_type =
+        Type::from_rbx_type(serialized_ty).ok_or_else(|| InnerError::UnsupportedPropType {
             type_name: type_name.to_string(),
             prop_name: serialized_name.to_string(),
             prop_type: format!("{:?}", serialized_ty),
-        });
-    };
+        })?;
 
     let prop_info = PropInfo {
         prop_type,

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -368,62 +368,63 @@ impl<'db> SerializationResolution<'db> {
     }
 }
 
-impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
-    /// Get or create a PropInfo given a serialized property.
-    //  Return the index into self.properties where the PropInfo is located.
-    fn get_or_create_prop_info(
-        properties: &mut Vec<PropInfo<'dom>>,
-        prop_info_indices_by_canonical_name: &mut UstrMap<usize>,
-        type_name: Ustr,
-        default_value: &'dom Variant,
-        SerializedProperty {
-            canonical_name,
-            serialized_name,
-            serialized_ty,
-        }: SerializedProperty,
-        migration: Option<&'dom PropertyMigration>,
-    ) -> Result<usize, InnerError> {
-        let vacant_entry = match prop_info_indices_by_canonical_name.entry(canonical_name) {
-            hash_map::Entry::Occupied(occupied_entry) => {
-                let &prop_info_index = occupied_entry.get();
-                // The visited property may contain a migration that the logical
-                // property has not been made aware of yet.
-                if let Some(migration) = migration {
-                    properties[prop_info_index].set_migration(migration);
-                }
-
-                return Ok(prop_info_index);
+/// Get or create a PropInfo given a serialized property.
+//  Return the index into self.properties where the PropInfo is located.
+fn get_or_create_prop_info<'dom, 'db: 'dom>(
+    properties: &mut Vec<PropInfo<'dom>>,
+    prop_info_indices_by_canonical_name: &mut UstrMap<usize>,
+    type_name: Ustr,
+    default_value: &'dom Variant,
+    SerializedProperty {
+        canonical_name,
+        serialized_name,
+        serialized_ty,
+    }: SerializedProperty,
+    migration: Option<&'dom PropertyMigration>,
+) -> Result<usize, InnerError> {
+    let vacant_entry = match prop_info_indices_by_canonical_name.entry(canonical_name) {
+        hash_map::Entry::Occupied(occupied_entry) => {
+            let &prop_info_index = occupied_entry.get();
+            // The visited property may contain a migration that the logical
+            // property has not been made aware of yet.
+            if let Some(migration) = migration {
+                properties[prop_info_index].set_migration(migration);
             }
-            hash_map::Entry::Vacant(vacant_entry) => vacant_entry,
-        };
 
-        let Some(prop_type) = Type::from_rbx_type(serialized_ty) else {
-            // This is a known value type, but rbx_binary doesn't have a
-            // binary type value for it. rbx_binary might be out of
-            // date?
-            return Err(InnerError::UnsupportedPropType {
-                type_name: type_name.to_string(),
-                prop_name: serialized_name.to_string(),
-                prop_type: format!("{:?}", serialized_ty),
-            });
-        };
+            return Ok(prop_info_index);
+        }
+        hash_map::Entry::Vacant(vacant_entry) => vacant_entry,
+    };
 
-        let prop_info = PropInfo {
-            prop_type,
-            canonical_name,
-            serialized_name,
-            values: Vec::new(),
-            default_value,
-            migration,
-        };
+    let Some(prop_type) = Type::from_rbx_type(serialized_ty) else {
+        // This is a known value type, but rbx_binary doesn't have a
+        // binary type value for it. rbx_binary might be out of
+        // date?
+        return Err(InnerError::UnsupportedPropType {
+            type_name: type_name.to_string(),
+            prop_name: serialized_name.to_string(),
+            prop_type: format!("{:?}", serialized_ty),
+        });
+    };
 
-        // Insert the new PropInfo into our properties list, and record its index
-        let prop_info_index = properties.len();
-        properties.push(prop_info);
-        vacant_entry.insert(prop_info_index);
+    let prop_info = PropInfo {
+        prop_type,
+        canonical_name,
+        serialized_name,
+        values: Vec::new(),
+        default_value,
+        migration,
+    };
 
-        Ok(prop_info_index)
-    }
+    // Insert the new PropInfo into our properties list, and record its index
+    let prop_info_index = properties.len();
+    properties.push(prop_info);
+    vacant_entry.insert(prop_info_index);
+
+    Ok(prop_info_index)
+}
+
+impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
     /// Resolve a visited property name into a PropInfoResolution, which
     /// contains the indices into TypeInfo.properties of the relevant PropInfos.
     fn resolve_visited_property(
@@ -478,7 +479,7 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
 
         let resolved_property = match serialization {
             SerializationResolution::Property(serialized_property) => {
-                let prop_info_index = TypeInfo::get_or_create_prop_info(
+                let prop_info_index = get_or_create_prop_info(
                     &mut self.properties,
                     &mut self.prop_info_indices_by_canonical_name,
                     type_name,
@@ -492,7 +493,7 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
                 let mut prop_info_indices = Vec::with_capacity(targets.len());
 
                 for serialized_property in targets {
-                    let prop_info_index = TypeInfo::get_or_create_prop_info(
+                    let prop_info_index = get_or_create_prop_info(
                         &mut self.properties,
                         &mut self.prop_info_indices_by_canonical_name,
                         type_name,

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -479,11 +479,12 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
 
         let resolved_property = match serialization {
             SerializationResolution::Property(serialized_property) => {
+                let default_value = default_value(&serialized_property)?;
                 let prop_info_index = get_or_create_prop_info(
                     &mut self.properties,
                     &mut self.prop_info_indices_by_canonical_name,
                     type_name,
-                    default_value(&serialized_property)?,
+                    default_value,
                     serialized_property,
                     None,
                 )?;
@@ -493,11 +494,12 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
                 let mut prop_info_indices = Vec::with_capacity(targets.len());
 
                 for serialized_property in targets {
+                    let default_value = default_value(&serialized_property)?;
                     let prop_info_index = get_or_create_prop_info(
                         &mut self.properties,
                         &mut self.prop_info_indices_by_canonical_name,
                         type_name,
-                        default_value(&serialized_property)?,
+                        default_value,
                         serialized_property,
                         Some(migration),
                     )?;

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -450,6 +450,7 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
             return Ok(vacant_entry.insert(PropInfoResolution::DoesNotSerialize));
         };
 
+        // Use a closure to reduce the argument count of get_or_create_prop_info
         let class_descriptor = self.class_descriptor;
         let mut default_value =
             |serialized_property: &SerializedProperty| -> Result<_, InnerError> {

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -374,10 +374,8 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
     fn get_or_create_prop_info(
         properties: &mut Vec<PropInfo<'dom>>,
         prop_info_indices_by_canonical_name: &mut UstrMap<usize>,
-        push_sstr: &mut impl FnMut(&Variant),
-        class_descriptor: Option<&'db ClassDescriptor<'db>>,
-        database: &'db ReflectionDatabase<'db>,
         type_name: Ustr,
+        default_value: &'dom Variant,
         SerializedProperty {
             canonical_name,
             serialized_name,
@@ -409,24 +407,6 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
                 prop_type: format!("{:?}", serialized_ty),
             });
         };
-
-        let default_value = class_descriptor
-            .and_then(|class| database.find_default_property(class, &canonical_name))
-            .or_else(|| fallback_default_value(serialized_ty))
-            .ok_or_else(|| {
-                // Since we don't know how to generate the default value
-                // for this property, we consider it unsupported.
-                InnerError::UnsupportedPropType {
-                    type_name: type_name.to_string(),
-                    prop_name: canonical_name.to_string(),
-                    prop_type: format!("{:?}", serialized_ty),
-                }
-            })?;
-
-        // There's no assurance that the default SharedString value
-        // will actually get serialized inside of the SSTR chunk, so we
-        // check here just to make sure.
-        push_sstr(default_value);
 
         let prop_info = PropInfo {
             prop_type,
@@ -470,15 +450,39 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
             return Ok(vacant_entry.insert(PropInfoResolution::DoesNotSerialize));
         };
 
+        let class_descriptor = self.class_descriptor;
+        let mut default_value =
+            |serialized_property: &SerializedProperty| -> Result<_, InnerError> {
+                let default_value = class_descriptor
+                    .and_then(|class| {
+                        database.find_default_property(class, &serialized_property.canonical_name)
+                    })
+                    .or_else(|| fallback_default_value(serialized_property.serialized_ty))
+                    .ok_or_else(|| {
+                        // Since we don't know how to generate the default value
+                        // for this property, we consider it unsupported.
+                        InnerError::UnsupportedPropType {
+                            type_name: type_name.to_string(),
+                            prop_name: serialized_property.canonical_name.to_string(),
+                            prop_type: format!("{:?}", serialized_property.serialized_ty),
+                        }
+                    })?;
+
+                // There's no assurance that the default SharedString value
+                // will actually get serialized inside of the SSTR chunk, so we
+                // check here just to make sure.
+                push_sstr(default_value);
+
+                Ok(default_value)
+            };
+
         let resolved_property = match serialization {
             SerializationResolution::Property(serialized_property) => {
                 let prop_info_index = TypeInfo::get_or_create_prop_info(
                     &mut self.properties,
                     &mut self.prop_info_indices_by_canonical_name,
-                    push_sstr,
-                    self.class_descriptor,
-                    database,
                     type_name,
+                    default_value(&serialized_property)?,
                     serialized_property,
                     None,
                 )?;
@@ -491,10 +495,8 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
                     let prop_info_index = TypeInfo::get_or_create_prop_info(
                         &mut self.properties,
                         &mut self.prop_info_indices_by_canonical_name,
-                        push_sstr,
-                        self.class_descriptor,
-                        database,
                         type_name,
+                        default_value(&serialized_property)?,
                         serialized_property,
                         Some(migration),
                     )?;

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::{btree_map, BTreeMap},
+    collections::{btree_map, hash_map, BTreeMap},
     io::Write,
 };
 
@@ -372,8 +372,10 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
     /// Get or create a PropInfo given a serialized property.
     //  Return the index into self.properties where the PropInfo is located.
     fn get_or_create_prop_info(
-        &mut self,
+        properties: &mut Vec<PropInfo<'dom>>,
+        prop_info_indices_by_canonical_name: &mut UstrMap<usize>,
         push_sstr: &mut impl FnMut(&Variant),
+        class_descriptor: Option<&'db ClassDescriptor<'db>>,
         database: &'db ReflectionDatabase<'db>,
         type_name: Ustr,
         SerializedProperty {
@@ -383,18 +385,19 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
         }: SerializedProperty,
         migration: Option<&'dom PropertyMigration>,
     ) -> Result<usize, InnerError> {
-        if let Some(&prop_info_index) = self
-            .prop_info_indices_by_canonical_name
-            .get(&canonical_name)
-        {
-            // The visited property may contain a migration that the logical
-            // property has not been made aware of yet.
-            if let Some(migration) = migration {
-                self.properties[prop_info_index].set_migration(migration);
-            }
+        let vacant_entry = match prop_info_indices_by_canonical_name.entry(canonical_name) {
+            hash_map::Entry::Occupied(occupied_entry) => {
+                let &prop_info_index = occupied_entry.get();
+                // The visited property may contain a migration that the logical
+                // property has not been made aware of yet.
+                if let Some(migration) = migration {
+                    properties[prop_info_index].set_migration(migration);
+                }
 
-            return Ok(prop_info_index);
-        }
+                return Ok(prop_info_index);
+            }
+            hash_map::Entry::Vacant(vacant_entry) => vacant_entry,
+        };
 
         let Some(prop_type) = Type::from_rbx_type(serialized_ty) else {
             // This is a known value type, but rbx_binary doesn't have a
@@ -407,8 +410,7 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
             });
         };
 
-        let default_value = self
-            .class_descriptor
+        let default_value = class_descriptor
             .and_then(|class| database.find_default_property(class, &canonical_name))
             .or_else(|| fallback_default_value(serialized_ty))
             .ok_or_else(|| {
@@ -436,15 +438,12 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
         };
 
         // Insert the new PropInfo into our properties list, and record its index
-        let prop_info_index = self.properties.len();
-        let canonical_name = prop_info.canonical_name;
-        self.properties.push(prop_info);
-        self.prop_info_indices_by_canonical_name
-            .insert(canonical_name, prop_info_index);
+        let prop_info_index = properties.len();
+        properties.push(prop_info);
+        vacant_entry.insert(prop_info_index);
 
         Ok(prop_info_index)
     }
-
     /// Resolve a visited property name into a PropInfoResolution, which
     /// contains the indices into TypeInfo.properties of the relevant PropInfos.
     fn resolve_visited_property(
@@ -454,28 +453,30 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
         type_name: Ustr,
         prop_name: Ustr,
         sample_value: &Variant,
-    ) -> Result<PropInfoResolution, InnerError> {
+    ) -> Result<&PropInfoResolution, InnerError> {
         let class = self.class_descriptor;
 
         // Check if visited property has already been resolved, return the
         // resolved property if so
-        if let Some(resolved_property) = self.resolved_properties_by_visited_name.get(&prop_name) {
-            return Ok(resolved_property.clone());
-        }
+        let vacant_entry = match self.resolved_properties_by_visited_name.entry(prop_name) {
+            hash_map::Entry::Occupied(resolved_property) => return Ok(resolved_property.into_mut()),
+            hash_map::Entry::Vacant(vacant_entry) => vacant_entry,
+        };
 
         let Some(serialization) =
             SerializationResolution::new(class, database, prop_name, sample_value)
         else {
             // Remember that this visited property does not serialize
-            self.resolved_properties_by_visited_name
-                .insert(prop_name, PropInfoResolution::DoesNotSerialize);
-            return Ok(PropInfoResolution::DoesNotSerialize);
+            return Ok(vacant_entry.insert(PropInfoResolution::DoesNotSerialize));
         };
 
         let resolved_property = match serialization {
             SerializationResolution::Property(serialized_property) => {
-                let prop_info_index = self.get_or_create_prop_info(
+                let prop_info_index = TypeInfo::get_or_create_prop_info(
+                    &mut self.properties,
+                    &mut self.prop_info_indices_by_canonical_name,
                     push_sstr,
+                    self.class_descriptor,
                     database,
                     type_name,
                     serialized_property,
@@ -484,11 +485,14 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
                 PropInfoResolution::SerializesTo(prop_info_index)
             }
             SerializationResolution::Migration { migration, targets } => {
-                let mut prop_info_indices = Vec::new();
+                let mut prop_info_indices = Vec::with_capacity(targets.len());
 
                 for serialized_property in targets {
-                    let prop_info_index = self.get_or_create_prop_info(
+                    let prop_info_index = TypeInfo::get_or_create_prop_info(
+                        &mut self.properties,
+                        &mut self.prop_info_indices_by_canonical_name,
                         push_sstr,
+                        self.class_descriptor,
                         database,
                         type_name,
                         serialized_property,
@@ -502,10 +506,7 @@ impl<'dom, 'db: 'dom> TypeInfo<'dom, 'db> {
             }
         };
 
-        self.resolved_properties_by_visited_name
-            .insert(prop_name, resolved_property.clone());
-
-        Ok(resolved_property)
+        Ok(vacant_entry.insert(resolved_property))
     }
 }
 
@@ -655,9 +656,9 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                     // later to push its instance value, because we don't know yet if the
                     // instance specifies any of the migration target properties, which
                     // should take precedence.
-                    deferred_migrations.push((prop_info_indices, prop_value));
+                    deferred_migrations.push((prop_info_indices.clone(), prop_value));
                 }
-                PropInfoResolution::SerializesTo(prop_info_index) => {
+                &PropInfoResolution::SerializesTo(prop_info_index) => {
                     // This property does not migrate, so no need to fill deferred_migrations
                     // and we may proceed
 

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -370,7 +370,7 @@ impl<'db> SerializationResolution<'db> {
 
 /// Get or create a PropInfo given a serialized property.
 //  Return the index into self.properties where the PropInfo is located.
-fn get_or_create_prop_info<'dom, 'db: 'dom>(
+fn get_or_create_prop_info<'dom>(
     properties: &mut Vec<PropInfo<'dom>>,
     prop_info_indices_by_canonical_name: &mut UstrMap<usize>,
     type_name: Ustr,


### PR DESCRIPTION
Uses the entry api in `get_or_create_prop_info` and `resolve_visited_property` to remember which bucket is open when inserting into the hash maps.

### Performance
The performance impact is within margin of error due to the hot path being cache hit, and double-index only happening on cache miss.

### Notes
- `resolve_visited_property` return type is changed to a reference to match vacant_entry.insert return type, but it doesn't really matter and we could clone on the spot instead to keep the return type the same.
- `get_or_create_prop_info` is unassociated with `TypeInfo` due to needing multiple split borrows for `type_info.resolved_properties_by_visited_name` and `type_info.prop_info_indices_by_canonical_name` in `resolve_visited_property`.  This pushes the argument count over clippy's maximum of 8, so a closure is used to generate the default values ahead of calling `get_or_create_prop_info`.  Perhaps there's a cleaner solution, but I don't see it.
- Lint check is failing due to #614

### See also
- Another entry api change #526