### PR TITLE
Drop bincode, use rmp_serde

### DIFF
--- a/rbx_types/Cargo.toml
+++ b/rbx_types/Cargo.toml
@@ -25,5 +25,5 @@ serde = { version = "1.0.137", features = ["derive"], optional = true }
 
 [dev-dependencies]
 insta = { version = "1.14.1", features = ["yaml"] }
-bincode = "1.3.3"
+rmp-serde = "1.1.0"
 serde_json = "1.0.81"

--- a/rbx_types/Cargo.toml
+++ b/rbx_types/Cargo.toml
@@ -25,5 +25,6 @@ serde = { version = "1.0.137", features = ["derive"], optional = true }
 
 [dev-dependencies]
 insta = { version = "1.14.1", features = ["yaml"] }
+rmp = "0.8.15"
 rmp-serde = "1.1.0"
 serde_json = "1.0.81"

--- a/rbx_types/src/axes.rs
+++ b/rbx_types/src/axes.rs
@@ -210,18 +210,18 @@ mod serde_test {
     #[test]
     fn non_human() {
         let empty = Axes::empty();
-        let ser_empty = bincode::serialize(&empty).unwrap();
-        let de_empty = bincode::deserialize(&ser_empty).unwrap();
+        let ser_empty = rmp_serde::to_vec(&empty).unwrap();
+        let de_empty = rmp_serde::from_slice(&ser_empty).unwrap();
         assert_eq!(empty, de_empty);
 
         let x = Axes::X;
-        let ser_x = bincode::serialize(&x).unwrap();
-        let de_x = bincode::deserialize(&ser_x).unwrap();
+        let ser_x = rmp_serde::to_vec(&x).unwrap();
+        let de_x = rmp_serde::from_slice(&ser_x).unwrap();
         assert_eq!(x, de_x);
 
         let all = Axes::all();
-        let ser_all = bincode::serialize(&all).unwrap();
-        let de_all = bincode::deserialize(&ser_all).unwrap();
+        let ser_all = rmp_serde::to_vec(&all).unwrap();
+        let de_all = rmp_serde::from_slice(&ser_all).unwrap();
         assert_eq!(all, de_all);
     }
 }

