### PR TITLE
Move header.rs out of deserializer

### DIFF
--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -6,10 +6,6 @@ use rbx_reflection::{
 
 use crate::chunk::ChunkBuilder;
 
-pub static FILE_MAGIC_HEADER: &[u8] = b"<roblox!";
-pub static FILE_SIGNATURE: &[u8] = b"\x89\xff\x0d\x0a\x1a\x0a";
-pub const FILE_VERSION: u16 = 0;
-
 pub struct ReadInterleavedBufferIter<const N: usize> {
     buffer: Vec<u8>,
     index: usize,

--- a/rbx_binary/src/deserializer/error.rs
+++ b/rbx_binary/src/deserializer/error.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use thiserror::Error;
 
-use crate::types::InvalidTypeError;
+use crate::{header::HeaderError, types::InvalidTypeError};
 
 /// Represents an error that occurred during deserialization.
 #[derive(Debug, Error)]
@@ -27,11 +27,8 @@ pub(crate) enum InnerError {
         source: io::Error,
     },
 
-    #[error("Invalid file header")]
-    BadHeader,
-
-    #[error("Unknown file version {version}. Known versions are: 0")]
-    UnknownFileVersion { version: u16 },
+    #[error("Header error: {0}")]
+    Header(#[from] HeaderError),
 
     #[error("Unknown version {version} for chunk {chunk_name}")]
     UnknownChunkVersion {

--- a/rbx_binary/src/deserializer/error.rs
+++ b/rbx_binary/src/deserializer/error.rs
@@ -18,6 +18,17 @@ impl From<InnerError> for Error {
         }
     }
 }
+impl From<HeaderError> for InnerError {
+    fn from(error: HeaderError) -> Self {
+        match error {
+            HeaderError::Io { source } => InnerError::Io { source },
+            HeaderError::BadHeader => InnerError::BadHeader,
+            HeaderError::UnknownFileVersion { version } => {
+                InnerError::UnknownFileVersion { version }
+            }
+        }
+    }
+}
 
 #[derive(Debug, Error)]
 pub(crate) enum InnerError {
@@ -27,8 +38,11 @@ pub(crate) enum InnerError {
         source: io::Error,
     },
 
-    #[error("Header error: {0}")]
-    Header(#[from] HeaderError),
+    #[error("Invalid file header")]
+    BadHeader,
+
+    #[error("Unknown file version {version}. Known versions are: 0")]
+    UnknownFileVersion { version: u16 },
 
     #[error("Unknown version {version} for chunk {chunk_name}")]
     UnknownChunkVersion {

--- a/rbx_binary/src/deserializer/mod.rs
+++ b/rbx_binary/src/deserializer/mod.rs
@@ -1,5 +1,4 @@
 mod error;
-mod header;
 mod state;
 
 use std::{io::Read, str};
@@ -8,9 +7,6 @@ use rbx_dom_weak::WeakDom;
 use rbx_reflection::ReflectionDatabase;
 
 use self::state::DeserializerState;
-
-#[cfg(any(test, feature = "unstable_text_format"))]
-pub(crate) use self::header::FileHeader;
 
 pub use self::error::Error;
 

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -17,10 +17,11 @@ use rbx_reflection::{ClassDescriptor, PropertyKind, PropertySerialization, Refle
 use crate::{
     chunk::Chunk,
     core::{find_property_descriptors, RbxReadExt},
+    header::FileHeader,
     types::Type,
 };
 
-use super::{error::InnerError, header::FileHeader, Deserializer};
+use super::{error::InnerError, Deserializer};
 
 pub(super) struct DeserializerState<'db, R> {
     /// The user-provided configuration that we should use.
@@ -217,11 +218,11 @@ impl<'db, R: Read> DeserializerState<'db, R> {
 
         let header = FileHeader::decode(&mut input)?;
 
-        let type_infos = HashMap::with_capacity(header.num_types as usize);
-        let instance_key_by_ref = HashMap::with_capacity(1 + header.num_instances as usize);
-        let instances = Vec::with_capacity(1 + header.num_instances as usize);
+        let type_infos = HashMap::with_capacity(header.num_types() as usize);
+        let instance_key_by_ref = HashMap::with_capacity(1 + header.num_instances() as usize);
+        let instances = Vec::with_capacity(1 + header.num_instances() as usize);
 
-        tree.reserve(header.num_instances as usize);
+        tree.reserve(header.num_instances() as usize);
 
         Ok(DeserializerState {
             deserializer,

--- a/rbx_binary/src/header.rs
+++ b/rbx_binary/src/header.rs
@@ -1,41 +1,55 @@
 use std::io::Read;
+use thiserror::Error;
 
 use crate::core::{RbxReadExt, FILE_MAGIC_HEADER, FILE_SIGNATURE, FILE_VERSION};
 
-use super::error::InnerError;
+#[derive(Debug, Error)]
+pub enum HeaderError {
+    #[error(transparent)]
+    Io {
+        #[from]
+        source: std::io::Error,
+    },
+
+    #[error("Invalid file header")]
+    BadHeader,
+
+    #[error("Unknown file version {version}. Known versions are: 0")]
+    UnknownFileVersion { version: u16 },
+}
 
 /// All the information contained in the header before any chunks are read from
 /// the file.
-pub(crate) struct FileHeader {
+pub struct FileHeader {
     /// The number of instance types (represented for us as `TypeInfo`) that are
     /// in this file. Generally useful to pre-size some containers before
     /// reading the file.
-    pub(crate) num_types: u32,
+    num_types: u32,
 
     /// The total number of instances described by this file.
-    pub(crate) num_instances: u32,
+    num_instances: u32,
 }
 
 impl FileHeader {
-    pub(crate) fn decode<R: Read>(mut source: R) -> Result<Self, InnerError> {
+    pub fn decode<R: Read>(mut source: R) -> Result<Self, HeaderError> {
         let mut magic_header = [0; 8];
         source.read_exact(&mut magic_header)?;
 
         if magic_header != FILE_MAGIC_HEADER {
-            return Err(InnerError::BadHeader);
+            return Err(HeaderError::BadHeader);
         }
 
         let mut signature = [0; 6];
         source.read_exact(&mut signature)?;
 
         if signature != FILE_SIGNATURE {
-            return Err(InnerError::BadHeader);
+            return Err(HeaderError::BadHeader);
         }
 
         let version = source.read_le_u16()?;
 
         if version != FILE_VERSION {
-            return Err(InnerError::UnknownFileVersion { version });
+            return Err(HeaderError::UnknownFileVersion { version });
         }
 
         let num_types = source.read_le_u32()?;
@@ -45,12 +59,18 @@ impl FileHeader {
         source.read_exact(&mut reserved)?;
 
         if reserved != [0; 8] {
-            return Err(InnerError::BadHeader);
+            return Err(HeaderError::BadHeader);
         }
 
         Ok(Self {
             num_types,
             num_instances,
         })
+    }
+    pub const fn num_types(&self) -> u32 {
+        self.num_types
+    }
+    pub const fn num_instances(&self) -> u32 {
+        self.num_instances
     }
 }

--- a/rbx_binary/src/header.rs
+++ b/rbx_binary/src/header.rs
@@ -1,7 +1,11 @@
 use std::io::Read;
 use thiserror::Error;
 
-use crate::core::{RbxReadExt, FILE_MAGIC_HEADER, FILE_SIGNATURE, FILE_VERSION};
+use crate::core::RbxReadExt;
+
+pub static FILE_MAGIC_HEADER: [u8; 8] = *b"<roblox!";
+pub static FILE_SIGNATURE: [u8; 6] = *b"\x89\xff\x0d\x0a\x1a\x0a";
+pub const FILE_VERSION: u16 = 0;
 
 #[derive(Debug, Error)]
 pub enum HeaderError {

--- a/rbx_binary/src/lib.rs
+++ b/rbx_binary/src/lib.rs
@@ -56,6 +56,7 @@ rbx_binary::to_writer(output, &dom, &[dom.root_ref()])?;
 mod chunk;
 mod core;
 mod deserializer;
+mod header;
 mod serializer;
 mod types;
 

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -23,10 +23,8 @@ use rbx_reflection::{
 
 use crate::{
     chunk::ChunkBuilder,
-    core::{
-        find_property_descriptors, PropertyDescriptors, RbxWriteExt, FILE_MAGIC_HEADER,
-        FILE_SIGNATURE, FILE_VERSION,
-    },
+    core::{find_property_descriptors, PropertyDescriptors, RbxWriteExt},
+    header::{FILE_MAGIC_HEADER, FILE_SIGNATURE, FILE_VERSION},
     types::Type,
     Serializer,
 };
@@ -706,8 +704,8 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
     pub fn write_header(&mut self) -> Result<(), InnerError> {
         log::trace!("Writing header");
 
-        self.output.write_all(FILE_MAGIC_HEADER)?;
-        self.output.write_all(FILE_SIGNATURE)?;
+        self.output.write_all(&FILE_MAGIC_HEADER)?;
+        self.output.write_all(&FILE_SIGNATURE)?;
         self.output.write_le_u16(FILE_VERSION)?;
 
         self.output

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -19,7 +19,7 @@ use rbx_dom_weak::types::{
 };
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 
-use crate::{chunk::Chunk, core::RbxReadExt, deserializer::FileHeader, types::Type};
+use crate::{chunk::Chunk, core::RbxReadExt, header::FileHeader, types::Type};
 
 #[derive(Debug, Serialize)]
 pub struct DecodedModel {
@@ -66,8 +66,8 @@ impl DecodedModel {
         }
 
         DecodedModel {
-            num_types: header.num_types,
-            num_instances: header.num_instances,
+            num_types: header.num_types(),
+            num_instances: header.num_instances(),
             chunks,
         }
     }


### PR DESCRIPTION
header.rs is weirdly located.  Move it to a more sensible location.

- header.rs gets its own HeaderError
- FileHeader fields are made private with getters
- Header constants are moved into header.rs