### PR TITLE
Update deps

### DIFF
--- a/rbx_binary/Cargo.toml
+++ b/rbx_binary/Cargo.toml
@@ -24,16 +24,16 @@ rbx_reflection_database = { version = "2.0.2", path = "../rbx_reflection_databas
 
 ahash = "0.8.11"
 log = "0.4.17"
-lz4_flex = "0.11"
+lz4_flex = "0.13.1"
 thiserror = "1.0.31"
 serde = { version = "1.0.137", features = ["derive"], optional = true }
 profiling = "1.0.6"
 zstd = "0.13.2"
 
 [dev-dependencies]
-criterion = "0.5.1"
-env_logger = "0.9.0"
-heck = "0.4.0"
+criterion = "0.8.2"
+env_logger = "0.11.10"
+heck = "0.5.0"
 insta = { version = "1.14.1", features = ["yaml"] }
 serde = { version = "1.0.137", features = ["derive"] }
 rbx_reflection_database = { path = "../rbx_reflection_database", features = [

--- a/rbx_reflection_database/Cargo.toml
+++ b/rbx_reflection_database/Cargo.toml
@@ -24,5 +24,5 @@ rbx_reflection = { version = "6.1.0", path = "../rbx_reflection" }
 
 serde = "1.0.137"
 rmp-serde = "1.1.1"
-dirs = "5.0.1"
+dirs = "6.0.0"
 log = "0.4.20"

--- a/rbx_reflector/Cargo.toml
+++ b/rbx_reflector/Cargo.toml
@@ -18,10 +18,10 @@ rbx_xml = { path = "../rbx_xml" }
 
 anyhow = "1.0.57"
 clap = { version = "4.1.4", features = ["derive"] }
-env_logger = "0.10.0"
+env_logger = "0.11.10"
 log = "0.4.17"
-notify = "5.0.0"
-reqwest = { version = "0.11.14", features = ["blocking", "json"] }
+notify = "8.2.0"
+reqwest = { version = "0.13.4", features = ["blocking", "json"] }
 rmp-serde = "1.1.0"
 roblox_install = "1.0.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/rbx_util/Cargo.toml
+++ b/rbx_util/Cargo.toml
@@ -30,7 +30,7 @@ rbx_xml = { path = "../rbx_xml" }
 serde_yaml = "0.8.24"
 clap = { version = "4.5.4", features = ["derive"] }
 
-fs-err = "2.7.0"
+fs-err = "3.3.0"
 anyhow = "1.0.57"
-env_logger = "0.11.3"
+env_logger = "0.11.10"
 log = "0.4.21"

--- a/rbx_xml/Cargo.toml
+++ b/rbx_xml/Cargo.toml
@@ -22,12 +22,12 @@ rbx_reflection_database = { version = "2.0.2", path = "../rbx_reflection_databas
 ahash = "0.8.11"
 base64 = "0.13.0"
 log = "0.4.17"
-xml-rs = "0.8.4"
+xml-rs = "1.0.0"
 
 [dev-dependencies]
-env_logger = "0.9.0"
+env_logger = "0.11.10"
 insta = { version = "1.14.1", features = ["yaml"] }
-heck = "0.4.1"
+heck = "0.5.0"
 rbx_reflection_database = { path = "../rbx_reflection_database", features = [
     "debug_always_use_bundled",
 ] }


### PR DESCRIPTION
I was looking at which dependencies cannot be updated by cargo update, and I believe these ones have no consequences.   They require no code changes and produce no warnings. No exposed types or version bumps.  I'm looking into updating the other dependencies as well.