### PR TITLE
Fix overspecified trait bound

### DIFF
--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -982,8 +982,7 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                 invalid_value: InvalidValue,
             ) -> Result<(), InnerError>
             where
-                I: IntoIterator<Item = (usize, &'a Variant)>,
-                I: ExactSizeIterator,
+                I: ExactSizeIterator<Item = (usize, &'a Variant)>,
                 TypeMismatch: Fn(usize, &Variant, &'static str) -> Result<(), InnerError>,
                 InvalidValue: Fn(usize, &Variant) -> InnerError,
             {


### PR DESCRIPTION
IntoIterator should really be Iterator, but Iterator is a supertrait of ExactSizeIterator so use that.