--- a/rbx_types/src/binary_string.rs
+++ b/rbx_types/src/binary_string.rs
@@ -136,8 +136,8 @@ mod serde_test {
     fn non_human() {
         let data = BinaryString::from(b"world".to_vec());
 
-        let ser = bincode::serialize(&data).unwrap();
-        let de: BinaryString = bincode::deserialize(&ser).unwrap();
+        let ser = rmp_serde::to_vec(&data).unwrap();
+        let de: BinaryString = rmp_serde::from_slice(&ser).unwrap();
 
         assert_eq!(de, data);
     }

--- a/rbx_types/src/brick_color.rs
+++ b/rbx_types/src/brick_color.rs
@@ -369,8 +369,8 @@ mod serde_test {
     fn non_human() {
         let value = BrickColor::Cork;
 
-        let ser = bincode::serialize(&value).unwrap();
-        let de: BrickColor = bincode::deserialize(&ser).unwrap();
+        let ser = rmp_serde::to_vec(&value).unwrap();
+        let de: BrickColor = rmp_serde::from_slice(&ser).unwrap();
 
         assert_eq!(de, value);
     }

--- a/rbx_types/src/faces.rs
+++ b/rbx_types/src/faces.rs
@@ -253,18 +253,18 @@ mod serde_test {
     #[test]
     fn non_human() {
         let empty = Faces::empty();
-        let ser_empty = bincode::serialize(&empty).unwrap();
-        let de_empty = bincode::deserialize(&ser_empty).unwrap();
+        let ser_empty = rmp_serde::to_vec(&empty).unwrap();
+        let de_empty = rmp_serde::from_slice(&ser_empty).unwrap();
         assert_eq!(empty, de_empty);
 
         let right = Faces::RIGHT;
-        let ser_right = bincode::serialize(&right).unwrap();
-        let de_right = bincode::deserialize(&ser_right).unwrap();
+        let ser_right = rmp_serde::to_vec(&right).unwrap();
+        let de_right = rmp_serde::from_slice(&ser_right).unwrap();
         assert_eq!(right, de_right);
 
         let all = Faces::all();
-        let ser_all = bincode::serialize(&all).unwrap();
-        let de_all = bincode::deserialize(&ser_all).unwrap();
+        let ser_all = rmp_serde::to_vec(&all).unwrap();
+        let de_all = rmp_serde::from_slice(&ser_all).unwrap();
         assert_eq!(all, de_all);
     }
 }

--- a/rbx_types/src/physical_properties.rs
+++ b/rbx_types/src/physical_properties.rs
@@ -256,8 +256,8 @@ mod serde_test {
     fn bincode_default() {
         let default = PhysicalProperties::Default;
 
-        let ser = bincode::serialize(&default).unwrap();
-        let de: PhysicalProperties = bincode::deserialize(&ser).unwrap();
+        let ser = rmp_serde::to_vec(&default).unwrap();
+        let de: PhysicalProperties = rmp_serde::from_slice(&ser).unwrap();
 
         assert_eq!(de, default);
     }
@@ -273,8 +273,8 @@ mod serde_test {
             acoustic_absorption: 1.0,
         });
 
-        let ser = bincode::serialize(&custom).unwrap();
-        let de: PhysicalProperties = bincode::deserialize(&ser).unwrap();
+        let ser = rmp_serde::to_vec(&custom).unwrap();
+        let de: PhysicalProperties = rmp_serde::from_slice(&ser).unwrap();
 
         assert_eq!(de, custom);
     }

--- a/rbx_types/src/referent.rs
+++ b/rbx_types/src/referent.rs
@@ -196,8 +196,8 @@ mod serde_test {
     fn non_human() {
         let value = Ref::new();
 
-        let ser = bincode::serialize(&value).unwrap();
-        let de = bincode::deserialize(&ser).unwrap();
+        let ser = rmp_serde::to_vec(&value).unwrap();
+        let de = rmp_serde::from_slice(&ser).unwrap();
 
         assert_eq!(value, de);
     }

--- a/rbx_types/src/shared_string.rs
+++ b/rbx_types/src/shared_string.rs
@@ -322,7 +322,7 @@ mod test {
 
         let sstr = SharedString::new(b"a test string".to_vec());
         let data = sstr.data();
-        let serialized = bincode::serialize(&sstr).unwrap();
+        let serialized = rmp_serde::to_vec(&sstr).unwrap();
 
         // Write the length of the string as little-endian u64 followed by the
         // bytes of the string. This is analoglous to how bincode does.
@@ -334,7 +334,7 @@ mod test {
 
         assert_eq!(serialized, expected);
 
-        let deserialized: SharedString = bincode::deserialize(&serialized).unwrap();
+        let deserialized: SharedString = rmp_serde::from_slice(&serialized).unwrap();
 
         assert_eq!(sstr, deserialized);
     }
@@ -354,12 +354,12 @@ mod test {
 
         assert_eq!(net, de_net_1);
 
-        let ser_sstr_2 = bincode::serialize(&sstr).unwrap();
-        let ser_net_2 = bincode::serialize(&net).unwrap();
+        let ser_sstr_2 = rmp_serde::to_vec(&sstr).unwrap();
+        let ser_net_2 = rmp_serde::to_vec(&net).unwrap();
 
         assert_eq!(ser_sstr_2, ser_net_2);
 
-        let de_net_2: NetAssetRef = bincode::deserialize(&ser_net_2).unwrap();
+        let de_net_2: NetAssetRef = rmp_serde::from_slice(&ser_net_2).unwrap();
 
         assert_eq!(net, de_net_2);
     }

--- a/rbx_types/src/shared_string.rs
+++ b/rbx_types/src/shared_string.rs
@@ -318,17 +318,16 @@ mod test {
     #[cfg(feature = "serde")]
     #[test]
     fn serde_non_human() {
-        use std::{io::Write, mem};
+        use std::io::Write;
 
         let sstr = SharedString::new(b"a test string".to_vec());
         let data = sstr.data();
         let serialized = rmp_serde::to_vec(&sstr).unwrap();
 
-        // Write the length of the string as little-endian u64 followed by the
-        // bytes of the string. This is analoglous to how bincode does.
-        let mut expected = Vec::with_capacity(mem::size_of::<u64>() + data.len());
+        // rmp_serde uses special markers for short arrays
+        let mut expected = Vec::with_capacity(1 + data.len());
         expected
-            .write_all(&(data.len() as u64).to_le_bytes())
+            .write_all(&[rmp::Marker::FixArray(data.len() as u8).to_u8()])
             .unwrap();
         expected.write_all(data).unwrap();
 

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -258,8 +258,8 @@ mod test {
     #[test]
     fn not_human_roundtrip() {
         let uid = UniqueId::new(0x1337_0000, 0xfaca_de00, 0x1020_3040_5060_7080);
-        let ser = bincode::serialize(&uid).unwrap();
-        let de: UniqueId = bincode::deserialize(&ser).unwrap();
+        let ser = rmp_serde::to_vec(&uid).unwrap();
+        let de: UniqueId = rmp_serde::from_slice(&ser).unwrap();
 
         // Bincode prefixes vectors with the vector's length as a little-endian `u64`
         assert_eq!(ser[0..8].as_ref(), 16_u64.to_le_bytes());

--- a/rbx_types/src/unique_id.rs
+++ b/rbx_types/src/unique_id.rs
@@ -261,11 +261,12 @@ mod test {
         let ser = rmp_serde::to_vec(&uid).unwrap();
         let de: UniqueId = rmp_serde::from_slice(&ser).unwrap();
 
-        // Bincode prefixes vectors with the vector's length as a little-endian `u64`
-        assert_eq!(ser[0..8].as_ref(), 16_u64.to_le_bytes());
+        // rmp_serde uses a marker to specify the size of the length
+        assert_eq!(ser[0], rmp::Marker::Bin8.to_u8());
+        assert_eq!(ser[1], 16);
 
         assert_eq!(
-            ser[8..].as_ref(),
+            ser[2..].as_ref(),
             b"\x10\x20\x30\x40\x50\x60\x70\x80\xfa\xca\xde\x00\x13\x37\x00\x00"
         );
         assert_eq!(de, uid);

--- a/rbx_types/src/variant.rs
+++ b/rbx_types/src/variant.rs
@@ -160,9 +160,9 @@ mod serde_test {
     fn non_human() {
         let vec2 = Variant::Vector2(Vector2::new(5.0, 7.0));
 
-        let ser = bincode::serialize(&vec2).unwrap();
+        let ser = rmp_serde::to_vec(&vec2).unwrap();
 
-        let de: Variant = bincode::deserialize(&ser).unwrap();
+        let de: Variant = rmp_serde::from_slice(&ser).unwrap();
         assert_eq!(de, vec2);
     }
 }


### PR DESCRIPTION
I tried to update this and it bit me with bincode 3.0.0.

Notes:
- This is a dev dependency
- The non-numan-readable tests for UniqueId and SharedString were modified since they were hardcoded to the bincode spec.
- rmp is also added as a direct dev-dependency due to using the marker values for array lengths