### PR TITLE
Fix silent corruption in OptionalCFrame deserialize

### DIFF
--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1319,15 +1319,17 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         .map(|((x, y), z)| Vector3::new(x, y, z))
                         .zip(rotations)
                         .map(|(position, rotation)| {
-                            if chunk.read_u8().ok()? == 0 {
-                                None
-                            } else {
-                                Some(CFrame::new(position, rotation))
-                            }
+                            chunk.read_u8().map(|byte| {
+                                if byte == 0 {
+                                    None
+                                } else {
+                                    Some(CFrame::new(position, rotation))
+                                }
+                            })
                         });
 
                     for (value, instance) in values.zip(instances) {
-                        add_property(instance, &property, value.into());
+                        add_property(instance, &property, value?.into());
                     }
                 }
                 invalid_type => {


### PR DESCRIPTION
If an io error occurs during this part of OptionalCFrame decoding, it will silently corrupt the output: an io error of any kind will produce a None optional CFrame, but decoding should bail. 

This has synergy with #530, the read_u8 within the iterator can be replaced with a single read_slice() outside the iterator.