### PR TITLE
Add decoding support for Tags stored in SharedString index

### DIFF
--- a/docs/binary-strings.md
+++ b/docs/binary-strings.md
@@ -72,4 +72,6 @@ As an example, an `Instance` that had the tags `Hello`, `from`, and `Rojo` would
 
 `48 65 6C 6C 6F 00 66 72 6F 6D 00 52 6F 6A 6F`
 
+The `Tags` blob may be stored in the SharedString index. Instances with identical sets of Tags share the same SharedString entry.
+
 [CollectionService]: https://create.roblox.com/docs/reference/engine/classes/CollectionService

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,6 +26,12 @@ In the XML format, `QDir` and `QFont` properties are deliberately not supported 
 
 Properties of these types will not raise parsing errors if encountered, but if Roblox ever decides to use them for user-facing files, support would need to be added.
 
+### Tags in the SharedString Index
+
+`rbx-binary` and `rbx-xml` normally serialize `Tags` as a `String`-like property (either a `String` or `BinaryString` respectively). However, files produced by Roblox have [begun storing `Tags` in the `SharedString` index](https://github.com/rojo-rbx/rbx-dom/pull/634) instead, referencing a shared blob by index rather than embedding the data directly. This is presumably a size optimization, as it lets instances with identical tags deduplicate to a single shared blob.
+
+`rbx-binary` and `rbx-xml` decode `Tags` stored this way, but do not encode them this way, so round-tripping such a file moves the tags back inline as a `String`-like property. Any `String` or `BinaryString` property could technically be stored in the `SharedString` index using this same pattern, but `Tags` is the only case observe in the wild so decoding support is currently limited to it. If Roblox begins doing this for other properties, decoding support for this will need to be added as well.
+
 ## XML
 
 Issues of this category would impact the usage of `rbx-xml` if Roblox makes a breaking change.
@@ -79,12 +85,6 @@ This is not expected to cause any compatibility issues in the future, but it is 
 Roblox has serialized invalid `PROP` chunks in the past when introducing new property values. Most notably, this occured when the `Optional` type was first introduced in the form of `OptionalCoordinateFrame`.
 
 This incompatibility cannot be anticipated but some flexibility can be coded into deserialization to prevent this from causing serious error.
-
-### Tags in the SharedString Index
-
-`rbx-binary` normally serializes `Tags` as a `String`-typed property, storing the null-delimited list of tags inline in the `PROP` chunk. However, files downloaded from Roblox's CDN endpoints (`asset-delivery-api` and `assetdelivery`) [have been observed storing `Tags` in the `SharedString` index](https://github.com/rojo-rbx/rbx-dom/pull/634) instead, referencing a shared blob by index rather than embedding the data directly. This is presumably a size optimization, as it lets instances with identical tags deduplicate to a single shared blob.
-
-`rbx-binary` decodes `Tags` stored this way but does not encode them this way, so round-tripping such a file moves the tags back inline as a `String`-typed property. Any `String` or `BinaryString` property could technically be stored in the `SharedString` index using this same pattern, but `Tags` is the only case observed in the wild, so decoding support is currently limited to it. If Roblox begins doing this for other properties, decoding support for those will need to be added as well.
 
 ### Arbitrary Changes
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -80,6 +80,12 @@ Roblox has serialized invalid `PROP` chunks in the past when introducing new pro
 
 This incompatibility cannot be anticipated but some flexibility can be coded into deserialization to prevent this from causing serious error.
 
+### Tags in the SharedString Index
+
+`rbx-binary` normally serializes `Tags` as a `String`-typed property, storing the null-delimited list of tags inline in the `PROP` chunk. However, files downloaded from Roblox's CDN endpoints (`asset-delivery-api` and `assetdelivery`) [have been observed storing `Tags` in the `SharedString` index](https://github.com/rojo-rbx/rbx-dom/pull/634) instead, referencing a shared blob by index rather than embedding the data directly. This is presumably a size optimization, as it lets instances with identical tags deduplicate to a single shared blob.
+
+`rbx-binary` decodes `Tags` stored this way but does not encode them this way, so round-tripping such a file moves the tags back inline as a `String`-typed property. Any `String` or `BinaryString` property could technically be stored in the `SharedString` index using this same pattern, but `Tags` is the only case observed in the wild, so decoding support is currently limited to it. If Roblox begins doing this for other properties, decoding support for those will need to be added as well.
+
 ### Arbitrary Changes
 
 Despite there being a version field present in the format's header, Roblox has made breaking changes without incrementing it in the past. Most notably, this includes support for `zstd` compression in chunks, which has no indication at all beyond the first `4` bytes of a chunk's body being a specific magic number.

--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -4,10 +4,12 @@
 * Changed serializer to not panic when Instance.properties contains Name entry. ([#596])
 * Used exact comparison when determining basic rotation IDs to exactly preserve CFrame inputs. ([#601])
 * Added support for one-to-many property migrations. ([#612])
+* Added support for reading Tags from a SharedString ([#634])
 
 [#596]: https://github.com/rojo-rbx/rbx-dom/pull/596
 [#601]: https://github.com/rojo-rbx/rbx-dom/pull/601
 [#612]: https://github.com/rojo-rbx/rbx-dom/pull/612
+[#634]: https://github.com/rojo-rbx/rbx-dom/pull/634
 
 ## 2.0.1 (2025-11-27)
 * Improved performance in several ways. Serializing in particular has been dramatically improved.

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1241,7 +1241,9 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         add_property(instance, &property, net_asset.into());
                     }
                 }
-                // On 2026-06-30, Roblox began storing Tags in the SharedString index.
+                // On 2026-06-30, Roblox began storing Tags in the SharedString index, but
+                // only those obtained from Roblox CDN / Open Cloud endpoints. At the time
+                // of writing, Roblox Studio still writes them inline.
                 VariantType::Tags => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1241,9 +1241,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         add_property(instance, &property, net_asset.into());
                     }
                 }
-                // On 2026-06-30, Roblox began storing Tags in the SharedString index, but
-                // only those obtained from Roblox CDN / Open Cloud endpoints. At the time
-                // of writing, Roblox Studio still writes them inline.
+                // On 2026-06-30, Roblox began storing Tags in the SharedString index.
                 VariantType::Tags => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1241,6 +1241,7 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         add_property(instance, &property, net_asset.into());
                     }
                 }
+                // On 2026-06-30, Roblox began storing Tags in the SharedString index.
                 VariantType::Tags => {
                     let values = chunk.read_interleaved_u32_array(instances.len())?;
 

--- a/rbx_binary/src/deserializer/state.rs
+++ b/rbx_binary/src/deserializer/state.rs
@@ -1241,6 +1241,34 @@ rbx-dom may require changes to fully support this property. Please open an issue
                         add_property(instance, &property, net_asset.into());
                     }
                 }
+                VariantType::Tags => {
+                    let values = chunk.read_interleaved_u32_array(instances.len())?;
+
+                    for (value, instance) in values.zip(instances) {
+                        let tags_shared_string = self
+                            .shared_strings
+                            .get(value as usize)
+                            .ok_or_else(|| InnerError::InvalidPropData {
+                                type_name: type_name.to_string(),
+                                prop_name: prop_name.clone(),
+                                valid_value: "a valid Tags SharedString index",
+                                actual_value: format!("{value:?}"),
+                            })?;
+
+                        add_property(
+                            instance,
+                            &property,
+                            Tags::decode(tags_shared_string.data())
+                                .map_err(|_| InnerError::InvalidPropData {
+                                    type_name: type_name.to_string(),
+                                    prop_name: prop_name.clone(),
+                                    valid_value: "a list of valid null-delimited UTF-8 strings",
+                                    actual_value: "invalid UTF-8".to_string(),
+                                })?
+                                .into(),
+                        );
+                    }
+                }
                 invalid_type => {
                     return Err(InnerError::PropTypeMismatch {
                         type_name: type_name.to_string(),

--- a/rbx_binary/src/tests/places.rs
+++ b/rbx_binary/src/tests/places.rs
@@ -26,4 +26,5 @@ macro_rules! place_tests {
 
 place_tests! {
     baseplate_566,
+    baseplate_727_with_tags,
 }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__baseplate-727-with-tags__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__baseplate-727-with-tags__decoded.snap
@@ -1,0 +1,3656 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Workspace
+  class: Workspace
+  properties:
+    AirDensity:
+      Float32: 0.0012
+    AirTurbulenceIntensity:
+      Float32: 0
+    AllowThirdPartySales:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    AuthorityMode:
+      Enum: 1
+    AvatarUnificationMode:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    ClientAnimatorThrottling:
+      Enum: 0
+    CollisionGroupData:
+      BinaryString: AQEABP////8HRGVmYXVsdA==
+    CurrentCamera: referent-1
+    DistributedGameTime:
+      Float64: 0
+    EnableSLIMAvatars:
+      Enum: 0
+    ExplicitAutoJoints:
+      Bool: true
+    FallHeightEnabled:
+      Bool: true
+    FallenPartsDestroyHeight:
+      Float32: -500
+    FluidForces:
+      Enum: 0
+    GlobalWind:
+      Vector3:
+        - 0
+        - 0
+        - 0
+    Gravity:
+      Float32: 196.2
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IKControlConstraintSupport:
+      Enum: 0
+    ImprovedAnimationConstraint:
+      Enum: 0
+    ImprovedPhysicsReplication:
+      Enum: 0
+    LayeredClothingCacheOptimizations:
+      Enum: 0
+    LevelOfDetail:
+      Enum: 0
+    LuauTypeCheckMode:
+      Enum: 0
+    MeshPartHeadsAndAccessories:
+      Enum: 0
+    MeshStreamingAndImprovedLods:
+      Enum: 0
+    ModelMeshCFrame:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Vector3:
+        - 0
+        - 0
+        - 0
+    ModelStreamingBehavior:
+      Enum: 0
+    ModelStreamingMode:
+      Enum: 0
+    NeedsPivotMigration:
+      Bool: false
+    NextGenerationReplication:
+      Enum: 0
+    PathfindingUseImprovedSearch:
+      Enum: 0
+    PhysicsSteppingMethod:
+      Enum: 0
+    PlayerCharacterDestroyBehavior:
+      Enum: 0
+    PlayerScriptsUseInputActionSystem:
+      Enum: 0
+    PrimalPhysicsSolver:
+      Enum: 0
+    PrimaryPart: "null"
+    RejectCharacterDeletions:
+      Enum: 0
+    RenderingCacheOptimizations:
+      Enum: 0
+    ReplicateInstanceDestroySetting:
+      Enum: 0
+    Retargeting:
+      Enum: 0
+    Sandboxed:
+      Bool: false
+    SandboxedInstanceMode:
+      Enum: 0
+    Scale:
+      Float32: 1
+    SignalBehavior:
+      Enum: 2
+    SlimHash:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    SourceAssetId:
+      Int64: -1
+    StreamOutBehavior:
+      Enum: 2
+    StreamingEnabled:
+      Bool: true
+    StreamingIntegrityMode:
+      Enum: 3
+    StreamingMinRadius:
+      Int32: 64
+    StreamingTargetRadius:
+      Int32: 1024
+    Tags:
+      Tags:
+        - hmmmm
+    TerrainWeldsFixed:
+      Bool: true
+    TouchEventsUseCollisionGroups:
+      Enum: 0
+    TouchesUseCollisionGroups:
+      Bool: false
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000002
+    UseFixedSimulation:
+      Enum: 0
+    UseNewLuauTypeSolver:
+      Enum: 2
+    ValidateEnabledProximityPrompt:
+      Enum: 0
+    WorldPivotData:
+      OptionalCFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+  children:
+    - referent: referent-1
+      name: Camera
+      class: Camera
+      properties:
+        Attributes:
+          Attributes: {}
+        CFrame:
+          CFrame:
+            position:
+              - -19.696095
+              - 14.091624
+              - -19.303886
+            orientation:
+              - - -0.7061509
+                - 0.31296578
+                - -0.6351404
+              - - 0.000000014901163
+                - 0.8970132
+                - 0.44200373
+              - - 0.7080614
+                - 0.31212133
+                - -0.63342667
+        CameraSubject: "null"
+        CameraType:
+          Enum: 0
+        Capabilities:
+          SecurityCapabilities: 0
+        FieldOfView:
+          Float32: 70
+        FieldOfViewMode:
+          Enum: 0
+        Focus:
+          CFrame:
+            position:
+              - -18.425814
+              - 13.207617
+              - -18.037033
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        HeadLocked:
+          Bool: true
+        HeadScale:
+          Float32: 1
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b8
+        VRTiltAndRollEnabled:
+          Bool: false
+      children: []
+    - referent: referent-2
+      name: Baseplate
+      class: Part
+      properties:
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - -8
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 91
+            - 91
+            - 91
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        EnableFluidForces:
+          Bool: true
+        FormFactor:
+          Enum: 0
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 2048
+            - 16
+            - 2048
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags:
+            - atag
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b9
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-3
+          name: Texture
+          class: Texture
+          properties:
+            Attributes:
+              Attributes: {}
+            AutoLocalize:
+              Bool: true
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 0
+                - 0
+                - 0
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            OffsetStudsU:
+              Float32: 0
+            OffsetStudsV:
+              Float32: 0
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            StudsPerTileU:
+              Float32: 8
+            StudsPerTileV:
+              Float32: 8
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxassetid://6372755229"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0.8
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ba
+            ZIndex:
+              Int32: 1
+          children: []
+    - referent: referent-4
+      name: Terrain
+      class: Terrain
+      properties:
+        AcquisitionMethod:
+          Enum: 0
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 4
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 163
+            - 162
+            - 165
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        Decoration:
+          Bool: true
+        EnableFluidForces:
+          Bool: true
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        GrassLength:
+          Float32: 0.7
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialColors:
+          MaterialColors:
+            Grass:
+              - 111
+              - 126
+              - 62
+            Slate:
+              - 88
+              - 89
+              - 86
+            Concrete:
+              - 152
+              - 152
+              - 152
+            Brick:
+              - 138
+              - 97
+              - 73
+            Sand:
+              - 207
+              - 203
+              - 167
+            WoodPlanks:
+              - 172
+              - 148
+              - 108
+            Rock:
+              - 99
+              - 100
+              - 102
+            Glacier:
+              - 221
+              - 228
+              - 229
+            Snow:
+              - 235
+              - 253
+              - 255
+            Sandstone:
+              - 148
+              - 124
+              - 95
+            Mud:
+              - 121
+              - 112
+              - 98
+            Basalt:
+              - 75
+              - 74
+              - 74
+            Ground:
+              - 140
+              - 130
+              - 104
+            CrackedLava:
+              - 255
+              - 24
+              - 67
+            Asphalt:
+              - 80
+              - 84
+              - 84
+            Cobblestone:
+              - 134
+              - 134
+              - 118
+            Ice:
+              - 204
+              - 210
+              - 223
+            LeafyGrass:
+              - 106
+              - 134
+              - 64
+            Salt:
+              - 255
+              - 255
+              - 254
+            Limestone:
+              - 255
+              - 243
+              - 192
+            Pavement:
+              - 143
+              - 144
+              - 135
+        MaterialVariant:
+          String: ""
+        Materials:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicsGrid:
+          BinaryString: AgMAAAAAAAAAAAAAAAA=
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Size:
+          Vector3:
+            - 2044
+            - 252
+            - 2044
+        SmoothGrid:
+          BinaryString: AQU=
+        SmoothVoxelsUpgraded:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 3
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bb
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        WaterColor:
+          Color3:
+            - 0.04705883
+            - 0.32941177
+            - 0.36078432
+        WaterReflectance:
+          Float32: 1
+        WaterTransparency:
+          Float32: 0.3
+        WaterWaveSize:
+          Float32: 0.15
+        WaterWaveSpeed:
+          Float32: 10
+      children: []
+    - referent: referent-5
+      name: SpawnLocation
+      class: SpawnLocation
+      properties:
+        AllowTeamChangeOnTouch:
+          Bool: false
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - 0.5
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 163
+            - 162
+            - 165
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        Duration:
+          Int32: 0
+        EnableFluidForces:
+          Bool: true
+        Enabled:
+          Bool: true
+        FormFactor:
+          Enum: 1
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        Neutral:
+          Bool: true
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 12
+            - 1
+            - 12
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TeamColor:
+          BrickColor: 194
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bc
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-6
+          name: Decal
+          class: Decal
+          properties:
+            Attributes:
+              Attributes: {}
+            AutoLocalize:
+              Bool: true
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxasset://textures/SpawnLocation.png"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bd
+            ZIndex:
+              Int32: 1
+          children: []
+    - referent: referent-7
+      name: Baseplate
+      class: Part
+      properties:
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - -8
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 91
+            - 91
+            - 91
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        EnableFluidForces:
+          Bool: true
+        FormFactor:
+          Enum: 0
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b9
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 2048
+            - 16
+            - 2048
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags:
+            - atag
+            - anothertag
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000008b3
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-8
+          name: Texture
+          class: Texture
+          properties:
+            Attributes:
+              Attributes: {}
+            AutoLocalize:
+              Bool: true
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 0
+                - 0
+                - 0
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ba
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            OffsetStudsU:
+              Float32: 0
+            OffsetStudsV:
+              Float32: 0
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            StudsPerTileU:
+              Float32: 8
+            StudsPerTileV:
+              Float32: 8
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxassetid://6372755229"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0.8
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000008b4
+            ZIndex:
+              Int32: 1
+          children: []
+- referent: referent-9
+  name: Instance
+  class: TimerService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000338
+  children: []
+- referent: referent-10
+  name: SoundService
+  class: SoundService
+  properties:
+    AcousticSimulationEnabled:
+      Bool: false
+    AmbientReverb:
+      Enum: 0
+    Attributes:
+      Attributes: {}
+    AudioApiByDefault:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterSoundsUseNewApi:
+      Enum: 0
+    DefaultListenerLocation:
+      Enum: 3
+    DiffractionEnabled:
+      Bool: true
+    DistanceFactor:
+      Float32: 3.33
+    DopplerScale:
+      Float32: 1
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsNewExpForAudioApiByDefault:
+      Bool: false
+    ListenerCFrame:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+    ListenerObject: "null"
+    ListenerType:
+      Enum: 0
+    OcclusionEnabled:
+      Bool: true
+    RespectFilteringEnabled:
+      Bool: true
+    ReverbEnabled:
+      Bool: true
+    RolloffScale:
+      Float32: 1
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000033a
+    VolumetricAudio:
+      Enum: 1
+  children: []
+- referent: referent-11
+  name: VideoCaptureService
+  class: VideoCaptureService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000346
+  children: []
+- referent: referent-12
+  name: NonReplicatedCSGDictionaryService
+  class: NonReplicatedCSGDictionaryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000347
+  children: []
+- referent: referent-13
+  name: CSGDictionaryService
+  class: CSGDictionaryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000348
+  children: []
+- referent: referent-14
+  name: Chat
+  class: Chat
+  properties:
+    Attributes:
+      Attributes: {}
+    BubbleChatEnabled:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsAutoMigrated:
+      Bool: true
+    LoadDefaultChat:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000034e
+  children: []
+- referent: referent-15
+  name: Players
+  class: Players
+  properties:
+    Attributes:
+      Attributes: {}
+    BanningEnabled:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterAutoLoads:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxPlayers:
+      Int32: 60
+    PreferredPlayers:
+      Int32: 60
+    RespawnTime:
+      Float32: 3
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000350
+    UseStrafingAnimations:
+      Bool: false
+  children: []
+- referent: referent-16
+  name: ReplicatedFirst
+  class: ReplicatedFirst
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000353
+  children: []
+- referent: referent-17
+  name: TweenService
+  class: TweenService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000355
+  children: []
+- referent: referent-18
+  name: MaterialService
+  class: MaterialService
+  properties:
+    AsphaltName:
+      String: Asphalt
+    Attributes:
+      Attributes: {}
+    BasaltName:
+      String: Basalt
+    BrickName:
+      String: Brick
+    Capabilities:
+      SecurityCapabilities: 0
+    CardboardName:
+      String: Cardboard
+    CarpetName:
+      String: Carpet
+    CeramicTilesName:
+      String: CeramicTiles
+    ClayRoofTilesName:
+      String: ClayRoofTiles
+    CobblestoneName:
+      String: Cobblestone
+    ConcreteName:
+      String: Concrete
+    CorrodedMetalName:
+      String: CorrodedMetal
+    CrackedLavaName:
+      String: CrackedLava
+    DiamondPlateName:
+      String: DiamondPlate
+    FabricName:
+      String: Fabric
+    FoilName:
+      String: Foil
+    GlacierName:
+      String: Glacier
+    GraniteName:
+      String: Granite
+    GrassName:
+      String: Grass
+    GroundName:
+      String: Ground
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IceName:
+      String: Ice
+    LeafyGrassName:
+      String: LeafyGrass
+    LeatherName:
+      String: Leather
+    LimestoneName:
+      String: Limestone
+    MarbleName:
+      String: Marble
+    MetalName:
+      String: Metal
+    MudName:
+      String: Mud
+    PavementName:
+      String: Pavement
+    PebbleName:
+      String: Pebble
+    PlasterName:
+      String: Plaster
+    PlasticName:
+      String: Plastic
+    RockName:
+      String: Rock
+    RoofShinglesName:
+      String: RoofShingles
+    RubberName:
+      String: Rubber
+    SaltName:
+      String: Salt
+    SandName:
+      String: Sand
+    Sandboxed:
+      Bool: false
+    SandstoneName:
+      String: Sandstone
+    SlateName:
+      String: Slate
+    SmoothPlasticName:
+      String: SmoothPlastic
+    SnowName:
+      String: Snow
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000356
+    Use2022MaterialsXml:
+      Bool: true
+    WoodName:
+      String: Wood
+    WoodPlanksName:
+      String: WoodPlanks
+  children: []
+- referent: referent-19
+  name: TextChatService
+  class: TextChatService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    ChatTranslationFTUXShown:
+      Bool: true
+    ChatTranslationToggleEnabled:
+      Bool: false
+    ChatVersion:
+      Enum: 1
+    CreateDefaultCommands:
+      Bool: true
+    CreateDefaultTextChannels:
+      Bool: true
+    EnableProtectedChat:
+      Enum: 0
+    HasSeenDeprecationDialog:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsLegacyChatDisabled:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000357
+  children:
+    - referent: referent-20
+      name: ChatWindowConfiguration
+      class: ChatWindowConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0.3
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HeightScale:
+          Float32: 1
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        HorizontalAlignment:
+          Enum: 1
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 0.5
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c7
+        VerticalAlignment:
+          Enum: 1
+        WidthScale:
+          Float32: 1
+      children: []
+    - referent: referent-21
+      name: ChatInputBarConfiguration
+      class: ChatInputBarConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        AutocompleteEnabled:
+          Bool: true
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0.2
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        KeyboardKeyCode:
+          Enum: 47
+        PlaceholderColor3:
+          Color3:
+            - 0.69803923
+            - 0.69803923
+            - 0.69803923
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TargetTextChannel: "null"
+        TextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 0.5
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c8
+      children: []
+    - referent: referent-22
+      name: BubbleChatConfiguration
+      class: BubbleChatConfiguration
+      properties:
+        AdorneeName:
+          String: HumanoidRootPart
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.98039216
+            - 0.98039216
+            - 0.98039216
+        BackgroundTransparency:
+          Float64: 0.1
+        BubbleDuration:
+          Float32: 15
+        BubblesSpacing:
+          Float32: 6
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        Font:
+          Enum: 47
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LocalPlayerStudsOffset:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        MaxBubbles:
+          Float32: 3
+        MaxDistance:
+          Float32: 100
+        MinimizeDistance:
+          Float32: 40
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TailVisible:
+          Bool: true
+        TextColor3:
+          Color3:
+            - 0.22352941
+            - 0.23137255
+            - 0.23921569
+        TextSize:
+          Int64: 20
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c9
+        VerticalStudsOffset:
+          Float32: 0
+      children:
+        - referent: referent-23
+          name: UIGradient
+          class: UIGradient
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color:
+              ColorSequence:
+                keypoints:
+                  - time: 0
+                    color:
+                      - 1
+                      - 1
+                      - 1
+                  - time: 1
+                    color:
+                      - 1
+                      - 1
+                      - 1
+            Enabled:
+              Bool: false
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Offset:
+              Vector2:
+                - 0
+                - 0
+            Rotation:
+              Float32: 0
+            Sandboxed:
+              Bool: false
+            Scale:
+              Float32: 1
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TileMode:
+              Enum: 0
+            Transparency:
+              NumberSequence:
+                keypoints:
+                  - time: 0
+                    value: 0
+                    envelope: 0
+                  - time: 1
+                    value: 0
+                    envelope: 0
+            Type:
+              Enum: 0
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ca
+          children: []
+        - referent: referent-24
+          name: ImageLabel
+          class: ImageLabel
+          properties:
+            Active:
+              Bool: false
+            AnchorPoint:
+              Vector2:
+                - 0
+                - 0
+            Attributes:
+              Attributes: {}
+            AutoLocalize:
+              Bool: true
+            AutomaticSize:
+              Enum: 0
+            BackgroundColor3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            BackgroundTransparency:
+              Float32: 0
+            BorderColor3:
+              Color3:
+                - 0.10588236
+                - 0.16470589
+                - 0.20784315
+            BorderMode:
+              Enum: 0
+            BorderSizePixel:
+              Int32: 1
+            Capabilities:
+              SecurityCapabilities: 0
+            ClipsDescendants:
+              Bool: false
+            Draggable:
+              Bool: false
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            ImageColor3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            ImageContent:
+              Content: None
+            ImageRectOffset:
+              Vector2:
+                - 0
+                - 0
+            ImageRectSize:
+              Vector2:
+                - 0
+                - 0
+            ImageTransparency:
+              Float32: 0
+            InputSink:
+              Enum: 0
+            Interactable:
+              Bool: true
+            LayoutOrder:
+              Int32: 0
+            NextSelectionDown: "null"
+            NextSelectionLeft: "null"
+            NextSelectionRight: "null"
+            NextSelectionUp: "null"
+            Position:
+              UDim2:
+                - - 0
+                  - 0
+                - - 0
+                  - 0
+            ResampleMode:
+              Enum: 0
+            RootLocalizationTable: "null"
+            Rotation:
+              Float32: 0
+            Sandboxed:
+              Bool: false
+            ScaleType:
+              Enum: 0
+            Selectable:
+              Bool: false
+            SelectionBehaviorDown:
+              Enum: 0
+            SelectionBehaviorLeft:
+              Enum: 0
+            SelectionBehaviorRight:
+              Enum: 0
+            SelectionBehaviorUp:
+              Enum: 0
+            SelectionGroup:
+              Bool: false
+            SelectionImageObject: "null"
+            SelectionOrder:
+              Int32: 0
+            Size:
+              UDim2:
+                - - 0
+                  - 100
+                - - 0
+                  - 100
+            SizeConstraint:
+              Enum: 0
+            SliceCenter:
+              Rect:
+                - - 0
+                  - 0
+                - - 0
+                  - 0
+            SliceScale:
+              Float32: 1
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TileSize:
+              UDim2:
+                - - 1
+                  - 0
+                - - 1
+                  - 0
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cb
+            Visible:
+              Bool: true
+            ZIndex:
+              Int32: 1
+          children: []
+        - referent: referent-25
+          name: UICorner
+          class: UICorner
+          properties:
+            Attributes:
+              Attributes: {}
+            BottomLeftRadius:
+              UDim:
+                - 0
+                - 12
+            BottomRightRadius:
+              UDim:
+                - 0
+                - 12
+            Capabilities:
+              SecurityCapabilities: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TopLeftRadius:
+              UDim:
+                - 0
+                - 12
+            TopRightRadius:
+              UDim:
+                - 0
+                - 12
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cc
+          children: []
+        - referent: referent-26
+          name: UIPadding
+          class: UIPadding
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            PaddingBottom:
+              UDim:
+                - 0
+                - 8
+            PaddingLeft:
+              UDim:
+                - 0
+                - 8
+            PaddingRight:
+              UDim:
+                - 0
+                - 8
+            PaddingTop:
+              UDim:
+                - 0
+                - 8
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cd
+          children: []
+    - referent: referent-27
+      name: ChannelTabsConfiguration
+      class: ChannelTabsConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: false
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Bold
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Bold.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        HoverBackgroundColor3:
+          Color3:
+            - 0.49019608
+            - 0.49019608
+            - 0.49019608
+        Sandboxed:
+          Bool: false
+        SelectedTabTextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TextColor3:
+          Color3:
+            - 0.6862745
+            - 0.6862745
+            - 0.6862745
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 1
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ce
+      children: []
+- referent: referent-28
+  name: PlayerEmulatorService
+  class: PlayerEmulatorService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    CustomPoliciesEnabled:
+      Bool: false
+    EmulatedCountryCode:
+      String: ""
+    EmulatedGameLocale:
+      String: ""
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    PlayerEmulationEnabled:
+      Bool: false
+    PseudolocalizationEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SerializedEmulatedPolicyInfo:
+      BinaryString: ""
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    TextElongationFactor:
+      Int32: 0
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035a
+  children: []
+- referent: referent-29
+  name: StudioData
+  class: StudioData
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    EnableScriptCollabByDefaultOnLoad:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035d
+  children: []
+- referent: referent-30
+  name: StarterPlayer
+  class: StarterPlayer
+  properties:
+    AllowCustomAnimations:
+      Bool: true
+    Attributes:
+      Attributes: {}
+    AutoJumpEnabled:
+      Bool: true
+    AvatarJointUpgrade:
+      Enum: 2
+    CameraMaxZoomDistance:
+      Float32: 128
+    CameraMinZoomDistance:
+      Float32: 0.5
+    CameraMode:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterBreakJointsOnDeath:
+      Bool: false
+    CharacterJumpHeight:
+      Float32: 7.2
+    CharacterJumpPower:
+      Float32: 50
+    CharacterMaxSlopeAngle:
+      Float32: 89
+    CharacterUseJumpPower:
+      Bool: false
+    CharacterWalkSpeed:
+      Float32: 16
+    ClassicDeath:
+      Bool: true
+    CreateDefaultPlayerModule:
+      Bool: true
+    DevCameraOcclusionMode:
+      Enum: 0
+    DevComputerCameraMovementMode:
+      Enum: 0
+    DevComputerMovementMode:
+      Enum: 0
+    DevTouchCameraMovementMode:
+      Enum: 0
+    DevTouchMovementMode:
+      Enum: 0
+    EnableDynamicHeads:
+      Enum: 0
+    EnableMouseLockOption:
+      Bool: true
+    GameSettingsAssetIDFace:
+      Int64: 0
+    GameSettingsAssetIDHead:
+      Int64: 0
+    GameSettingsAssetIDLeftArm:
+      Int64: 0
+    GameSettingsAssetIDLeftLeg:
+      Int64: 0
+    GameSettingsAssetIDPants:
+      Int64: 0
+    GameSettingsAssetIDRightArm:
+      Int64: 0
+    GameSettingsAssetIDRightLeg:
+      Int64: 0
+    GameSettingsAssetIDShirt:
+      Int64: 0
+    GameSettingsAssetIDTeeShirt:
+      Int64: 0
+    GameSettingsAssetIDTorso:
+      Int64: 0
+    GameSettingsAvatar:
+      Enum: 1
+    GameSettingsR15Collision:
+      Enum: 0
+    GameSettingsScaleRangeBodyType:
+      NumberRange:
+        - 0
+        - 1
+    GameSettingsScaleRangeHead:
+      NumberRange:
+        - 0.95
+        - 1
+    GameSettingsScaleRangeHeight:
+      NumberRange:
+        - 0.9
+        - 1.05
+    GameSettingsScaleRangeProportion:
+      NumberRange:
+        - 0
+        - 1
+    GameSettingsScaleRangeWidth:
+      NumberRange:
+        - 0.7
+        - 1
+    HealthDisplayDistance:
+      Float32: 100
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LoadCharacterAppearance:
+      Bool: true
+    LoadCharacterLayeredClothing:
+      Enum: 0
+    LuaCharacterController:
+      Enum: 0
+    NameDisplayDistance:
+      Float32: 100
+    PlayerModuleStatus:
+      Int32: 0
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035f
+    UserEmotesEnabled:
+      Bool: true
+  children:
+    - referent: referent-31
+      name: StarterPlayerScripts
+      class: StarterPlayerScripts
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bf
+      children: []
+    - referent: referent-32
+      name: StarterCharacterScripts
+      class: StarterCharacterScripts
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c0
+      children: []
+- referent: referent-33
+  name: StarterPack
+  class: StarterPack
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000360
+  children: []
+- referent: referent-34
+  name: StarterGui
+  class: StarterGui
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    ClipsDescendantsSupportsRotation:
+      Enum: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    ResetPlayerGuiOnSpawn:
+      Bool: true
+    RtlTextSupport:
+      Enum: 0
+    Sandboxed:
+      Bool: false
+    ScreenOrientation:
+      Enum: 4
+    ShowDevelopmentGui:
+      Bool: true
+    SourceAssetId:
+      Int64: -1
+    StudioDefaultStyleSheet: "null"
+    StudioInsertWidgetLayerCollectorAutoLinkStyleSheet: "null"
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000361
+    VirtualCursorMode:
+      Enum: 0
+  children: []
+- referent: referent-35
+  name: LocalizationService
+  class: LocalizationService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000363
+  children: []
+- referent: referent-36
+  name: Teleport Service
+  class: TeleportService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000367
+  children: []
+- referent: referent-37
+  name: CollectionService
+  class: CollectionService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000339
+  children: []
+- referent: referent-38
+  name: PhysicsService
+  class: PhysicsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000369
+  children: []
+- referent: referent-39
+  name: InsertService
+  class: InsertService
+  properties:
+    AllowInsertFreeModels:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036c
+  children:
+    - referent: referent-40
+      name: InsertionHash
+      class: StringValue
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c1
+        Value:
+          String: "{a4b4fc84-d3fa-4580-b9d0-98390afa7f7f}"
+      children: []
+- referent: referent-41
+  name: GamePassService
+  class: GamePassService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036d
+  children: []
+- referent: referent-42
+  name: Debris
+  class: Debris
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxItems:
+      Int32: 1000
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036e
+  children: []
+- referent: referent-43
+  name: CookiesService
+  class: CookiesService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036f
+  children: []
+- referent: referent-44
+  name: Selection
+  class: Selection
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000370
+  children: []
+- referent: referent-45
+  name: VRService
+  class: VRService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutomaticScaling:
+      Enum: 0
+    AvatarGestures:
+      Bool: false
+    Capabilities:
+      SecurityCapabilities: 0
+    ControllerModels:
+      Enum: 1
+    FadeOutViewOnCollision:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LaserPointer:
+      Enum: 1
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000374
+  children: []
+- referent: referent-46
+  name: ContextActionService
+  class: ContextActionService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000375
+  children: []
+- referent: referent-47
+  name: Instance
+  class: ScriptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000376
+  children: []
+- referent: referent-48
+  name: AssetService
+  class: AssetService
+  properties:
+    AllowInsertFreeAssets:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000377
+  children: []
+- referent: referent-49
+  name: TouchInputService
+  class: TouchInputService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000379
+  children: []
+- referent: referent-50
+  name: AvatarSettings
+  class: AvatarSettings
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000037f
+  children:
+    - referent: referent-51
+      name: DefaultAvatarRules
+      class: AvatarRules
+      properties:
+        Attributes:
+          Attributes: {}
+        AvatarType:
+          Enum: 1
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7edfffb096708e650a5620f100000e00
+      children:
+        - referent: referent-52
+          name: AvatarBodyRules
+          class: AvatarBodyRules
+          properties:
+            AppearanceMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            BuildMode:
+              Enum: 0
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomBodyBundleId:
+              Int64: 0
+            CustomBodyType:
+              Enum: 0
+            CustomBodyTypeScale:
+              NumberRange:
+                - 0
+                - 1
+            CustomEyebrowEnabled:
+              Bool: false
+            CustomEyebrowId:
+              Int64: 0
+            CustomEyelashEnabled:
+              Bool: false
+            CustomEyelashId:
+              Int64: 0
+            CustomFaceEnabled:
+              Bool: false
+            CustomFaceId:
+              Int64: 0
+            CustomHeadEnabled:
+              Bool: false
+            CustomHeadId:
+              Int64: 0
+            CustomHeadScale:
+              NumberRange:
+                - 0.95
+                - 1
+            CustomHeight:
+              NumberRange:
+                - 5.5
+                - 5.5
+            CustomHeightScale:
+              NumberRange:
+                - 0.9
+                - 1.05
+            CustomLeftArmEnabled:
+              Bool: false
+            CustomLeftArmId:
+              Int64: 0
+            CustomLeftLegEnabled:
+              Bool: false
+            CustomLeftLegId:
+              Int64: 0
+            CustomMoodEnabled:
+              Bool: false
+            CustomMoodId:
+              Int64: 0
+            CustomProportionsScale:
+              NumberRange:
+                - 0
+                - 1
+            CustomRightArmEnabled:
+              Bool: false
+            CustomRightArmId:
+              Int64: 0
+            CustomRightLegEnabled:
+              Bool: false
+            CustomRightLegId:
+              Int64: 0
+            CustomTorsoEnabled:
+              Bool: false
+            CustomTorsoId:
+              Int64: 0
+            CustomWidthScale:
+              NumberRange:
+                - 0.7
+                - 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            KeepPlayerHead:
+              Bool: true
+            Sandboxed:
+              Bool: false
+            ScaleMode:
+              Enum: 0
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e01
+          children: []
+        - referent: referent-53
+          name: AvatarCollisionRules
+          class: AvatarCollisionRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CollisionMode:
+              Enum: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            HitAndTouchDetectionMode:
+              Enum: 0
+            LegacyCollisionMode:
+              Enum: 1
+            Sandboxed:
+              Bool: false
+            SingleColliderSize:
+              Vector3:
+                - 2
+                - 3
+                - 1
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e02
+          children: []
+        - referent: referent-54
+          name: AvatarAbilityRules
+          class: AvatarAbilityRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CharacterControllerMode:
+              Enum: 0
+            EnableClimbing:
+              Bool: true
+            EnableCrouching:
+              Bool: true
+            EnableFallingDown:
+              Bool: true
+            EnableGettingUp:
+              Bool: true
+            EnableHolding:
+              Bool: true
+            EnableJumping:
+              Bool: true
+            EnableReaching:
+              Bool: true
+            EnableRunning:
+              Bool: true
+            EnableSitting:
+              Bool: true
+            EnableSprinting:
+              Bool: true
+            EnableStrafing:
+              Bool: true
+            EnableSwimming:
+              Bool: true
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e03
+          children: []
+        - referent: referent-55
+          name: AvatarAnimationRules
+          class: AvatarAnimationRules
+          properties:
+            AnimationClipsMode:
+              Enum: 0
+            AnimationPacksMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomClimbAnimationEnabled:
+              Bool: false
+            CustomClimbAnimationId:
+              Int64: 0
+            CustomFallAnimationEnabled:
+              Bool: false
+            CustomFallAnimationId:
+              Int64: 0
+            CustomIdleAlt1AnimationEnabled:
+              Bool: false
+            CustomIdleAlt1AnimationId:
+              Int64: 0
+            CustomIdleAlt2AnimationEnabled:
+              Bool: false
+            CustomIdleAlt2AnimationId:
+              Int64: 0
+            CustomIdleAnimationEnabled:
+              Bool: false
+            CustomIdleAnimationId:
+              Int64: 0
+            CustomJumpAnimationEnabled:
+              Bool: false
+            CustomJumpAnimationId:
+              Int64: 0
+            CustomRunAnimationEnabled:
+              Bool: false
+            CustomRunAnimationId:
+              Int64: 0
+            CustomSwimAnimationEnabled:
+              Bool: false
+            CustomSwimAnimationId:
+              Int64: 0
+            CustomSwimIdleAnimationEnabled:
+              Bool: false
+            CustomSwimIdleAnimationId:
+              Int64: 0
+            CustomWalkAnimationEnabled:
+              Bool: false
+            CustomWalkAnimationId:
+              Int64: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e04
+          children: []
+        - referent: referent-56
+          name: AvatarAccessoryRules
+          class: AvatarAccessoryRules
+          properties:
+            AccessoryMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomAccessoryMode:
+              Enum: 0
+            CustomBackAccessoryEnabled:
+              Bool: false
+            CustomBackAccessoryId:
+              Int64: 0
+            CustomFaceAccessoryEnabled:
+              Bool: false
+            CustomFaceAccessoryId:
+              Int64: 0
+            CustomFrontAccessoryEnabled:
+              Bool: false
+            CustomFrontAccessoryId:
+              Int64: 0
+            CustomHairAccessoryEnabled:
+              Bool: false
+            CustomHairAccessoryId:
+              Int64: 0
+            CustomHeadAccessoryEnabled:
+              Bool: false
+            CustomHeadAccessoryId:
+              Int64: 0
+            CustomNeckAccessoryEnabled:
+              Bool: false
+            CustomNeckAccessoryId:
+              Int64: 0
+            CustomShoulderAccessoryEnabled:
+              Bool: false
+            CustomShoulderAccessoryId:
+              Int64: 0
+            CustomWaistAccessoryEnabled:
+              Bool: false
+            CustomWaistAccessoryId:
+              Int64: 0
+            EnableEmissives:
+              Bool: true
+            EnableSound:
+              Bool: true
+            EnableVFX:
+              Bool: true
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            LimitBounds:
+              Vector3:
+                - 0
+                - 0
+                - 0
+            LimitMethod:
+              Enum: 1
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e05
+          children: []
+        - referent: referent-57
+          name: AvatarClothingRules
+          class: AvatarClothingRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            ClothingMode:
+              Enum: 0
+            CustomClassicPantsAccessoryEnabled:
+              Bool: false
+            CustomClassicPantsAccessoryId:
+              Int64: 0
+            CustomClassicShirtsAccessoryEnabled:
+              Bool: false
+            CustomClassicShirtsAccessoryId:
+              Int64: 0
+            CustomClassicTShirtsAccessoryEnabled:
+              Bool: false
+            CustomClassicTShirtsAccessoryId:
+              Int64: 0
+            CustomClothingMode:
+              Enum: 0
+            CustomDressSkirtAccessoryEnabled:
+              Bool: false
+            CustomDressSkirtAccessoryId:
+              Int64: 0
+            CustomJacketAccessoryEnabled:
+              Bool: false
+            CustomJacketAccessoryId:
+              Int64: 0
+            CustomLeftShoesAccessoryEnabled:
+              Bool: false
+            CustomLeftShoesAccessoryId:
+              Int64: 0
+            CustomPantsAccessoryEnabled:
+              Bool: false
+            CustomPantsAccessoryId:
+              Int64: 0
+            CustomRightShoesAccessoryEnabled:
+              Bool: false
+            CustomRightShoesAccessoryId:
+              Int64: 0
+            CustomShirtAccessoryEnabled:
+              Bool: false
+            CustomShirtAccessoryId:
+              Int64: 0
+            CustomShortsAccessoryEnabled:
+              Bool: false
+            CustomShortsAccessoryId:
+              Int64: 0
+            CustomSweaterAccessoryEnabled:
+              Bool: false
+            CustomSweaterAccessoryId:
+              Int64: 0
+            CustomTShirtAccessoryEnabled:
+              Bool: false
+            CustomTShirtAccessoryId:
+              Int64: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            LimitBounds:
+              Vector3:
+                - 0
+                - 0
+                - 0
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e06
+          children: []
+- referent: referent-58
+  name: Instance
+  class: LodDataService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b1
+  children: []
+- referent: referent-59
+  name: Packages
+  class: Packages
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsDehydrated:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    ShellPackagesCount:
+      Int32: 0
+    SkippedInstancesCount:
+      Int32: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000383
+  children: []
+- referent: referent-60
+  name: GuidRegistryService
+  class: GuidRegistryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000384
+  children: []
+- referent: referent-61
+  name: ConfigureServerService
+  class: ConfigureServerService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7edfffb096708e650a5620f100000387
+  children: []
+- referent: referent-62
+  name: DataStoreService
+  class: DataStoreService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutomaticRetry:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LegacyNamingScheme:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003af
+  children: []
+- referent: referent-63
+  name: HttpService
+  class: HttpService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    HttpEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ac
+  children: []
+- referent: referent-64
+  name: Lighting
+  class: Lighting
+  properties:
+    Ambient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Attributes:
+      Attributes:
+        RBX_LightingTechnologyUnifiedMigration:
+          Bool: true
+        RBX_OriginalTechnologyOnFileLoad:
+          Int32: 3
+    Brightness:
+      Float32: 3
+    Capabilities:
+      SecurityCapabilities: 0
+    ColorShift_Bottom:
+      Color3:
+        - 0
+        - 0
+        - 0
+    ColorShift_Top:
+      Color3:
+        - 0
+        - 0
+        - 0
+    EnvironmentDiffuseScale:
+      Float32: 1
+    EnvironmentSpecularScale:
+      Float32: 1
+    ExposureCompensation:
+      Float32: 0
+    ExtendLightRangeTo120:
+      Enum: 0
+    FogColor:
+      Color3:
+        - 0.75294125
+        - 0.75294125
+        - 0.75294125
+    FogEnd:
+      Float32: 100000
+    FogStart:
+      Float32: 0
+    GeographicLatitude:
+      Float32: 0
+    GlobalShadows:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LightingStyle:
+      Enum: 1
+    OutdoorAmbient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Outlines:
+      Bool: false
+    PrioritizeLightingQuality:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    ShadowSoftness:
+      Float32: 0.2
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Technology:
+      Enum: 3
+    TimeOfDay:
+      String: "14:30:00"
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b0
+  children:
+    - referent: referent-65
+      name: Sky
+      class: Sky
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        CelestialBodiesShown:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        MoonAngularSize:
+          Float32: 11
+        MoonTextureContent:
+          Content:
+            Uri: "rbxassetid://6444320592"
+        Sandboxed:
+          Bool: false
+        SkyboxBackContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxDownContent:
+          Content:
+            Uri: "rbxassetid://6444884785"
+        SkyboxFrontContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxLeftContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxOrientation:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        SkyboxRightContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxUpContent:
+          Content:
+            Uri: "rbxassetid://6412503613"
+        SourceAssetId:
+          Int64: 332039975
+        StarCount:
+          Int32: 3000
+        SunAngularSize:
+          Float32: 11
+        SunTextureContent:
+          Content:
+            Uri: "rbxassetid://6196665106"
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c2
+      children: []
+    - referent: referent-66
+      name: SunRays
+      class: SunRaysEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Intensity:
+          Float32: 0.01
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Spread:
+          Float32: 0.1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c3
+      children: []
+    - referent: referent-67
+      name: Atmosphere
+      class: Atmosphere
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Color:
+          Color3:
+            - 0.78039217
+            - 0.78039217
+            - 0.78039217
+        Decay:
+          Color3:
+            - 0.41568628
+            - 0.4392157
+            - 0.49019608
+        Density:
+          Float32: 0.3
+        Glare:
+          Float32: 0
+        Haze:
+          Float32: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Offset:
+          Float32: 0.25
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c4
+      children: []
+    - referent: referent-68
+      name: Bloom
+      class: BloomEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Intensity:
+          Float32: 1
+        Sandboxed:
+          Bool: false
+        Size:
+          Float32: 24
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        Threshold:
+          Float32: 2
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c5
+      children: []
+    - referent: referent-69
+      name: DepthOfField
+      class: DepthOfFieldEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: false
+        FarIntensity:
+          Float32: 0.1
+        FocusDistance:
+          Float32: 0.05
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        InFocusRadius:
+          Float32: 30
+        NearIntensity:
+          Float32: 0.75
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c6
+      children: []
+- referent: referent-70
+  name: ProximityPromptService
+  class: ProximityPromptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    Enabled:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxIndicatorsVisible:
+      Int32: 16
+    MaxPromptsVisible:
+      Int32: 16
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b2
+  children: []
+- referent: referent-71
+  name: ReplicatedStorage
+  class: ReplicatedStorage
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000398
+  children: []
+- referent: referent-72
+  name: ServerScriptService
+  class: ServerScriptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LoadStringEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000399
+  children: []
+- referent: referent-73
+  name: ServerStorage
+  class: ServerStorage
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000039a
+  children: []
+- referent: referent-74
+  name: ServiceVisibilityService
+  class: ServiceVisibilityService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HiddenServices:
+      BinaryString: AAAAAA==
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003a1
+    VisibleServices:
+      BinaryString: AAAAAA==
+  children: []
+- referent: referent-75
+  name: Teams
+  class: Teams
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b3
+  children: []
+- referent: referent-76
+  name: TestService
+  class: TestService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutoRuns:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    Description:
+      String: ""
+    ExecuteWithStudioRun:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsPhysicsEnvironmentalThrottled:
+      Bool: true
+    IsSleepAllowed:
+      Bool: true
+    NumberOfPlayers:
+      Int32: 0
+    Sandboxed:
+      Bool: false
+    SimulateSecondsLag:
+      Float64: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    ThrottlePhysicsToRealtime:
+      Bool: true
+    Timeout:
+      Float64: 10
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b4
+  children: []
+- referent: referent-77
+  name: UGCAvatarService
+  class: UGCAvatarService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b5
+  children: []
+- referent: referent-78
+  name: VideoService
+  class: VideoService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003da
+  children: []
+- referent: referent-79
+  name: VoiceChatService
+  class: VoiceChatService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    DefaultDistanceAttenuation:
+      Enum: 0
+    EnableDefaultVoice:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b7
+    UseAudioApi:
+      Enum: 2
+  children: []
+- referent: referent-80
+  name: PermissionsService
+  class: PermissionsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7edfffb096708e650a5620f100000e07
+  children: []
+- referent: referent-81
+  name: LuaWebService
+  class: LuaWebService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7edfffb096708e650a5620f100000f22
+  children: []

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__baseplate-727-with-tags__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__baseplate-727-with-tags__encoded.snap
@@ -1,0 +1,9248 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 80
+num_instances: 82
+chunks:
+  - Sstr:
+      version: 0
+      entries:
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+  - Inst:
+      type_id: 46
+      type_name: AssetService
+      object_format: 1
+      referents:
+        - 48
+      remaining: "01"
+  - Inst:
+      type_id: 64
+      type_name: Atmosphere
+      object_format: 0
+      referents:
+        - 66
+  - Inst:
+      type_id: 50
+      type_name: AvatarAbilityRules
+      object_format: 0
+      referents:
+        - 52
+  - Inst:
+      type_id: 52
+      type_name: AvatarAccessoryRules
+      object_format: 0
+      referents:
+        - 54
+  - Inst:
+      type_id: 51
+      type_name: AvatarAnimationRules
+      object_format: 0
+      referents:
+        - 53
+  - Inst:
+      type_id: 48
+      type_name: AvatarBodyRules
+      object_format: 0
+      referents:
+        - 50
+  - Inst:
+      type_id: 53
+      type_name: AvatarClothingRules
+      object_format: 0
+      referents:
+        - 55
+  - Inst:
+      type_id: 49
+      type_name: AvatarCollisionRules
+      object_format: 0
+      referents:
+        - 51
+  - Inst:
+      type_id: 54
+      type_name: AvatarRules
+      object_format: 0
+      referents:
+        - 56
+  - Inst:
+      type_id: 55
+      type_name: AvatarSettings
+      object_format: 1
+      referents:
+        - 57
+      remaining: "01"
+  - Inst:
+      type_id: 65
+      type_name: BloomEffect
+      object_format: 0
+      referents:
+        - 67
+  - Inst:
+      type_id: 23
+      type_name: BubbleChatConfiguration
+      object_format: 0
+      referents:
+        - 25
+  - Inst:
+      type_id: 11
+      type_name: CSGDictionaryService
+      object_format: 1
+      referents:
+        - 13
+      remaining: "01"
+  - Inst:
+      type_id: 0
+      type_name: Camera
+      object_format: 0
+      referents:
+        - 0
+  - Inst:
+      type_id: 24
+      type_name: ChannelTabsConfiguration
+      object_format: 0
+      referents:
+        - 26
+  - Inst:
+      type_id: 12
+      type_name: Chat
+      object_format: 1
+      referents:
+        - 14
+      remaining: "01"
+  - Inst:
+      type_id: 18
+      type_name: ChatInputBarConfiguration
+      object_format: 0
+      referents:
+        - 20
+  - Inst:
+      type_id: 17
+      type_name: ChatWindowConfiguration
+      object_format: 0
+      referents:
+        - 19
+  - Inst:
+      type_id: 35
+      type_name: CollectionService
+      object_format: 1
+      referents:
+        - 37
+      remaining: "01"
+  - Inst:
+      type_id: 59
+      type_name: ConfigureServerService
+      object_format: 1
+      referents:
+        - 61
+      remaining: "01"
+  - Inst:
+      type_id: 44
+      type_name: ContextActionService
+      object_format: 1
+      referents:
+        - 46
+      remaining: "01"
+  - Inst:
+      type_id: 41
+      type_name: CookiesService
+      object_format: 1
+      referents:
+        - 43
+      remaining: "01"
+  - Inst:
+      type_id: 60
+      type_name: DataStoreService
+      object_format: 1
+      referents:
+        - 62
+      remaining: "01"
+  - Inst:
+      type_id: 40
+      type_name: Debris
+      object_format: 1
+      referents:
+        - 42
+      remaining: "01"
+  - Inst:
+      type_id: 4
+      type_name: Decal
+      object_format: 0
+      referents:
+        - 4
+  - Inst:
+      type_id: 66
+      type_name: DepthOfFieldEffect
+      object_format: 0
+      referents:
+        - 68
+  - Inst:
+      type_id: 39
+      type_name: GamePassService
+      object_format: 1
+      referents:
+        - 41
+      remaining: "01"
+  - Inst:
+      type_id: 58
+      type_name: GuidRegistryService
+      object_format: 1
+      referents:
+        - 60
+      remaining: "01"
+  - Inst:
+      type_id: 61
+      type_name: HttpService
+      object_format: 1
+      referents:
+        - 63
+      remaining: "01"
+  - Inst:
+      type_id: 20
+      type_name: ImageLabel
+      object_format: 0
+      referents:
+        - 22
+  - Inst:
+      type_id: 38
+      type_name: InsertService
+      object_format: 1
+      referents:
+        - 40
+      remaining: "01"
+  - Inst:
+      type_id: 67
+      type_name: Lighting
+      object_format: 1
+      referents:
+        - 69
+      remaining: "01"
+  - Inst:
+      type_id: 33
+      type_name: LocalizationService
+      object_format: 1
+      referents:
+        - 35
+      remaining: "01"
+  - Inst:
+      type_id: 56
+      type_name: LodDataService
+      object_format: 1
+      referents:
+        - 58
+      remaining: "01"
+  - Inst:
+      type_id: 79
+      type_name: LuaWebService
+      object_format: 1
+      referents:
+        - 81
+      remaining: "01"
+  - Inst:
+      type_id: 16
+      type_name: MaterialService
+      object_format: 1
+      referents:
+        - 18
+      remaining: "01"
+  - Inst:
+      type_id: 10
+      type_name: NonReplicatedCSGDictionaryService
+      object_format: 1
+      referents:
+        - 12
+      remaining: "01"
+  - Inst:
+      type_id: 57
+      type_name: Packages
+      object_format: 1
+      referents:
+        - 59
+      remaining: "01"
+  - Inst:
+      type_id: 2
+      type_name: Part
+      object_format: 0
+      referents:
+        - 2
+        - 7
+  - Inst:
+      type_id: 78
+      type_name: PermissionsService
+      object_format: 1
+      referents:
+        - 80
+      remaining: "01"
+  - Inst:
+      type_id: 36
+      type_name: PhysicsService
+      object_format: 1
+      referents:
+        - 38
+      remaining: "01"
+  - Inst:
+      type_id: 26
+      type_name: PlayerEmulatorService
+      object_format: 1
+      referents:
+        - 28
+      remaining: "01"
+  - Inst:
+      type_id: 13
+      type_name: Players
+      object_format: 1
+      referents:
+        - 15
+      remaining: "01"
+  - Inst:
+      type_id: 68
+      type_name: ProximityPromptService
+      object_format: 1
+      referents:
+        - 70
+      remaining: "01"
+  - Inst:
+      type_id: 14
+      type_name: ReplicatedFirst
+      object_format: 1
+      referents:
+        - 16
+      remaining: "01"
+  - Inst:
+      type_id: 69
+      type_name: ReplicatedStorage
+      object_format: 1
+      referents:
+        - 71
+      remaining: "01"
+  - Inst:
+      type_id: 45
+      type_name: ScriptService
+      object_format: 1
+      referents:
+        - 47
+      remaining: "01"
+  - Inst:
+      type_id: 42
+      type_name: Selection
+      object_format: 1
+      referents:
+        - 44
+      remaining: "01"
+  - Inst:
+      type_id: 70
+      type_name: ServerScriptService
+      object_format: 1
+      referents:
+        - 72
+      remaining: "01"
+  - Inst:
+      type_id: 71
+      type_name: ServerStorage
+      object_format: 1
+      referents:
+        - 73
+      remaining: "01"
+  - Inst:
+      type_id: 72
+      type_name: ServiceVisibilityService
+      object_format: 1
+      referents:
+        - 74
+      remaining: "01"
+  - Inst:
+      type_id: 62
+      type_name: Sky
+      object_format: 0
+      referents:
+        - 64
+  - Inst:
+      type_id: 8
+      type_name: SoundService
+      object_format: 1
+      referents:
+        - 10
+      remaining: "01"
+  - Inst:
+      type_id: 5
+      type_name: SpawnLocation
+      object_format: 0
+      referents:
+        - 5
+  - Inst:
+      type_id: 29
+      type_name: StarterCharacterScripts
+      object_format: 0
+      referents:
+        - 31
+  - Inst:
+      type_id: 32
+      type_name: StarterGui
+      object_format: 1
+      referents:
+        - 34
+      remaining: "01"
+  - Inst:
+      type_id: 31
+      type_name: StarterPack
+      object_format: 1
+      referents:
+        - 33
+      remaining: "01"
+  - Inst:
+      type_id: 30
+      type_name: StarterPlayer
+      object_format: 1
+      referents:
+        - 32
+      remaining: "01"
+  - Inst:
+      type_id: 28
+      type_name: StarterPlayerScripts
+      object_format: 0
+      referents:
+        - 30
+  - Inst:
+      type_id: 37
+      type_name: StringValue
+      object_format: 0
+      referents:
+        - 39
+  - Inst:
+      type_id: 27
+      type_name: StudioData
+      object_format: 1
+      referents:
+        - 29
+      remaining: "01"
+  - Inst:
+      type_id: 63
+      type_name: SunRaysEffect
+      object_format: 0
+      referents:
+        - 65
+  - Inst:
+      type_id: 73
+      type_name: Teams
+      object_format: 1
+      referents:
+        - 75
+      remaining: "01"
+  - Inst:
+      type_id: 34
+      type_name: TeleportService
+      object_format: 1
+      referents:
+        - 36
+      remaining: "01"
+  - Inst:
+      type_id: 3
+      type_name: Terrain
+      object_format: 0
+      referents:
+        - 3
+  - Inst:
+      type_id: 74
+      type_name: TestService
+      object_format: 1
+      referents:
+        - 76
+      remaining: "01"
+  - Inst:
+      type_id: 25
+      type_name: TextChatService
+      object_format: 1
+      referents:
+        - 27
+      remaining: "01"
+  - Inst:
+      type_id: 1
+      type_name: Texture
+      object_format: 0
+      referents:
+        - 1
+        - 6
+  - Inst:
+      type_id: 7
+      type_name: TimerService
+      object_format: 1
+      referents:
+        - 9
+      remaining: "01"
+  - Inst:
+      type_id: 47
+      type_name: TouchInputService
+      object_format: 1
+      referents:
+        - 49
+      remaining: "01"
+  - Inst:
+      type_id: 15
+      type_name: TweenService
+      object_format: 1
+      referents:
+        - 17
+      remaining: "01"
+  - Inst:
+      type_id: 75
+      type_name: UGCAvatarService
+      object_format: 1
+      referents:
+        - 77
+      remaining: "01"
+  - Inst:
+      type_id: 21
+      type_name: UICorner
+      object_format: 0
+      referents:
+        - 23
+  - Inst:
+      type_id: 19
+      type_name: UIGradient
+      object_format: 0
+      referents:
+        - 21
+  - Inst:
+      type_id: 22
+      type_name: UIPadding
+      object_format: 0
+      referents:
+        - 24
+  - Inst:
+      type_id: 43
+      type_name: VRService
+      object_format: 1
+      referents:
+        - 45
+      remaining: "01"
+  - Inst:
+      type_id: 9
+      type_name: VideoCaptureService
+      object_format: 1
+      referents:
+        - 11
+      remaining: "01"
+  - Inst:
+      type_id: 76
+      type_name: VideoService
+      object_format: 1
+      referents:
+        - 78
+      remaining: "01"
+  - Inst:
+      type_id: 77
+      type_name: VoiceChatService
+      object_format: 1
+      referents:
+        - 79
+      remaining: "01"
+  - Inst:
+      type_id: 6
+      type_name: Workspace
+      object_format: 1
+      referents:
+        - 8
+      remaining: "01"
+  - Prop:
+      type_id: 46
+      prop_name: AllowInsertFreeAssets
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 46
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 46
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 46
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 46
+      prop_name: Name
+      prop_type: String
+      values:
+        - AssetService
+  - Prop:
+      type_id: 46
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 46
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 46
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 46
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000377
+  - Prop:
+      type_id: 64
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 64
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: Color
+      prop_type: Color3
+      values:
+        - - 0.78039217
+          - 0.78039217
+          - 0.78039217
+  - Prop:
+      type_id: 64
+      prop_name: Decay
+      prop_type: Color3
+      values:
+        - - 0.41568628
+          - 0.4392157
+          - 0.49019608
+  - Prop:
+      type_id: 64
+      prop_name: Density
+      prop_type: Float32
+      values:
+        - 0.3
+  - Prop:
+      type_id: 64
+      prop_name: Glare
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: Haze
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 64
+      prop_name: Name
+      prop_type: String
+      values:
+        - Atmosphere
+  - Prop:
+      type_id: 64
+      prop_name: Offset
+      prop_type: Float32
+      values:
+        - 0.25
+  - Prop:
+      type_id: 64
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 64
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 64
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 64
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c4
+  - Prop:
+      type_id: 50
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 50
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 50
+      prop_name: CharacterControllerMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 50
+      prop_name: EnableClimbing
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableCrouching
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableFallingDown
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableGettingUp
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableHolding
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableJumping
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableReaching
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableRunning
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableSitting
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableSprinting
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableStrafing
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: EnableSwimming
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 50
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 50
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarAbilityRules
+  - Prop:
+      type_id: 50
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 50
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 50
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 50
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e03
+  - Prop:
+      type_id: 52
+      prop_name: AccessoryMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 52
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomAccessoryMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomBackAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomBackAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomFaceAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomFaceAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomFrontAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomFrontAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomHairAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomHairAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomHeadAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomHeadAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomNeckAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomNeckAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomShoulderAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomShoulderAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CustomWaistAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: CustomWaistAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: EnableEmissives
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 52
+      prop_name: EnableSound
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 52
+      prop_name: EnableVFX
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 52
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 52
+      prop_name: LimitBounds
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 52
+      prop_name: LimitMethod
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 52
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarAccessoryRules
+  - Prop:
+      type_id: 52
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 52
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 52
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e05
+  - Prop:
+      type_id: 51
+      prop_name: AnimationClipsMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: AnimationPacksMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 51
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomClimbAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomClimbAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomFallAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomFallAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomIdleAlt1AnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomIdleAlt1AnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomIdleAlt2AnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomIdleAlt2AnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomIdleAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomIdleAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomJumpAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomJumpAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomRunAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomRunAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomSwimAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomSwimAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomSwimIdleAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomSwimIdleAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CustomWalkAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: CustomWalkAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 51
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarAnimationRules
+  - Prop:
+      type_id: 51
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 51
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 51
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e04
+  - Prop:
+      type_id: 48
+      prop_name: AppearanceMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 48
+      prop_name: BuildMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomBodyBundleId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomBodyType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomBodyTypeScale
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 48
+      prop_name: CustomEyebrowEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomEyebrowId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomEyelashEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomEyelashId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomFaceEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomFaceId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomHeadEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomHeadId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomHeadScale
+      prop_type: NumberRange
+      values:
+        - - 0.95
+          - 1
+  - Prop:
+      type_id: 48
+      prop_name: CustomHeight
+      prop_type: NumberRange
+      values:
+        - - 5.5
+          - 5.5
+  - Prop:
+      type_id: 48
+      prop_name: CustomHeightScale
+      prop_type: NumberRange
+      values:
+        - - 0.9
+          - 1.05
+  - Prop:
+      type_id: 48
+      prop_name: CustomLeftArmEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomLeftArmId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomLeftLegEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomLeftLegId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomMoodEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomMoodId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomProportionsScale
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 48
+      prop_name: CustomRightArmEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomRightArmId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomRightLegEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomRightLegId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomTorsoEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: CustomTorsoId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: CustomWidthScale
+      prop_type: NumberRange
+      values:
+        - - 0.7
+          - 1
+  - Prop:
+      type_id: 48
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 48
+      prop_name: KeepPlayerHead
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 48
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarBodyRules
+  - Prop:
+      type_id: 48
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: ScaleMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 48
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 48
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e01
+  - Prop:
+      type_id: 53
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 53
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: ClothingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomClassicPantsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomClassicPantsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomClassicShirtsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomClassicShirtsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomClassicTShirtsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomClassicTShirtsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomClothingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomDressSkirtAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomDressSkirtAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomJacketAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomJacketAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomLeftShoesAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomLeftShoesAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomPantsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomPantsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomRightShoesAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomRightShoesAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomShirtAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomShirtAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomShortsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomShortsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomSweaterAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomSweaterAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CustomTShirtAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: CustomTShirtAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 53
+      prop_name: LimitBounds
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 53
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarClothingRules
+  - Prop:
+      type_id: 53
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 53
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 53
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e06
+  - Prop:
+      type_id: 49
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 49
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 49
+      prop_name: CollisionMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 49
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 49
+      prop_name: HitAndTouchDetectionMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 49
+      prop_name: LegacyCollisionMode
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 49
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarCollisionRules
+  - Prop:
+      type_id: 49
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 49
+      prop_name: SingleColliderSize
+      prop_type: Vector3
+      values:
+        - - 2
+          - 3
+          - 1
+  - Prop:
+      type_id: 49
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 49
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 49
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e02
+  - Prop:
+      type_id: 54
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 54
+      prop_name: AvatarType
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 54
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 54
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 54
+      prop_name: Name
+      prop_type: String
+      values:
+        - DefaultAvatarRules
+  - Prop:
+      type_id: 54
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 54
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 54
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 54
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e00
+  - Prop:
+      type_id: 55
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 55
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 55
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 55
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarSettings
+  - Prop:
+      type_id: 55
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 55
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 55
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 55
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000037f
+  - Prop:
+      type_id: 65
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 65
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 65
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 65
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 65
+      prop_name: Intensity
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 65
+      prop_name: Name
+      prop_type: String
+      values:
+        - Bloom
+  - Prop:
+      type_id: 65
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 65
+      prop_name: Size
+      prop_type: Float32
+      values:
+        - 24
+  - Prop:
+      type_id: 65
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 65
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 65
+      prop_name: Threshold
+      prop_type: Float32
+      values:
+        - 2
+  - Prop:
+      type_id: 65
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c5
+  - Prop:
+      type_id: 23
+      prop_name: AdorneeName
+      prop_type: String
+      values:
+        - HumanoidRootPart
+  - Prop:
+      type_id: 23
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 23
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.98039216
+          - 0.98039216
+          - 0.98039216
+  - Prop:
+      type_id: 23
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0.1
+  - Prop:
+      type_id: 23
+      prop_name: BubbleDuration
+      prop_type: Float32
+      values:
+        - 15
+  - Prop:
+      type_id: 23
+      prop_name: BubblesSpacing
+      prop_type: Float32
+      values:
+        - 6
+  - Prop:
+      type_id: 23
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 23
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 23
+      prop_name: Font
+      prop_type: Enum
+      values:
+        - 47
+  - Prop:
+      type_id: 23
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Medium
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+  - Prop:
+      type_id: 23
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 23
+      prop_name: LocalPlayerStudsOffset
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 23
+      prop_name: MaxBubbles
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 23
+      prop_name: MaxDistance
+      prop_type: Float32
+      values:
+        - 100
+  - Prop:
+      type_id: 23
+      prop_name: MinimizeDistance
+      prop_type: Float32
+      values:
+        - 40
+  - Prop:
+      type_id: 23
+      prop_name: Name
+      prop_type: String
+      values:
+        - BubbleChatConfiguration
+  - Prop:
+      type_id: 23
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 23
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 23
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 23
+      prop_name: TailVisible
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 23
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 0.22352941
+          - 0.23137255
+          - 0.23921569
+  - Prop:
+      type_id: 23
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 20
+  - Prop:
+      type_id: 23
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c9
+  - Prop:
+      type_id: 23
+      prop_name: VerticalStudsOffset
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 11
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 11
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 11
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 11
+      prop_name: Name
+      prop_type: String
+      values:
+        - CSGDictionaryService
+  - Prop:
+      type_id: 11
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 11
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 11
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 11
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000348
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - -19.696095
+            - 14.091624
+            - -19.303886
+          orientation:
+            - - -0.7061509
+              - 0.31296578
+              - -0.6351404
+            - - 0.000000014901163
+              - 0.8970132
+              - 0.44200373
+            - - 0.7080614
+              - 0.31212133
+              - -0.63342667
+  - Prop:
+      type_id: 0
+      prop_name: CameraSubject
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: CameraType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: FieldOfView
+      prop_type: Float32
+      values:
+        - 70
+  - Prop:
+      type_id: 0
+      prop_name: FieldOfViewMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Focus
+      prop_type: CFrame
+      values:
+        - position:
+            - -18.425814
+            - 13.207617
+            - -18.037033
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 0
+      prop_name: HeadLocked
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 0
+      prop_name: HeadScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 0
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Camera
+  - Prop:
+      type_id: 0
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b8
+  - Prop:
+      type_id: 0
+      prop_name: VRTiltAndRollEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 24
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.09803922
+          - 0.105882354
+          - 0.11372549
+  - Prop:
+      type_id: 24
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0
+  - Prop:
+      type_id: 24
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 24
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 24
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Bold
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Bold.otf"
+  - Prop:
+      type_id: 24
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 24
+      prop_name: HoverBackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.49019608
+          - 0.49019608
+          - 0.49019608
+  - Prop:
+      type_id: 24
+      prop_name: Name
+      prop_type: String
+      values:
+        - ChannelTabsConfiguration
+  - Prop:
+      type_id: 24
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 24
+      prop_name: SelectedTabTextColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 24
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 24
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 0.6862745
+          - 0.6862745
+          - 0.6862745
+  - Prop:
+      type_id: 24
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 18
+  - Prop:
+      type_id: 24
+      prop_name: TextStrokeColor3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 24
+      prop_name: TextStrokeTransparency
+      prop_type: Float64
+      values:
+        - 1
+  - Prop:
+      type_id: 24
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ce
+  - Prop:
+      type_id: 12
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 12
+      prop_name: BubbleChatEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 12
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 12
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 12
+      prop_name: IsAutoMigrated
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 12
+      prop_name: LoadDefaultChat
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 12
+      prop_name: Name
+      prop_type: String
+      values:
+        - Chat
+  - Prop:
+      type_id: 12
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 12
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 12
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 12
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000034e
+  - Prop:
+      type_id: 18
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 18
+      prop_name: AutocompleteEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 18
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.09803922
+          - 0.105882354
+          - 0.11372549
+  - Prop:
+      type_id: 18
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0.2
+  - Prop:
+      type_id: 18
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 18
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 18
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Medium
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+  - Prop:
+      type_id: 18
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 18
+      prop_name: KeyboardKeyCode
+      prop_type: Enum
+      values:
+        - 47
+  - Prop:
+      type_id: 18
+      prop_name: Name
+      prop_type: String
+      values:
+        - ChatInputBarConfiguration
+  - Prop:
+      type_id: 18
+      prop_name: PlaceholderColor3
+      prop_type: Color3
+      values:
+        - - 0.69803923
+          - 0.69803923
+          - 0.69803923
+  - Prop:
+      type_id: 18
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 18
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 18
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 18
+      prop_name: TargetTextChannel
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 18
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 18
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 18
+  - Prop:
+      type_id: 18
+      prop_name: TextStrokeColor3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 18
+      prop_name: TextStrokeTransparency
+      prop_type: Float64
+      values:
+        - 0.5
+  - Prop:
+      type_id: 18
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c8
+  - Prop:
+      type_id: 17
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 17
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.09803922
+          - 0.105882354
+          - 0.11372549
+  - Prop:
+      type_id: 17
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0.3
+  - Prop:
+      type_id: 17
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 17
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 17
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Medium
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+  - Prop:
+      type_id: 17
+      prop_name: HeightScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 17
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 17
+      prop_name: HorizontalAlignment
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 17
+      prop_name: Name
+      prop_type: String
+      values:
+        - ChatWindowConfiguration
+  - Prop:
+      type_id: 17
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 17
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 17
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 17
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 17
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 18
+  - Prop:
+      type_id: 17
+      prop_name: TextStrokeColor3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 17
+      prop_name: TextStrokeTransparency
+      prop_type: Float64
+      values:
+        - 0.5
+  - Prop:
+      type_id: 17
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c7
+  - Prop:
+      type_id: 17
+      prop_name: VerticalAlignment
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 17
+      prop_name: WidthScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 35
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 35
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 35
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 35
+      prop_name: Name
+      prop_type: String
+      values:
+        - CollectionService
+  - Prop:
+      type_id: 35
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 35
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 35
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 35
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000339
+  - Prop:
+      type_id: 59
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 59
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 59
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 59
+      prop_name: Name
+      prop_type: String
+      values:
+        - ConfigureServerService
+  - Prop:
+      type_id: 59
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 59
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 59
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 59
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000387
+  - Prop:
+      type_id: 44
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 44
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 44
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 44
+      prop_name: Name
+      prop_type: String
+      values:
+        - ContextActionService
+  - Prop:
+      type_id: 44
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 44
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 44
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 44
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000375
+  - Prop:
+      type_id: 41
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 41
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 41
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 41
+      prop_name: Name
+      prop_type: String
+      values:
+        - CookiesService
+  - Prop:
+      type_id: 41
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 41
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 41
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 41
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036f
+  - Prop:
+      type_id: 60
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 60
+      prop_name: AutomaticRetry
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 60
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 60
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 60
+      prop_name: LegacyNamingScheme
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 60
+      prop_name: Name
+      prop_type: String
+      values:
+        - DataStoreService
+  - Prop:
+      type_id: 60
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 60
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 60
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 60
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003af
+  - Prop:
+      type_id: 40
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 40
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 40
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 40
+      prop_name: MaxItems
+      prop_type: Int32
+      values:
+        - 1000
+  - Prop:
+      type_id: 40
+      prop_name: Name
+      prop_type: String
+      values:
+        - Debris
+  - Prop:
+      type_id: 40
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 40
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 40
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 40
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036e
+  - Prop:
+      type_id: 4
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 4
+      prop_name: AutoLocalize
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 4
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: Color3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 4
+      prop_name: Face
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 4
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 4
+      prop_name: MetalnessMapContent
+      prop_type: Content
+      values:
+        - None
+  - Prop:
+      type_id: 4
+      prop_name: Name
+      prop_type: String
+      values:
+        - Decal
+  - Prop:
+      type_id: 4
+      prop_name: NormalMapContent
+      prop_type: Content
+      values:
+        - None
+  - Prop:
+      type_id: 4
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: RoughnessMapContent
+      prop_type: Content
+      values:
+        - None
+  - Prop:
+      type_id: 4
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 4
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 4
+      prop_name: TextureContent
+      prop_type: Content
+      values:
+        - Uri: "rbxasset://textures/SpawnLocation.png"
+  - Prop:
+      type_id: 4
+      prop_name: TexturePack
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 4
+      prop_name: TexturePackMetadata
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 4
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: UVOffset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 4
+      prop_name: UVScale
+      prop_type: Vector2
+      values:
+        - - 1
+          - 1
+  - Prop:
+      type_id: 4
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bd
+  - Prop:
+      type_id: 4
+      prop_name: ZIndex
+      prop_type: Int32
+      values:
+        - 1
+  - Prop:
+      type_id: 66
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 66
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 66
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 66
+      prop_name: FarIntensity
+      prop_type: Float32
+      values:
+        - 0.1
+  - Prop:
+      type_id: 66
+      prop_name: FocusDistance
+      prop_type: Float32
+      values:
+        - 0.05
+  - Prop:
+      type_id: 66
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 66
+      prop_name: InFocusRadius
+      prop_type: Float32
+      values:
+        - 30
+  - Prop:
+      type_id: 66
+      prop_name: Name
+      prop_type: String
+      values:
+        - DepthOfField
+  - Prop:
+      type_id: 66
+      prop_name: NearIntensity
+      prop_type: Float32
+      values:
+        - 0.75
+  - Prop:
+      type_id: 66
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 66
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 66
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 66
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c6
+  - Prop:
+      type_id: 39
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 39
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 39
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 39
+      prop_name: Name
+      prop_type: String
+      values:
+        - GamePassService
+  - Prop:
+      type_id: 39
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 39
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 39
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 39
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036d
+  - Prop:
+      type_id: 58
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 58
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 58
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 58
+      prop_name: Name
+      prop_type: String
+      values:
+        - GuidRegistryService
+  - Prop:
+      type_id: 58
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 58
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 58
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 58
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000384
+  - Prop:
+      type_id: 61
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 61
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 61
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 61
+      prop_name: HttpEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 61
+      prop_name: Name
+      prop_type: String
+      values:
+        - HttpService
+  - Prop:
+      type_id: 61
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 61
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 61
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 61
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ac
+  - Prop:
+      type_id: 20
+      prop_name: Active
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 20
+      prop_name: AnchorPoint
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 20
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 20
+      prop_name: AutoLocalize
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 20
+      prop_name: AutomaticSize
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 20
+      prop_name: BackgroundTransparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: BorderColor3
+      prop_type: Color3
+      values:
+        - - 0.10588236
+          - 0.16470589
+          - 0.20784315
+  - Prop:
+      type_id: 20
+      prop_name: BorderMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: BorderSizePixel
+      prop_type: Int32
+      values:
+        - 1
+  - Prop:
+      type_id: 20
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: ClipsDescendants
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 20
+      prop_name: Draggable
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 20
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 20
+      prop_name: ImageColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 20
+      prop_name: ImageContent
+      prop_type: Content
+      values:
+        - None
+  - Prop:
+      type_id: 20
+      prop_name: ImageRectOffset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 20
+      prop_name: ImageRectSize
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 20
+      prop_name: ImageTransparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: InputSink
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: Interactable
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 20
+      prop_name: LayoutOrder
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: Name
+      prop_type: String
+      values:
+        - ImageLabel
+  - Prop:
+      type_id: 20
+      prop_name: NextSelectionDown
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: NextSelectionLeft
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: NextSelectionRight
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: NextSelectionUp
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: Position
+      prop_type: UDim2
+      values:
+        - - - 0
+            - 0
+          - - 0
+            - 0
+  - Prop:
+      type_id: 20
+      prop_name: ResampleMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: RootLocalizationTable
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 20
+      prop_name: ScaleType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: Selectable
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 20
+      prop_name: SelectionBehaviorDown
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: SelectionBehaviorLeft
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: SelectionBehaviorRight
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: SelectionBehaviorUp
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: SelectionGroup
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 20
+      prop_name: SelectionImageObject
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: SelectionOrder
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: Size
+      prop_type: UDim2
+      values:
+        - - - 0
+            - 100
+          - - 0
+            - 100
+  - Prop:
+      type_id: 20
+      prop_name: SizeConstraint
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: SliceCenter
+      prop_type: Rect
+      values:
+        - - - 0
+            - 0
+          - - 0
+            - 0
+  - Prop:
+      type_id: 20
+      prop_name: SliceScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 20
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 20
+      prop_name: TileSize
+      prop_type: UDim2
+      values:
+        - - - 1
+            - 0
+          - - 1
+            - 0
+  - Prop:
+      type_id: 20
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003cb
+  - Prop:
+      type_id: 20
+      prop_name: Visible
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 20
+      prop_name: ZIndex
+      prop_type: Int32
+      values:
+        - 1
+  - Prop:
+      type_id: 38
+      prop_name: AllowInsertFreeModels
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 38
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 38
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 38
+      prop_name: Name
+      prop_type: String
+      values:
+        - InsertService
+  - Prop:
+      type_id: 38
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 38
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 38
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 38
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036c
+  - Prop:
+      type_id: 67
+      prop_name: Ambient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 67
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - "\u0002\u0000\u0000\u0000&\u0000\u0000\u0000RBX_LightingTechnologyUnifiedMigration\u0003\u0001 \u0000\u0000\u0000RBX_OriginalTechnologyOnFileLoad\u0004\u0003\u0000\u0000\u0000"
+  - Prop:
+      type_id: 67
+      prop_name: Brightness
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 67
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: ColorShift_Bottom
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 67
+      prop_name: ColorShift_Top
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 67
+      prop_name: EnvironmentDiffuseScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 67
+      prop_name: EnvironmentSpecularScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 67
+      prop_name: ExposureCompensation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: ExtendLightRangeTo120
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: FogColor
+      prop_type: Color3
+      values:
+        - - 0.75294125
+          - 0.75294125
+          - 0.75294125
+  - Prop:
+      type_id: 67
+      prop_name: FogEnd
+      prop_type: Float32
+      values:
+        - 100000
+  - Prop:
+      type_id: 67
+      prop_name: FogStart
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: GeographicLatitude
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: GlobalShadows
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 67
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 67
+      prop_name: LightingStyle
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 67
+      prop_name: Name
+      prop_type: String
+      values:
+        - Lighting
+  - Prop:
+      type_id: 67
+      prop_name: OutdoorAmbient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 67
+      prop_name: Outlines
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 67
+      prop_name: PrioritizeLightingQuality
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 67
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 67
+      prop_name: ShadowSoftness
+      prop_type: Float32
+      values:
+        - 0.2
+  - Prop:
+      type_id: 67
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 67
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 67
+      prop_name: Technology
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 67
+      prop_name: TimeOfDay
+      prop_type: String
+      values:
+        - "14:30:00"
+  - Prop:
+      type_id: 67
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b0
+  - Prop:
+      type_id: 33
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 33
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 33
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 33
+      prop_name: Name
+      prop_type: String
+      values:
+        - LocalizationService
+  - Prop:
+      type_id: 33
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 33
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 33
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 33
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000363
+  - Prop:
+      type_id: 56
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 56
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 56
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 56
+      prop_name: Name
+      prop_type: String
+      values:
+        - Instance
+  - Prop:
+      type_id: 56
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 56
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 56
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 56
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b1
+  - Prop:
+      type_id: 79
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 79
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 79
+      prop_name: Name
+      prop_type: String
+      values:
+        - LuaWebService
+  - Prop:
+      type_id: 79
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 79
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 79
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 79
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000f22
+  - Prop:
+      type_id: 16
+      prop_name: AsphaltName
+      prop_type: String
+      values:
+        - Asphalt
+  - Prop:
+      type_id: 16
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 16
+      prop_name: BasaltName
+      prop_type: String
+      values:
+        - Basalt
+  - Prop:
+      type_id: 16
+      prop_name: BrickName
+      prop_type: String
+      values:
+        - Brick
+  - Prop:
+      type_id: 16
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 16
+      prop_name: CardboardName
+      prop_type: String
+      values:
+        - Cardboard
+  - Prop:
+      type_id: 16
+      prop_name: CarpetName
+      prop_type: String
+      values:
+        - Carpet
+  - Prop:
+      type_id: 16
+      prop_name: CeramicTilesName
+      prop_type: String
+      values:
+        - CeramicTiles
+  - Prop:
+      type_id: 16
+      prop_name: ClayRoofTilesName
+      prop_type: String
+      values:
+        - ClayRoofTiles
+  - Prop:
+      type_id: 16
+      prop_name: CobblestoneName
+      prop_type: String
+      values:
+        - Cobblestone
+  - Prop:
+      type_id: 16
+      prop_name: ConcreteName
+      prop_type: String
+      values:
+        - Concrete
+  - Prop:
+      type_id: 16
+      prop_name: CorrodedMetalName
+      prop_type: String
+      values:
+        - CorrodedMetal
+  - Prop:
+      type_id: 16
+      prop_name: CrackedLavaName
+      prop_type: String
+      values:
+        - CrackedLava
+  - Prop:
+      type_id: 16
+      prop_name: DiamondPlateName
+      prop_type: String
+      values:
+        - DiamondPlate
+  - Prop:
+      type_id: 16
+      prop_name: FabricName
+      prop_type: String
+      values:
+        - Fabric
+  - Prop:
+      type_id: 16
+      prop_name: FoilName
+      prop_type: String
+      values:
+        - Foil
+  - Prop:
+      type_id: 16
+      prop_name: GlacierName
+      prop_type: String
+      values:
+        - Glacier
+  - Prop:
+      type_id: 16
+      prop_name: GraniteName
+      prop_type: String
+      values:
+        - Granite
+  - Prop:
+      type_id: 16
+      prop_name: GrassName
+      prop_type: String
+      values:
+        - Grass
+  - Prop:
+      type_id: 16
+      prop_name: GroundName
+      prop_type: String
+      values:
+        - Ground
+  - Prop:
+      type_id: 16
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 16
+      prop_name: IceName
+      prop_type: String
+      values:
+        - Ice
+  - Prop:
+      type_id: 16
+      prop_name: LeafyGrassName
+      prop_type: String
+      values:
+        - LeafyGrass
+  - Prop:
+      type_id: 16
+      prop_name: LeatherName
+      prop_type: String
+      values:
+        - Leather
+  - Prop:
+      type_id: 16
+      prop_name: LimestoneName
+      prop_type: String
+      values:
+        - Limestone
+  - Prop:
+      type_id: 16
+      prop_name: MarbleName
+      prop_type: String
+      values:
+        - Marble
+  - Prop:
+      type_id: 16
+      prop_name: MetalName
+      prop_type: String
+      values:
+        - Metal
+  - Prop:
+      type_id: 16
+      prop_name: MudName
+      prop_type: String
+      values:
+        - Mud
+  - Prop:
+      type_id: 16
+      prop_name: Name
+      prop_type: String
+      values:
+        - MaterialService
+  - Prop:
+      type_id: 16
+      prop_name: PavementName
+      prop_type: String
+      values:
+        - Pavement
+  - Prop:
+      type_id: 16
+      prop_name: PebbleName
+      prop_type: String
+      values:
+        - Pebble
+  - Prop:
+      type_id: 16
+      prop_name: PlasterName
+      prop_type: String
+      values:
+        - Plaster
+  - Prop:
+      type_id: 16
+      prop_name: PlasticName
+      prop_type: String
+      values:
+        - Plastic
+  - Prop:
+      type_id: 16
+      prop_name: RockName
+      prop_type: String
+      values:
+        - Rock
+  - Prop:
+      type_id: 16
+      prop_name: RoofShinglesName
+      prop_type: String
+      values:
+        - RoofShingles
+  - Prop:
+      type_id: 16
+      prop_name: RubberName
+      prop_type: String
+      values:
+        - Rubber
+  - Prop:
+      type_id: 16
+      prop_name: SaltName
+      prop_type: String
+      values:
+        - Salt
+  - Prop:
+      type_id: 16
+      prop_name: SandName
+      prop_type: String
+      values:
+        - Sand
+  - Prop:
+      type_id: 16
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 16
+      prop_name: SandstoneName
+      prop_type: String
+      values:
+        - Sandstone
+  - Prop:
+      type_id: 16
+      prop_name: SlateName
+      prop_type: String
+      values:
+        - Slate
+  - Prop:
+      type_id: 16
+      prop_name: SmoothPlasticName
+      prop_type: String
+      values:
+        - SmoothPlastic
+  - Prop:
+      type_id: 16
+      prop_name: SnowName
+      prop_type: String
+      values:
+        - Snow
+  - Prop:
+      type_id: 16
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 16
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 16
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000356
+  - Prop:
+      type_id: 16
+      prop_name: Use2022MaterialsXml
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 16
+      prop_name: WoodName
+      prop_type: String
+      values:
+        - Wood
+  - Prop:
+      type_id: 16
+      prop_name: WoodPlanksName
+      prop_type: String
+      values:
+        - WoodPlanks
+  - Prop:
+      type_id: 10
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 10
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 10
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 10
+      prop_name: Name
+      prop_type: String
+      values:
+        - NonReplicatedCSGDictionaryService
+  - Prop:
+      type_id: 10
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 10
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 10
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 10
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000347
+  - Prop:
+      type_id: 57
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 57
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 57
+      prop_name: IsDehydrated
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 57
+      prop_name: Name
+      prop_type: String
+      values:
+        - Packages
+  - Prop:
+      type_id: 57
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 57
+      prop_name: ShellPackagesCount
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: SkippedInstancesCount
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 57
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 57
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000383
+  - Prop:
+      type_id: 2
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 2
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 2
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 2
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 2
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 2
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - -8
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - -8
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 2
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+        - Default
+  - Prop:
+      type_id: 2
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 91
+          - 91
+          - 91
+        - - 91
+          - 91
+          - 91
+  - Prop:
+      type_id: 2
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+        - Default
+  - Prop:
+      type_id: 2
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: formFactorRaw
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 2
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 2
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+        - 7ae0e5570bbb7d4c0a5586bb000003b9
+  - Prop:
+      type_id: 2
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 2
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 2
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+        - false
+  - Prop:
+      type_id: 2
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+        - 256
+  - Prop:
+      type_id: 2
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 2
+      prop_name: Name
+      prop_type: String
+      values:
+        - Baseplate
+        - Baseplate
+  - Prop:
+      type_id: 2
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 2
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 2
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 2
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 2
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+        - false
+  - Prop:
+      type_id: 2
+      prop_name: shape
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 2
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 2048
+          - 16
+          - 2048
+        - - 2048
+          - 16
+          - 2048
+  - Prop:
+      type_id: 2
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+  - Prop:
+      type_id: 2
+      prop_name: Tags
+      prop_type: String
+      values:
+        - atag
+        - "atag\u0000anothertag"
+  - Prop:
+      type_id: 2
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 2
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 2
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b9
+        - 7ae0e5570bbb7d4c0a5586bb000008b3
+  - Prop:
+      type_id: 2
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 78
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 78
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 78
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 78
+      prop_name: Name
+      prop_type: String
+      values:
+        - PermissionsService
+  - Prop:
+      type_id: 78
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 78
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 78
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 78
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e07
+  - Prop:
+      type_id: 36
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 36
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 36
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 36
+      prop_name: Name
+      prop_type: String
+      values:
+        - PhysicsService
+  - Prop:
+      type_id: 36
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 36
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 36
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 36
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000369
+  - Prop:
+      type_id: 26
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 26
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 26
+      prop_name: CustomPoliciesEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 26
+      prop_name: EmulatedCountryCode
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 26
+      prop_name: EmulatedGameLocale
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 26
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 26
+      prop_name: Name
+      prop_type: String
+      values:
+        - PlayerEmulatorService
+  - Prop:
+      type_id: 26
+      prop_name: PlayerEmulationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 26
+      prop_name: PseudolocalizationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 26
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 26
+      prop_name: SerializedEmulatedPolicyInfo
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 26
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 26
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 26
+      prop_name: TextElongationFactor
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 26
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000035a
+  - Prop:
+      type_id: 13
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 13
+      prop_name: BanningEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 13
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 13
+      prop_name: CharacterAutoLoads
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 13
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 13
+      prop_name: MaxPlayersInternal
+      prop_type: Int32
+      values:
+        - 60
+  - Prop:
+      type_id: 13
+      prop_name: Name
+      prop_type: String
+      values:
+        - Players
+  - Prop:
+      type_id: 13
+      prop_name: PreferredPlayersInternal
+      prop_type: Int32
+      values:
+        - 60
+  - Prop:
+      type_id: 13
+      prop_name: RespawnTime
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 13
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 13
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 13
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 13
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000350
+  - Prop:
+      type_id: 13
+      prop_name: UseStrafingAnimations
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 68
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 68
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 68
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 68
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 68
+      prop_name: MaxIndicatorsVisible
+      prop_type: Int32
+      values:
+        - 16
+  - Prop:
+      type_id: 68
+      prop_name: MaxPromptsVisible
+      prop_type: Int32
+      values:
+        - 16
+  - Prop:
+      type_id: 68
+      prop_name: Name
+      prop_type: String
+      values:
+        - ProximityPromptService
+  - Prop:
+      type_id: 68
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 68
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 68
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 68
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b2
+  - Prop:
+      type_id: 14
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 14
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 14
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 14
+      prop_name: Name
+      prop_type: String
+      values:
+        - ReplicatedFirst
+  - Prop:
+      type_id: 14
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 14
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 14
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 14
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000353
+  - Prop:
+      type_id: 69
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 69
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 69
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 69
+      prop_name: Name
+      prop_type: String
+      values:
+        - ReplicatedStorage
+  - Prop:
+      type_id: 69
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 69
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 69
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 69
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000398
+  - Prop:
+      type_id: 45
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 45
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 45
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 45
+      prop_name: Name
+      prop_type: String
+      values:
+        - Instance
+  - Prop:
+      type_id: 45
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 45
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 45
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 45
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000376
+  - Prop:
+      type_id: 42
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 42
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 42
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 42
+      prop_name: Name
+      prop_type: String
+      values:
+        - Selection
+  - Prop:
+      type_id: 42
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 42
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 42
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 42
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000370
+  - Prop:
+      type_id: 70
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 70
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 70
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 70
+      prop_name: LoadStringEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 70
+      prop_name: Name
+      prop_type: String
+      values:
+        - ServerScriptService
+  - Prop:
+      type_id: 70
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 70
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 70
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 70
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000399
+  - Prop:
+      type_id: 71
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 71
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 71
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 71
+      prop_name: Name
+      prop_type: String
+      values:
+        - ServerStorage
+  - Prop:
+      type_id: 71
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 71
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 71
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 71
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000039a
+  - Prop:
+      type_id: 72
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 72
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 72
+      prop_name: HiddenServices
+      prop_type: String
+      values:
+        - "\u0000\u0000\u0000\u0000"
+  - Prop:
+      type_id: 72
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 72
+      prop_name: Name
+      prop_type: String
+      values:
+        - ServiceVisibilityService
+  - Prop:
+      type_id: 72
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 72
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 72
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 72
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003a1
+  - Prop:
+      type_id: 72
+      prop_name: VisibleServices
+      prop_type: String
+      values:
+        - "\u0000\u0000\u0000\u0000"
+  - Prop:
+      type_id: 62
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 62
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 62
+      prop_name: CelestialBodiesShown
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 62
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 62
+      prop_name: MoonAngularSize
+      prop_type: Float32
+      values:
+        - 11
+  - Prop:
+      type_id: 62
+      prop_name: MoonTextureContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6444320592"
+  - Prop:
+      type_id: 62
+      prop_name: Name
+      prop_type: String
+      values:
+        - Sky
+  - Prop:
+      type_id: 62
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 62
+      prop_name: SkyboxBackContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6444884337"
+  - Prop:
+      type_id: 62
+      prop_name: SkyboxDownContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6444884785"
+  - Prop:
+      type_id: 62
+      prop_name: SkyboxFrontContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6444884337"
+  - Prop:
+      type_id: 62
+      prop_name: SkyboxLeftContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6444884337"
+  - Prop:
+      type_id: 62
+      prop_name: SkyboxOrientation
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 62
+      prop_name: SkyboxRightContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6444884337"
+  - Prop:
+      type_id: 62
+      prop_name: SkyboxUpContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6412503613"
+  - Prop:
+      type_id: 62
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - 332039975
+  - Prop:
+      type_id: 62
+      prop_name: StarCount
+      prop_type: Int32
+      values:
+        - 3000
+  - Prop:
+      type_id: 62
+      prop_name: SunAngularSize
+      prop_type: Float32
+      values:
+        - 11
+  - Prop:
+      type_id: 62
+      prop_name: SunTextureContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6196665106"
+  - Prop:
+      type_id: 62
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 62
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c2
+  - Prop:
+      type_id: 8
+      prop_name: AcousticSimulationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 8
+      prop_name: AmbientReverb
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 8
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 8
+      prop_name: AudioApiByDefault
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 8
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 8
+      prop_name: CharacterSoundsUseNewApi
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 8
+      prop_name: DefaultListenerLocation
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 8
+      prop_name: DiffractionEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 8
+      prop_name: DistanceFactor
+      prop_type: Float32
+      values:
+        - 3.33
+  - Prop:
+      type_id: 8
+      prop_name: DopplerScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 8
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 8
+      prop_name: IsNewExpForAudioApiByDefault
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 8
+      prop_name: ListenerCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 8
+      prop_name: ListenerObject
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 8
+      prop_name: ListenerType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 8
+      prop_name: Name
+      prop_type: String
+      values:
+        - SoundService
+  - Prop:
+      type_id: 8
+      prop_name: OcclusionEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 8
+      prop_name: RespectFilteringEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 8
+      prop_name: ReverbEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 8
+      prop_name: RolloffScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 8
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 8
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 8
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 8
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000033a
+  - Prop:
+      type_id: 8
+      prop_name: VolumetricAudio
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 5
+      prop_name: AllowTeamChangeOnTouch
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 5
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 5
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 5
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 5
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 5
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0.5
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 5
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+  - Prop:
+      type_id: 5
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 163
+          - 162
+          - 165
+  - Prop:
+      type_id: 5
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+  - Prop:
+      type_id: 5
+      prop_name: Duration
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: formFactorRaw
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 5
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 5
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 5
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 5
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 5
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 5
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+  - Prop:
+      type_id: 5
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 5
+      prop_name: Name
+      prop_type: String
+      values:
+        - SpawnLocation
+  - Prop:
+      type_id: 5
+      prop_name: Neutral
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 5
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 5
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 5
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 5
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: shape
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 5
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 12
+          - 1
+          - 12
+  - Prop:
+      type_id: 5
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 5
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 5
+      prop_name: TeamColor
+      prop_type: BrickColor
+      values:
+        - 194
+  - Prop:
+      type_id: 5
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 5
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 5
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bc
+  - Prop:
+      type_id: 5
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 29
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 29
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 29
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterCharacterScripts
+  - Prop:
+      type_id: 29
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 29
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 29
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c0
+  - Prop:
+      type_id: 32
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 32
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 32
+      prop_name: ClipsDescendantsSupportsRotation
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 32
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 32
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterGui
+  - Prop:
+      type_id: 32
+      prop_name: ResetPlayerGuiOnSpawn
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 32
+      prop_name: RtlTextSupport
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 32
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 32
+      prop_name: ScreenOrientation
+      prop_type: Enum
+      values:
+        - 4
+  - Prop:
+      type_id: 32
+      prop_name: ShowDevelopmentGui
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 32
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 32
+      prop_name: StudioDefaultStyleSheet
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 32
+      prop_name: StudioInsertWidgetLayerCollectorAutoLinkStyleSheet
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 32
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 32
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000361
+  - Prop:
+      type_id: 32
+      prop_name: VirtualCursorMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 31
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 31
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterPack
+  - Prop:
+      type_id: 31
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 31
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 31
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 31
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000360
+  - Prop:
+      type_id: 30
+      prop_name: AllowCustomAnimations
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 30
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 30
+      prop_name: AutoJumpEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 30
+      prop_name: AvatarJointUpgrade_SerializedRollout
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 30
+      prop_name: CameraMaxZoomDistance
+      prop_type: Float32
+      values:
+        - 128
+  - Prop:
+      type_id: 30
+      prop_name: CameraMinZoomDistance
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 30
+      prop_name: CameraMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: CharacterBreakJointsOnDeath
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 30
+      prop_name: CharacterJumpHeight
+      prop_type: Float32
+      values:
+        - 7.2
+  - Prop:
+      type_id: 30
+      prop_name: CharacterJumpPower
+      prop_type: Float32
+      values:
+        - 50
+  - Prop:
+      type_id: 30
+      prop_name: CharacterMaxSlopeAngle
+      prop_type: Float32
+      values:
+        - 89
+  - Prop:
+      type_id: 30
+      prop_name: CharacterUseJumpPower
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 30
+      prop_name: CharacterWalkSpeed
+      prop_type: Float32
+      values:
+        - 16
+  - Prop:
+      type_id: 30
+      prop_name: ClassicDeath
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 30
+      prop_name: CreateDefaultPlayerModule
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 30
+      prop_name: DevCameraOcclusionMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: DevComputerCameraMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: DevComputerMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: DevTouchCameraMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: DevTouchMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: EnableDynamicHeads
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: EnableMouseLockOption
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDFace
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDHead
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDLeftArm
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDLeftLeg
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDPants
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDRightArm
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDRightLeg
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDShirt
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDTeeShirt
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAssetIDTorso
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsAvatar
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsR15Collision
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsScaleRangeBodyType
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsScaleRangeHead
+      prop_type: NumberRange
+      values:
+        - - 0.95
+          - 1
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsScaleRangeHeight
+      prop_type: NumberRange
+      values:
+        - - 0.9
+          - 1.05
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsScaleRangeProportion
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 30
+      prop_name: GameSettingsScaleRangeWidth
+      prop_type: NumberRange
+      values:
+        - - 0.7
+          - 1
+  - Prop:
+      type_id: 30
+      prop_name: HealthDisplayDistance
+      prop_type: Float32
+      values:
+        - 100
+  - Prop:
+      type_id: 30
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 30
+      prop_name: LoadCharacterAppearance
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 30
+      prop_name: LoadCharacterLayeredClothing
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: LuaCharacterController
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterPlayer
+  - Prop:
+      type_id: 30
+      prop_name: NameDisplayDistance
+      prop_type: Float32
+      values:
+        - 100
+  - Prop:
+      type_id: 30
+      prop_name: PlayerModuleStatus
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 30
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 30
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 30
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000035f
+  - Prop:
+      type_id: 30
+      prop_name: UserEmotesEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 28
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 28
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 28
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 28
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterPlayerScripts
+  - Prop:
+      type_id: 28
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 28
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 28
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 28
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bf
+  - Prop:
+      type_id: 37
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 37
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 37
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 37
+      prop_name: Name
+      prop_type: String
+      values:
+        - InsertionHash
+  - Prop:
+      type_id: 37
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 37
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 37
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 37
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c1
+  - Prop:
+      type_id: 37
+      prop_name: Value
+      prop_type: String
+      values:
+        - "{a4b4fc84-d3fa-4580-b9d0-98390afa7f7f}"
+  - Prop:
+      type_id: 27
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 27
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 27
+      prop_name: EnableScriptCollabByDefaultOnLoad
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 27
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 27
+      prop_name: Name
+      prop_type: String
+      values:
+        - StudioData
+  - Prop:
+      type_id: 27
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 27
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 27
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 27
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000035d
+  - Prop:
+      type_id: 63
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 63
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 63
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 63
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 63
+      prop_name: Intensity
+      prop_type: Float32
+      values:
+        - 0.01
+  - Prop:
+      type_id: 63
+      prop_name: Name
+      prop_type: String
+      values:
+        - SunRays
+  - Prop:
+      type_id: 63
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 63
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 63
+      prop_name: Spread
+      prop_type: Float32
+      values:
+        - 0.1
+  - Prop:
+      type_id: 63
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 63
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c3
+  - Prop:
+      type_id: 73
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 73
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 73
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 73
+      prop_name: Name
+      prop_type: String
+      values:
+        - Teams
+  - Prop:
+      type_id: 73
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 73
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 73
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 73
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b3
+  - Prop:
+      type_id: 34
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 34
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 34
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 34
+      prop_name: Name
+      prop_type: String
+      values:
+        - Teleport Service
+  - Prop:
+      type_id: 34
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 34
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 34
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 34
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000367
+  - Prop:
+      type_id: 3
+      prop_name: AcquisitionMethod
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 3
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 3
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 3
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 3
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 3
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 4
+  - Prop:
+      type_id: 3
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 3
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+  - Prop:
+      type_id: 3
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 163
+          - 162
+          - 165
+  - Prop:
+      type_id: 3
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+  - Prop:
+      type_id: 3
+      prop_name: Decoration
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 3
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 3
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: GrassLength
+      prop_type: Float32
+      values:
+        - 0.7
+  - Prop:
+      type_id: 3
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 3
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 3
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 3
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+  - Prop:
+      type_id: 3
+      prop_name: MaterialColors
+      prop_type: String
+      values:
+        - 00 00 00 00 00 00 6f 7e 3e 58 59 56 98 98 98 8a 61 49 cf cb a7 ac 94 6c 63 64 66 dd e4 e5 eb fd ff 94 7c 5f 79 70 62 4b 4a 4a 8c 82 68 ff 18 43 50 54 54 86 86 76 cc d2 df 6a 86 40 ff ff fe ff f3 c0 8f 90 87
+  - Prop:
+      type_id: 3
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 3
+      prop_name: Materials
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: Name
+      prop_type: String
+      values:
+        - Terrain
+  - Prop:
+      type_id: 3
+      prop_name: PhysicsGrid
+      prop_type: String
+      values:
+        - "\u0002\u0003\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+  - Prop:
+      type_id: 3
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 3
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 3
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 3
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 3
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 2044
+          - 252
+          - 2044
+  - Prop:
+      type_id: 3
+      prop_name: SmoothGrid
+      prop_type: String
+      values:
+        - "\u0001\u0005"
+  - Prop:
+      type_id: 3
+      prop_name: SmoothVoxelsUpgraded
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 3
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 3
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 3
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 3
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 3
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bb
+  - Prop:
+      type_id: 3
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 3
+      prop_name: WaterColor
+      prop_type: Color3
+      values:
+        - - 0.04705883
+          - 0.32941177
+          - 0.36078432
+  - Prop:
+      type_id: 3
+      prop_name: WaterReflectance
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 3
+      prop_name: WaterTransparency
+      prop_type: Float32
+      values:
+        - 0.3
+  - Prop:
+      type_id: 3
+      prop_name: WaterWaveSize
+      prop_type: Float32
+      values:
+        - 0.15
+  - Prop:
+      type_id: 3
+      prop_name: WaterWaveSpeed
+      prop_type: Float32
+      values:
+        - 10
+  - Prop:
+      type_id: 74
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 74
+      prop_name: AutoRuns
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 74
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 74
+      prop_name: Description
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 74
+      prop_name: ExecuteWithStudioRun
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 74
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 74
+      prop_name: IsPhysicsEnvironmentalThrottled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 74
+      prop_name: IsSleepAllowed
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 74
+      prop_name: Name
+      prop_type: String
+      values:
+        - TestService
+  - Prop:
+      type_id: 74
+      prop_name: NumberOfPlayers
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 74
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 74
+      prop_name: SimulateSecondsLag
+      prop_type: Float64
+      values:
+        - 0
+  - Prop:
+      type_id: 74
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 74
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 74
+      prop_name: ThrottlePhysicsToRealtime
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 74
+      prop_name: Timeout
+      prop_type: Float64
+      values:
+        - 10
+  - Prop:
+      type_id: 74
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b4
+  - Prop:
+      type_id: 25
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 25
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 25
+      prop_name: ChatTranslationFTUXShown
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 25
+      prop_name: ChatTranslationToggleEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 25
+      prop_name: ChatVersion
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 25
+      prop_name: CreateDefaultCommands
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 25
+      prop_name: CreateDefaultTextChannels
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 25
+      prop_name: EnableProtectedChat
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 25
+      prop_name: HasSeenDeprecationDialog
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 25
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 25
+      prop_name: IsLegacyChatDisabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 25
+      prop_name: Name
+      prop_type: String
+      values:
+        - TextChatService
+  - Prop:
+      type_id: 25
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 25
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 25
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 25
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000357
+  - Prop:
+      type_id: 1
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: AutoLocalize
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 1
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Color3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 1
+      prop_name: Face
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 1
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+        - 7ae0e5570bbb7d4c0a5586bb000003ba
+  - Prop:
+      type_id: 1
+      prop_name: MetalnessMapContent
+      prop_type: Content
+      values:
+        - None
+        - None
+  - Prop:
+      type_id: 1
+      prop_name: Name
+      prop_type: String
+      values:
+        - Texture
+        - Texture
+  - Prop:
+      type_id: 1
+      prop_name: NormalMapContent
+      prop_type: Content
+      values:
+        - None
+        - None
+  - Prop:
+      type_id: 1
+      prop_name: OffsetStudsU
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: OffsetStudsV
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: RoughnessMapContent
+      prop_type: Content
+      values:
+        - None
+        - None
+  - Prop:
+      type_id: 1
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+  - Prop:
+      type_id: 1
+      prop_name: StudsPerTileU
+      prop_type: Float32
+      values:
+        - 8
+        - 8
+  - Prop:
+      type_id: 1
+      prop_name: StudsPerTileV
+      prop_type: Float32
+      values:
+        - 8
+        - 8
+  - Prop:
+      type_id: 1
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: TextureContent
+      prop_type: Content
+      values:
+        - Uri: "rbxassetid://6372755229"
+        - Uri: "rbxassetid://6372755229"
+  - Prop:
+      type_id: 1
+      prop_name: TexturePack
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: TexturePackMetadata
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0.8
+        - 0.8
+  - Prop:
+      type_id: 1
+      prop_name: UVOffset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+        - - 0
+          - 0
+  - Prop:
+      type_id: 1
+      prop_name: UVScale
+      prop_type: Vector2
+      values:
+        - - 1
+          - 1
+        - - 1
+          - 1
+  - Prop:
+      type_id: 1
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ba
+        - 7ae0e5570bbb7d4c0a5586bb000008b4
+  - Prop:
+      type_id: 1
+      prop_name: ZIndex
+      prop_type: Int32
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 7
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 7
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 7
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 7
+      prop_name: Name
+      prop_type: String
+      values:
+        - Instance
+  - Prop:
+      type_id: 7
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 7
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 7
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 7
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000338
+  - Prop:
+      type_id: 47
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 47
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 47
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 47
+      prop_name: Name
+      prop_type: String
+      values:
+        - TouchInputService
+  - Prop:
+      type_id: 47
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 47
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 47
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 47
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000379
+  - Prop:
+      type_id: 15
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 15
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 15
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 15
+      prop_name: Name
+      prop_type: String
+      values:
+        - TweenService
+  - Prop:
+      type_id: 15
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 15
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 15
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 15
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000355
+  - Prop:
+      type_id: 75
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 75
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 75
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 75
+      prop_name: Name
+      prop_type: String
+      values:
+        - UGCAvatarService
+  - Prop:
+      type_id: 75
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 75
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 75
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 75
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b5
+  - Prop:
+      type_id: 21
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 21
+      prop_name: BottomLeftRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 21
+      prop_name: BottomRightRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 21
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 21
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 21
+      prop_name: Name
+      prop_type: String
+      values:
+        - UICorner
+  - Prop:
+      type_id: 21
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 21
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 21
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 21
+      prop_name: TopLeftRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 21
+      prop_name: TopRightRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 21
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003cc
+  - Prop:
+      type_id: 19
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 19
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 19
+      prop_name: Color
+      prop_type: ColorSequence
+      values:
+        - keypoints:
+            - time: 0
+              color:
+                - 1
+                - 1
+                - 1
+            - time: 1
+              color:
+                - 1
+                - 1
+                - 1
+  - Prop:
+      type_id: 19
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 19
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 19
+      prop_name: Name
+      prop_type: String
+      values:
+        - UIGradient
+  - Prop:
+      type_id: 19
+      prop_name: Offset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 19
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 19
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 19
+      prop_name: Scale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 19
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 19
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 19
+      prop_name: TileMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 19
+      prop_name: Transparency
+      prop_type: NumberSequence
+      values:
+        - keypoints:
+            - time: 0
+              value: 0
+              envelope: 0
+            - time: 1
+              value: 0
+              envelope: 0
+  - Prop:
+      type_id: 19
+      prop_name: Type
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 19
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ca
+  - Prop:
+      type_id: 22
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 22
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 22
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 22
+      prop_name: Name
+      prop_type: String
+      values:
+        - UIPadding
+  - Prop:
+      type_id: 22
+      prop_name: PaddingBottom
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 22
+      prop_name: PaddingLeft
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 22
+      prop_name: PaddingRight
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 22
+      prop_name: PaddingTop
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 22
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 22
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 22
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 22
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003cd
+  - Prop:
+      type_id: 43
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 43
+      prop_name: AutomaticScaling
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 43
+      prop_name: AvatarGestures
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 43
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 43
+      prop_name: ControllerModels
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 43
+      prop_name: FadeOutViewOnCollision
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 43
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 43
+      prop_name: LaserPointer
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 43
+      prop_name: Name
+      prop_type: String
+      values:
+        - VRService
+  - Prop:
+      type_id: 43
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 43
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 43
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 43
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000374
+  - Prop:
+      type_id: 9
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 9
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 9
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 9
+      prop_name: Name
+      prop_type: String
+      values:
+        - VideoCaptureService
+  - Prop:
+      type_id: 9
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 9
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 9
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 9
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000346
+  - Prop:
+      type_id: 76
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 76
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 76
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 76
+      prop_name: Name
+      prop_type: String
+      values:
+        - VideoService
+  - Prop:
+      type_id: 76
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 76
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 76
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 76
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003da
+  - Prop:
+      type_id: 77
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 77
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 77
+      prop_name: DefaultDistanceAttenuation
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 77
+      prop_name: EnableDefaultVoice
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 77
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 77
+      prop_name: Name
+      prop_type: String
+      values:
+        - VoiceChatService
+  - Prop:
+      type_id: 77
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 77
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 77
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 77
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b7
+  - Prop:
+      type_id: 77
+      prop_name: UseAudioApi
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 6
+      prop_name: AirDensity
+      prop_type: Float32
+      values:
+        - 0.0012
+  - Prop:
+      type_id: 6
+      prop_name: AirTurbulenceIntensity
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: AllowThirdPartySales
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 6
+      prop_name: AuthorityMode
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 6
+      prop_name: AvatarUnificationMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ClientAnimatorThrottling
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CollisionGroupData
+      prop_type: String
+      values:
+        - 01 01 00 04 ff ff ff ff 07 44 65 66 61 75 6c 74
+  - Prop:
+      type_id: 6
+      prop_name: CurrentCamera
+      prop_type: Ref
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: DistributedGameTime
+      prop_type: Float64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: EnableSLIMAvatars
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ExplicitAutoJoints
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 6
+      prop_name: FallHeightEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 6
+      prop_name: FallenPartsDestroyHeight
+      prop_type: Float32
+      values:
+        - -500
+  - Prop:
+      type_id: 6
+      prop_name: FluidForces
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: GlobalWind
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 6
+      prop_name: Gravity
+      prop_type: Float32
+      values:
+        - 196.2
+  - Prop:
+      type_id: 6
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 6
+      prop_name: IKControlConstraintSupport
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ImprovedAnimationConstraint
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ImprovedPhysicsReplication
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: LayeredClothingCacheOptimizations
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: LuauTypeCheckMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: MeshPartHeadsAndAccessories
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: MeshStreamingAndImprovedLods
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 6
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 6
+      prop_name: ModelStreamingBehavior
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ModelStreamingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: Name
+      prop_type: String
+      values:
+        - Workspace
+  - Prop:
+      type_id: 6
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: NextGenerationReplication
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: PathfindingUseImprovedSearch
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: PhysicsSteppingMethod
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: PlayerCharacterDestroyBehavior
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: PlayerScriptsUseInputActionSystem
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: PrimalPhysicsSolver
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 6
+      prop_name: RejectCharacterDeletions
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: RenderingCacheOptimizations
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ReplicateInstanceDestroySetting
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: Retargeting
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: SandboxedInstanceMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ScaleFactor
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 6
+      prop_name: SignalBehavior2
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 6
+      prop_name: SlimHash
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 6
+      prop_name: StreamOutBehavior
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 6
+      prop_name: StreamingEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 6
+      prop_name: StreamingIntegrityMode
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 6
+      prop_name: StreamingMinRadius
+      prop_type: Int32
+      values:
+        - 64
+  - Prop:
+      type_id: 6
+      prop_name: StreamingTargetRadius
+      prop_type: Int32
+      values:
+        - 1024
+  - Prop:
+      type_id: 6
+      prop_name: Tags
+      prop_type: String
+      values:
+        - hmmmm
+  - Prop:
+      type_id: 6
+      prop_name: TerrainWeldsFixed
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 6
+      prop_name: TouchEventsUseCollisionGroups
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: TouchesUseCollisionGroups
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000002
+  - Prop:
+      type_id: 6
+      prop_name: UseFixedSimulation
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: UseNewLuauTypeSolver
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 6
+      prop_name: ValidateEnabledProximityPrompt
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - 8
+        - - 1
+          - 2
+        - - 2
+          - 8
+        - - 3
+          - 8
+        - - 4
+          - 5
+        - - 5
+          - 8
+        - - 6
+          - 7
+        - - 7
+          - 8
+        - - 8
+          - -1
+        - - 9
+          - -1
+        - - 10
+          - -1
+        - - 11
+          - -1
+        - - 12
+          - -1
+        - - 13
+          - -1
+        - - 14
+          - -1
+        - - 15
+          - -1
+        - - 16
+          - -1
+        - - 17
+          - -1
+        - - 18
+          - -1
+        - - 19
+          - 27
+        - - 20
+          - 27
+        - - 21
+          - 25
+        - - 22
+          - 25
+        - - 23
+          - 25
+        - - 24
+          - 25
+        - - 25
+          - 27
+        - - 26
+          - 27
+        - - 27
+          - -1
+        - - 28
+          - -1
+        - - 29
+          - -1
+        - - 30
+          - 32
+        - - 31
+          - 32
+        - - 32
+          - -1
+        - - 33
+          - -1
+        - - 34
+          - -1
+        - - 35
+          - -1
+        - - 36
+          - -1
+        - - 37
+          - -1
+        - - 38
+          - -1
+        - - 39
+          - 40
+        - - 40
+          - -1
+        - - 41
+          - -1
+        - - 42
+          - -1
+        - - 43
+          - -1
+        - - 44
+          - -1
+        - - 45
+          - -1
+        - - 46
+          - -1
+        - - 47
+          - -1
+        - - 48
+          - -1
+        - - 49
+          - -1
+        - - 50
+          - 56
+        - - 51
+          - 56
+        - - 52
+          - 56
+        - - 53
+          - 56
+        - - 54
+          - 56
+        - - 55
+          - 56
+        - - 56
+          - 57
+        - - 57
+          - -1
+        - - 58
+          - -1
+        - - 59
+          - -1
+        - - 60
+          - -1
+        - - 61
+          - -1
+        - - 62
+          - -1
+        - - 63
+          - -1
+        - - 64
+          - 69
+        - - 65
+          - 69
+        - - 66
+          - 69
+        - - 67
+          - 69
+        - - 68
+          - 69
+        - - 69
+          - -1
+        - - 70
+          - -1
+        - - 71
+          - -1
+        - - 72
+          - -1
+        - - 73
+          - -1
+        - - 74
+          - -1
+        - - 75
+          - -1
+        - - 76
+          - -1
+        - - 77
+          - -1
+        - - 78
+          - -1
+        - - 79
+          - -1
+        - - 80
+          - -1
+        - - 81
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__baseplate-727-with-tags__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__baseplate-727-with-tags__input.snap
@@ -1,0 +1,9254 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 80
+num_instances: 82
+chunks:
+  - Sstr:
+      version: 0
+      entries:
+        - len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        - len: 4
+          hash: 5ee73426e51f4affba11dbf386fa3da8bca38962dd719566300711822e3f73e5
+        - len: 15
+          hash: 1dc278f08b1ec71d15c4e7be72876159dc9400f2e7c363ba6dcfd16415fcafee
+        - len: 5
+          hash: fcd84509847a8416ee54417aa838d14d47417ba563bfac6934e0fceaffa1209e
+  - Inst:
+      type_id: 0
+      type_name: AssetService
+      object_format: 1
+      referents:
+        - 48
+      remaining: "01"
+  - Inst:
+      type_id: 1
+      type_name: Atmosphere
+      object_format: 0
+      referents:
+        - 67
+  - Inst:
+      type_id: 2
+      type_name: AvatarAbilityRules
+      object_format: 0
+      referents:
+        - 54
+  - Inst:
+      type_id: 3
+      type_name: AvatarAccessoryRules
+      object_format: 0
+      referents:
+        - 56
+  - Inst:
+      type_id: 4
+      type_name: AvatarAnimationRules
+      object_format: 0
+      referents:
+        - 55
+  - Inst:
+      type_id: 5
+      type_name: AvatarBodyRules
+      object_format: 0
+      referents:
+        - 52
+  - Inst:
+      type_id: 6
+      type_name: AvatarClothingRules
+      object_format: 0
+      referents:
+        - 57
+  - Inst:
+      type_id: 7
+      type_name: AvatarCollisionRules
+      object_format: 0
+      referents:
+        - 53
+  - Inst:
+      type_id: 8
+      type_name: AvatarRules
+      object_format: 0
+      referents:
+        - 51
+  - Inst:
+      type_id: 9
+      type_name: AvatarSettings
+      object_format: 1
+      referents:
+        - 50
+      remaining: "01"
+  - Inst:
+      type_id: 10
+      type_name: BloomEffect
+      object_format: 0
+      referents:
+        - 68
+  - Inst:
+      type_id: 11
+      type_name: BubbleChatConfiguration
+      object_format: 0
+      referents:
+        - 22
+  - Inst:
+      type_id: 12
+      type_name: CSGDictionaryService
+      object_format: 1
+      referents:
+        - 13
+      remaining: "01"
+  - Inst:
+      type_id: 13
+      type_name: Camera
+      object_format: 0
+      referents:
+        - 1
+  - Inst:
+      type_id: 14
+      type_name: ChannelTabsConfiguration
+      object_format: 0
+      referents:
+        - 27
+  - Inst:
+      type_id: 15
+      type_name: Chat
+      object_format: 1
+      referents:
+        - 14
+      remaining: "01"
+  - Inst:
+      type_id: 16
+      type_name: ChatInputBarConfiguration
+      object_format: 0
+      referents:
+        - 21
+  - Inst:
+      type_id: 17
+      type_name: ChatWindowConfiguration
+      object_format: 0
+      referents:
+        - 20
+  - Inst:
+      type_id: 18
+      type_name: CollectionService
+      object_format: 1
+      referents:
+        - 37
+      remaining: "01"
+  - Inst:
+      type_id: 19
+      type_name: ConfigureServerService
+      object_format: 1
+      referents:
+        - 61
+      remaining: "01"
+  - Inst:
+      type_id: 20
+      type_name: ContextActionService
+      object_format: 1
+      referents:
+        - 46
+      remaining: "01"
+  - Inst:
+      type_id: 21
+      type_name: CookiesService
+      object_format: 1
+      referents:
+        - 43
+      remaining: "01"
+  - Inst:
+      type_id: 22
+      type_name: DataStoreService
+      object_format: 1
+      referents:
+        - 62
+      remaining: "01"
+  - Inst:
+      type_id: 23
+      type_name: Debris
+      object_format: 1
+      referents:
+        - 42
+      remaining: "01"
+  - Inst:
+      type_id: 24
+      type_name: Decal
+      object_format: 0
+      referents:
+        - 6
+  - Inst:
+      type_id: 25
+      type_name: DepthOfFieldEffect
+      object_format: 0
+      referents:
+        - 69
+  - Inst:
+      type_id: 26
+      type_name: GamePassService
+      object_format: 1
+      referents:
+        - 41
+      remaining: "01"
+  - Inst:
+      type_id: 27
+      type_name: GuidRegistryService
+      object_format: 1
+      referents:
+        - 60
+      remaining: "01"
+  - Inst:
+      type_id: 28
+      type_name: HttpService
+      object_format: 1
+      referents:
+        - 63
+      remaining: "01"
+  - Inst:
+      type_id: 29
+      type_name: ImageLabel
+      object_format: 0
+      referents:
+        - 24
+  - Inst:
+      type_id: 30
+      type_name: InsertService
+      object_format: 1
+      referents:
+        - 39
+      remaining: "01"
+  - Inst:
+      type_id: 31
+      type_name: Lighting
+      object_format: 1
+      referents:
+        - 64
+      remaining: "01"
+  - Inst:
+      type_id: 32
+      type_name: LocalizationService
+      object_format: 1
+      referents:
+        - 35
+      remaining: "01"
+  - Inst:
+      type_id: 33
+      type_name: LodDataService
+      object_format: 1
+      referents:
+        - 58
+      remaining: "01"
+  - Inst:
+      type_id: 34
+      type_name: LuaWebService
+      object_format: 1
+      referents:
+        - 81
+      remaining: "01"
+  - Inst:
+      type_id: 35
+      type_name: MaterialService
+      object_format: 1
+      referents:
+        - 18
+      remaining: "01"
+  - Inst:
+      type_id: 36
+      type_name: NonReplicatedCSGDictionaryService
+      object_format: 1
+      referents:
+        - 12
+      remaining: "01"
+  - Inst:
+      type_id: 37
+      type_name: Packages
+      object_format: 1
+      referents:
+        - 59
+      remaining: "01"
+  - Inst:
+      type_id: 38
+      type_name: Part
+      object_format: 0
+      referents:
+        - 2
+        - 7
+  - Inst:
+      type_id: 39
+      type_name: PermissionsService
+      object_format: 1
+      referents:
+        - 80
+      remaining: "01"
+  - Inst:
+      type_id: 40
+      type_name: PhysicsService
+      object_format: 1
+      referents:
+        - 38
+      remaining: "01"
+  - Inst:
+      type_id: 41
+      type_name: PlayerEmulatorService
+      object_format: 1
+      referents:
+        - 28
+      remaining: "01"
+  - Inst:
+      type_id: 42
+      type_name: Players
+      object_format: 1
+      referents:
+        - 15
+      remaining: "01"
+  - Inst:
+      type_id: 43
+      type_name: ProximityPromptService
+      object_format: 1
+      referents:
+        - 70
+      remaining: "01"
+  - Inst:
+      type_id: 44
+      type_name: ReplicatedFirst
+      object_format: 1
+      referents:
+        - 16
+      remaining: "01"
+  - Inst:
+      type_id: 45
+      type_name: ReplicatedStorage
+      object_format: 1
+      referents:
+        - 71
+      remaining: "01"
+  - Inst:
+      type_id: 46
+      type_name: ScriptService
+      object_format: 1
+      referents:
+        - 47
+      remaining: "01"
+  - Inst:
+      type_id: 47
+      type_name: Selection
+      object_format: 1
+      referents:
+        - 44
+      remaining: "01"
+  - Inst:
+      type_id: 48
+      type_name: ServerScriptService
+      object_format: 1
+      referents:
+        - 72
+      remaining: "01"
+  - Inst:
+      type_id: 49
+      type_name: ServerStorage
+      object_format: 1
+      referents:
+        - 73
+      remaining: "01"
+  - Inst:
+      type_id: 50
+      type_name: ServiceVisibilityService
+      object_format: 1
+      referents:
+        - 74
+      remaining: "01"
+  - Inst:
+      type_id: 51
+      type_name: Sky
+      object_format: 0
+      referents:
+        - 65
+  - Inst:
+      type_id: 52
+      type_name: SoundService
+      object_format: 1
+      referents:
+        - 10
+      remaining: "01"
+  - Inst:
+      type_id: 53
+      type_name: SpawnLocation
+      object_format: 0
+      referents:
+        - 5
+  - Inst:
+      type_id: 54
+      type_name: StarterCharacterScripts
+      object_format: 0
+      referents:
+        - 32
+  - Inst:
+      type_id: 55
+      type_name: StarterGui
+      object_format: 1
+      referents:
+        - 34
+      remaining: "01"
+  - Inst:
+      type_id: 56
+      type_name: StarterPack
+      object_format: 1
+      referents:
+        - 33
+      remaining: "01"
+  - Inst:
+      type_id: 57
+      type_name: StarterPlayer
+      object_format: 1
+      referents:
+        - 30
+      remaining: "01"
+  - Inst:
+      type_id: 58
+      type_name: StarterPlayerScripts
+      object_format: 0
+      referents:
+        - 31
+  - Inst:
+      type_id: 59
+      type_name: StringValue
+      object_format: 0
+      referents:
+        - 40
+  - Inst:
+      type_id: 60
+      type_name: StudioData
+      object_format: 1
+      referents:
+        - 29
+      remaining: "01"
+  - Inst:
+      type_id: 61
+      type_name: SunRaysEffect
+      object_format: 0
+      referents:
+        - 66
+  - Inst:
+      type_id: 62
+      type_name: Teams
+      object_format: 1
+      referents:
+        - 75
+      remaining: "01"
+  - Inst:
+      type_id: 63
+      type_name: TeleportService
+      object_format: 1
+      referents:
+        - 36
+      remaining: "01"
+  - Inst:
+      type_id: 64
+      type_name: Terrain
+      object_format: 0
+      referents:
+        - 4
+  - Inst:
+      type_id: 65
+      type_name: TestService
+      object_format: 1
+      referents:
+        - 76
+      remaining: "01"
+  - Inst:
+      type_id: 66
+      type_name: TextChatService
+      object_format: 1
+      referents:
+        - 19
+      remaining: "01"
+  - Inst:
+      type_id: 67
+      type_name: Texture
+      object_format: 0
+      referents:
+        - 3
+        - 8
+  - Inst:
+      type_id: 68
+      type_name: TimerService
+      object_format: 1
+      referents:
+        - 9
+      remaining: "01"
+  - Inst:
+      type_id: 69
+      type_name: TouchInputService
+      object_format: 1
+      referents:
+        - 49
+      remaining: "01"
+  - Inst:
+      type_id: 70
+      type_name: TweenService
+      object_format: 1
+      referents:
+        - 17
+      remaining: "01"
+  - Inst:
+      type_id: 71
+      type_name: UGCAvatarService
+      object_format: 1
+      referents:
+        - 77
+      remaining: "01"
+  - Inst:
+      type_id: 72
+      type_name: UICorner
+      object_format: 0
+      referents:
+        - 25
+  - Inst:
+      type_id: 73
+      type_name: UIGradient
+      object_format: 0
+      referents:
+        - 23
+  - Inst:
+      type_id: 74
+      type_name: UIPadding
+      object_format: 0
+      referents:
+        - 26
+  - Inst:
+      type_id: 75
+      type_name: VRService
+      object_format: 1
+      referents:
+        - 45
+      remaining: "01"
+  - Inst:
+      type_id: 76
+      type_name: VideoCaptureService
+      object_format: 1
+      referents:
+        - 11
+      remaining: "01"
+  - Inst:
+      type_id: 77
+      type_name: VideoService
+      object_format: 1
+      referents:
+        - 78
+      remaining: "01"
+  - Inst:
+      type_id: 78
+      type_name: VoiceChatService
+      object_format: 1
+      referents:
+        - 79
+      remaining: "01"
+  - Inst:
+      type_id: 79
+      type_name: Workspace
+      object_format: 1
+      referents:
+        - 0
+      remaining: "01"
+  - Prop:
+      type_id: 0
+      prop_name: AllowInsertFreeAssets
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 0
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - AssetService
+  - Prop:
+      type_id: 0
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000377
+  - Prop:
+      type_id: 1
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 1
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Color
+      prop_type: Color3
+      values:
+        - - 0.78039217
+          - 0.78039217
+          - 0.78039217
+  - Prop:
+      type_id: 1
+      prop_name: Decay
+      prop_type: Color3
+      values:
+        - - 0.41568628
+          - 0.4392157
+          - 0.49019608
+  - Prop:
+      type_id: 1
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 1
+      prop_name: Density
+      prop_type: Float32
+      values:
+        - 0.3
+  - Prop:
+      type_id: 1
+      prop_name: Glare
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: Haze
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 1
+      prop_name: Name
+      prop_type: String
+      values:
+        - Atmosphere
+  - Prop:
+      type_id: 1
+      prop_name: Offset
+      prop_type: Float32
+      values:
+        - 0.25
+  - Prop:
+      type_id: 1
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 1
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 1
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c4
+  - Prop:
+      type_id: 2
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 2
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: CharacterControllerMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 2
+      prop_name: EnableClimbing
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableCrouching
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableFallingDown
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableGettingUp
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableHolding
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableJumping
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableReaching
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableRunning
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableSitting
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableSprinting
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableStrafing
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: EnableSwimming
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 2
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 2
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarAbilityRules
+  - Prop:
+      type_id: 2
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 2
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 2
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e03
+  - Prop:
+      type_id: 3
+      prop_name: AccessoryMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 3
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomAccessoryMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomBackAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomBackAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomFaceAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomFaceAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomFrontAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomFrontAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomHairAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomHairAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomHeadAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomHeadAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomNeckAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomNeckAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomShoulderAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomShoulderAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: CustomWaistAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: CustomWaistAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 3
+      prop_name: EnableEmissives
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: EnableSound
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: EnableVFX
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 3
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 3
+      prop_name: LimitBounds
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 3
+      prop_name: LimitMethod
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 3
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarAccessoryRules
+  - Prop:
+      type_id: 3
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 3
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 3
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e05
+  - Prop:
+      type_id: 4
+      prop_name: AnimationClipsMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: AnimationPacksMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 4
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomClimbAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomClimbAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomFallAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomFallAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomIdleAlt1AnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomIdleAlt1AnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomIdleAlt2AnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomIdleAlt2AnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomIdleAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomIdleAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomJumpAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomJumpAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomRunAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomRunAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomSwimAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomSwimAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomSwimIdleAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomSwimIdleAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: CustomWalkAnimationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: CustomWalkAnimationId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 4
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 4
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarAnimationRules
+  - Prop:
+      type_id: 4
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 4
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 4
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e04
+  - Prop:
+      type_id: 5
+      prop_name: AppearanceMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 5
+      prop_name: BuildMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomBodyBundleId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomBodyType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomBodyTypeScale
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 5
+      prop_name: CustomEyebrowEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomEyebrowId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomEyelashEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomEyelashId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomFaceEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomFaceId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomHeadEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomHeadId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomHeadScale
+      prop_type: NumberRange
+      values:
+        - - 0.95
+          - 1
+  - Prop:
+      type_id: 5
+      prop_name: CustomHeight
+      prop_type: NumberRange
+      values:
+        - - 5.5
+          - 5.5
+  - Prop:
+      type_id: 5
+      prop_name: CustomHeightScale
+      prop_type: NumberRange
+      values:
+        - - 0.9
+          - 1.05
+  - Prop:
+      type_id: 5
+      prop_name: CustomLeftArmEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomLeftArmId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomLeftLegEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomLeftLegId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomMoodEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomMoodId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomProportionsScale
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 5
+      prop_name: CustomRightArmEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomRightArmId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomRightLegEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomRightLegId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomTorsoEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: CustomTorsoId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: CustomWidthScale
+      prop_type: NumberRange
+      values:
+        - - 0.7
+          - 1
+  - Prop:
+      type_id: 5
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 5
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 5
+      prop_name: KeepPlayerHead
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 5
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarBodyRules
+  - Prop:
+      type_id: 5
+      prop_name: ScaleMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 5
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 5
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e01
+  - Prop:
+      type_id: 6
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 6
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: ClothingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomClassicPantsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomClassicPantsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomClassicShirtsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomClassicShirtsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomClassicTShirtsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomClassicTShirtsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomClothingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomDressSkirtAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomDressSkirtAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomJacketAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomJacketAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomLeftShoesAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomLeftShoesAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomPantsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomPantsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomRightShoesAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomRightShoesAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomShirtAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomShirtAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomShortsAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomShortsAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomSweaterAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomSweaterAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: CustomTShirtAccessoryEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: CustomTShirtAccessoryId
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 6
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 6
+      prop_name: LimitBounds
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 6
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarClothingRules
+  - Prop:
+      type_id: 6
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 6
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 6
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e06
+  - Prop:
+      type_id: 7
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 7
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 7
+      prop_name: CollisionMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 7
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 7
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 7
+      prop_name: HitAndTouchDetectionMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 7
+      prop_name: LegacyCollisionMode
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 7
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarCollisionRules
+  - Prop:
+      type_id: 7
+      prop_name: SingleColliderSize
+      prop_type: Vector3
+      values:
+        - - 2
+          - 3
+          - 1
+  - Prop:
+      type_id: 7
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 7
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 7
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e02
+  - Prop:
+      type_id: 8
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 8
+      prop_name: AvatarType
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 8
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 8
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 8
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 8
+      prop_name: Name
+      prop_type: String
+      values:
+        - DefaultAvatarRules
+  - Prop:
+      type_id: 8
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 8
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 8
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e00
+  - Prop:
+      type_id: 9
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 9
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 9
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 9
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 9
+      prop_name: Name
+      prop_type: String
+      values:
+        - AvatarSettings
+  - Prop:
+      type_id: 9
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 9
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 9
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000037f
+  - Prop:
+      type_id: 10
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 10
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 10
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 10
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 10
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 10
+      prop_name: Intensity
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 10
+      prop_name: Name
+      prop_type: String
+      values:
+        - Bloom
+  - Prop:
+      type_id: 10
+      prop_name: Size
+      prop_type: Float32
+      values:
+        - 24
+  - Prop:
+      type_id: 10
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 10
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 10
+      prop_name: Threshold
+      prop_type: Float32
+      values:
+        - 2
+  - Prop:
+      type_id: 10
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c5
+  - Prop:
+      type_id: 11
+      prop_name: AdorneeName
+      prop_type: String
+      values:
+        - HumanoidRootPart
+  - Prop:
+      type_id: 11
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 11
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.98039216
+          - 0.98039216
+          - 0.98039216
+  - Prop:
+      type_id: 11
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0.1
+  - Prop:
+      type_id: 11
+      prop_name: BubbleDuration
+      prop_type: Float32
+      values:
+        - 15
+  - Prop:
+      type_id: 11
+      prop_name: BubblesSpacing
+      prop_type: Float32
+      values:
+        - 6
+  - Prop:
+      type_id: 11
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 11
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 11
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 11
+      prop_name: Font
+      prop_type: Enum
+      values:
+        - 47
+  - Prop:
+      type_id: 11
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Medium
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+  - Prop:
+      type_id: 11
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 11
+      prop_name: LocalPlayerStudsOffset
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 11
+      prop_name: MaxBubbles
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 11
+      prop_name: MaxDistance
+      prop_type: Float32
+      values:
+        - 100
+  - Prop:
+      type_id: 11
+      prop_name: MinimizeDistance
+      prop_type: Float32
+      values:
+        - 40
+  - Prop:
+      type_id: 11
+      prop_name: Name
+      prop_type: String
+      values:
+        - BubbleChatConfiguration
+  - Prop:
+      type_id: 11
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 11
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 11
+      prop_name: TailVisible
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 11
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 0.22352941
+          - 0.23137255
+          - 0.23921569
+  - Prop:
+      type_id: 11
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 20
+  - Prop:
+      type_id: 11
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c9
+  - Prop:
+      type_id: 11
+      prop_name: VerticalStudsOffset
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 12
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 12
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 12
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 12
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 12
+      prop_name: Name
+      prop_type: String
+      values:
+        - CSGDictionaryService
+  - Prop:
+      type_id: 12
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 12
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 12
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000348
+  - Prop:
+      type_id: 13
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 13
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - -19.696095
+            - 14.091624
+            - -19.303886
+          orientation:
+            - - -0.7061509
+              - 0.31296578
+              - -0.6351404
+            - - 0.000000014901163
+              - 0.8970132
+              - 0.44200373
+            - - 0.7080614
+              - 0.31212133
+              - -0.63342667
+  - Prop:
+      type_id: 13
+      prop_name: CameraSubject
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 13
+      prop_name: CameraType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 13
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 13
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 13
+      prop_name: FieldOfView
+      prop_type: Float32
+      values:
+        - 70
+  - Prop:
+      type_id: 13
+      prop_name: FieldOfViewMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 13
+      prop_name: Focus
+      prop_type: CFrame
+      values:
+        - position:
+            - -18.425814
+            - 13.207617
+            - -18.037033
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 13
+      prop_name: HeadLocked
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 13
+      prop_name: HeadScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 13
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 13
+      prop_name: Name
+      prop_type: String
+      values:
+        - Camera
+  - Prop:
+      type_id: 13
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 13
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 13
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b8
+  - Prop:
+      type_id: 13
+      prop_name: VRTiltAndRollEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 14
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 14
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.09803922
+          - 0.105882354
+          - 0.11372549
+  - Prop:
+      type_id: 14
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0
+  - Prop:
+      type_id: 14
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 14
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 14
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 14
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Bold
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Bold.otf"
+  - Prop:
+      type_id: 14
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 14
+      prop_name: HoverBackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.49019608
+          - 0.49019608
+          - 0.49019608
+  - Prop:
+      type_id: 14
+      prop_name: Name
+      prop_type: String
+      values:
+        - ChannelTabsConfiguration
+  - Prop:
+      type_id: 14
+      prop_name: SelectedTabTextColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 14
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 14
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 14
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 0.6862745
+          - 0.6862745
+          - 0.6862745
+  - Prop:
+      type_id: 14
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 18
+  - Prop:
+      type_id: 14
+      prop_name: TextStrokeColor3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 14
+      prop_name: TextStrokeTransparency
+      prop_type: Float64
+      values:
+        - 1
+  - Prop:
+      type_id: 14
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ce
+  - Prop:
+      type_id: 15
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 15
+      prop_name: BubbleChatEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 15
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 15
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 15
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 15
+      prop_name: IsAutoMigrated
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 15
+      prop_name: LoadDefaultChat
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 15
+      prop_name: Name
+      prop_type: String
+      values:
+        - Chat
+  - Prop:
+      type_id: 15
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 15
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 15
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000034e
+  - Prop:
+      type_id: 16
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 16
+      prop_name: AutocompleteEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 16
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.09803922
+          - 0.105882354
+          - 0.11372549
+  - Prop:
+      type_id: 16
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0.2
+  - Prop:
+      type_id: 16
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 16
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 16
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 16
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Medium
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+  - Prop:
+      type_id: 16
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 16
+      prop_name: KeyboardKeyCode
+      prop_type: Enum
+      values:
+        - 47
+  - Prop:
+      type_id: 16
+      prop_name: Name
+      prop_type: String
+      values:
+        - ChatInputBarConfiguration
+  - Prop:
+      type_id: 16
+      prop_name: PlaceholderColor3
+      prop_type: Color3
+      values:
+        - - 0.69803923
+          - 0.69803923
+          - 0.69803923
+  - Prop:
+      type_id: 16
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 16
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 16
+      prop_name: TargetTextChannel
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 16
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 16
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 18
+  - Prop:
+      type_id: 16
+      prop_name: TextStrokeColor3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 16
+      prop_name: TextStrokeTransparency
+      prop_type: Float64
+      values:
+        - 0.5
+  - Prop:
+      type_id: 16
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c8
+  - Prop:
+      type_id: 17
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 17
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 0.09803922
+          - 0.105882354
+          - 0.11372549
+  - Prop:
+      type_id: 17
+      prop_name: BackgroundTransparency
+      prop_type: Float64
+      values:
+        - 0.3
+  - Prop:
+      type_id: 17
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 17
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 17
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 17
+      prop_name: FontFace
+      prop_type: Font
+      values:
+        - family: "rbxasset://fonts/families/BuilderSans.json"
+          weight: Medium
+          style: Normal
+          cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+  - Prop:
+      type_id: 17
+      prop_name: HeightScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 17
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 17
+      prop_name: HorizontalAlignment
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 17
+      prop_name: Name
+      prop_type: String
+      values:
+        - ChatWindowConfiguration
+  - Prop:
+      type_id: 17
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 17
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 17
+      prop_name: TextColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 17
+      prop_name: TextSize
+      prop_type: Int64
+      values:
+        - 18
+  - Prop:
+      type_id: 17
+      prop_name: TextStrokeColor3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 17
+      prop_name: TextStrokeTransparency
+      prop_type: Float64
+      values:
+        - 0.5
+  - Prop:
+      type_id: 17
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c7
+  - Prop:
+      type_id: 17
+      prop_name: VerticalAlignment
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 17
+      prop_name: WidthScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 18
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 18
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 18
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 18
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 18
+      prop_name: Name
+      prop_type: String
+      values:
+        - CollectionService
+  - Prop:
+      type_id: 18
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 18
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 18
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000339
+  - Prop:
+      type_id: 19
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 19
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 19
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 19
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 19
+      prop_name: Name
+      prop_type: String
+      values:
+        - ConfigureServerService
+  - Prop:
+      type_id: 19
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 19
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 19
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000387
+  - Prop:
+      type_id: 20
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 20
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 20
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 20
+      prop_name: Name
+      prop_type: String
+      values:
+        - ContextActionService
+  - Prop:
+      type_id: 20
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 20
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 20
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000375
+  - Prop:
+      type_id: 21
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 21
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 21
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 21
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 21
+      prop_name: Name
+      prop_type: String
+      values:
+        - CookiesService
+  - Prop:
+      type_id: 21
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 21
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 21
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036f
+  - Prop:
+      type_id: 22
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 22
+      prop_name: AutomaticRetry
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 22
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 22
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 22
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 22
+      prop_name: LegacyNamingScheme
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 22
+      prop_name: Name
+      prop_type: String
+      values:
+        - DataStoreService
+  - Prop:
+      type_id: 22
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 22
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 22
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003af
+  - Prop:
+      type_id: 23
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 23
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 23
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 23
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 23
+      prop_name: MaxItems
+      prop_type: Int32
+      values:
+        - 1000
+  - Prop:
+      type_id: 23
+      prop_name: Name
+      prop_type: String
+      values:
+        - Debris
+  - Prop:
+      type_id: 23
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 23
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 23
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036e
+  - Prop:
+      type_id: 24
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: AutoLocalize
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 24
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 24
+      prop_name: Color3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 24
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 24
+      prop_name: Face
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 24
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 24
+      prop_name: MetalnessMap
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: Name
+      prop_type: String
+      values:
+        - Decal
+  - Prop:
+      type_id: 24
+      prop_name: NormalMap
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 24
+      prop_name: RoughnessMap
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 24
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 24
+      prop_name: Texture
+      prop_type: String
+      values:
+        - "rbxasset://textures/SpawnLocation.png"
+  - Prop:
+      type_id: 24
+      prop_name: TexturePack
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: TexturePackMetadata
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 24
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 24
+      prop_name: UVOffset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 24
+      prop_name: UVScale
+      prop_type: Vector2
+      values:
+        - - 1
+          - 1
+  - Prop:
+      type_id: 24
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bd
+  - Prop:
+      type_id: 24
+      prop_name: ZIndex
+      prop_type: Int32
+      values:
+        - 1
+  - Prop:
+      type_id: 25
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 25
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 25
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 25
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 25
+      prop_name: FarIntensity
+      prop_type: Float32
+      values:
+        - 0.1
+  - Prop:
+      type_id: 25
+      prop_name: FocusDistance
+      prop_type: Float32
+      values:
+        - 0.05
+  - Prop:
+      type_id: 25
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 25
+      prop_name: InFocusRadius
+      prop_type: Float32
+      values:
+        - 30
+  - Prop:
+      type_id: 25
+      prop_name: Name
+      prop_type: String
+      values:
+        - DepthOfField
+  - Prop:
+      type_id: 25
+      prop_name: NearIntensity
+      prop_type: Float32
+      values:
+        - 0.75
+  - Prop:
+      type_id: 25
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 25
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 25
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c6
+  - Prop:
+      type_id: 26
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 26
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 26
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 26
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 26
+      prop_name: Name
+      prop_type: String
+      values:
+        - GamePassService
+  - Prop:
+      type_id: 26
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 26
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 26
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036d
+  - Prop:
+      type_id: 27
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 27
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 27
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 27
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 27
+      prop_name: Name
+      prop_type: String
+      values:
+        - GuidRegistryService
+  - Prop:
+      type_id: 27
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 27
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 27
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000384
+  - Prop:
+      type_id: 28
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 28
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 28
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 28
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 28
+      prop_name: HttpEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 28
+      prop_name: Name
+      prop_type: String
+      values:
+        - HttpService
+  - Prop:
+      type_id: 28
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 28
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 28
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ac
+  - Prop:
+      type_id: 29
+      prop_name: Active
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 29
+      prop_name: AnchorPoint
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 29
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 29
+      prop_name: AutoLocalize
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 29
+      prop_name: AutomaticSize
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: BackgroundColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 29
+      prop_name: BackgroundTransparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: BorderColor3
+      prop_type: Color3
+      values:
+        - - 0.10588236
+          - 0.16470589
+          - 0.20784315
+  - Prop:
+      type_id: 29
+      prop_name: BorderMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: BorderSizePixel
+      prop_type: Int32
+      values:
+        - 1
+  - Prop:
+      type_id: 29
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: ClipsDescendants
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 29
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 29
+      prop_name: Draggable
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 29
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 29
+      prop_name: Image
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 29
+      prop_name: ImageColor3
+      prop_type: Color3
+      values:
+        - - 1
+          - 1
+          - 1
+  - Prop:
+      type_id: 29
+      prop_name: ImageRectOffset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 29
+      prop_name: ImageRectSize
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 29
+      prop_name: ImageTransparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: InputSink
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: Interactable
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 29
+      prop_name: LayoutOrder
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: Name
+      prop_type: String
+      values:
+        - ImageLabel
+  - Prop:
+      type_id: 29
+      prop_name: NextSelectionDown
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: NextSelectionLeft
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: NextSelectionRight
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: NextSelectionUp
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: Position
+      prop_type: UDim2
+      values:
+        - - - 0
+            - 0
+          - - 0
+            - 0
+  - Prop:
+      type_id: 29
+      prop_name: ResampleMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: RootLocalizationTable
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: ScaleType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: Selectable
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 29
+      prop_name: SelectionBehaviorDown
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: SelectionBehaviorLeft
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: SelectionBehaviorRight
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: SelectionBehaviorUp
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: SelectionGroup
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 29
+      prop_name: SelectionImageObject
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: SelectionOrder
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: Size
+      prop_type: UDim2
+      values:
+        - - - 0
+            - 100
+          - - 0
+            - 100
+  - Prop:
+      type_id: 29
+      prop_name: SizeConstraint
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: SliceCenter
+      prop_type: Rect
+      values:
+        - - - 0
+            - 0
+          - - 0
+            - 0
+  - Prop:
+      type_id: 29
+      prop_name: SliceScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 29
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 29
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 29
+      prop_name: TileSize
+      prop_type: UDim2
+      values:
+        - - - 1
+            - 0
+          - - 1
+            - 0
+  - Prop:
+      type_id: 29
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003cb
+  - Prop:
+      type_id: 29
+      prop_name: Visible
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 29
+      prop_name: ZIndex
+      prop_type: Int32
+      values:
+        - 1
+  - Prop:
+      type_id: 30
+      prop_name: AllowInsertFreeModels
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 30
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 30
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 30
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 30
+      prop_name: Name
+      prop_type: String
+      values:
+        - InsertService
+  - Prop:
+      type_id: 30
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 30
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 30
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000036c
+  - Prop:
+      type_id: 31
+      prop_name: Ambient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 31
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - "\u0002\u0000\u0000\u0000&\u0000\u0000\u0000RBX_LightingTechnologyUnifiedMigration\u0003\u0001 \u0000\u0000\u0000RBX_OriginalTechnologyOnFileLoad\u0004\u0003\u0000\u0000\u0000"
+  - Prop:
+      type_id: 31
+      prop_name: Brightness
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 31
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: ColorShift_Bottom
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 31
+      prop_name: ColorShift_Top
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 31
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 31
+      prop_name: EnvironmentDiffuseScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 31
+      prop_name: EnvironmentSpecularScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 31
+      prop_name: ExposureCompensation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: ExtendLightRangeTo120
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: FogColor
+      prop_type: Color3
+      values:
+        - - 0.75294125
+          - 0.75294125
+          - 0.75294125
+  - Prop:
+      type_id: 31
+      prop_name: FogEnd
+      prop_type: Float32
+      values:
+        - 100000
+  - Prop:
+      type_id: 31
+      prop_name: FogStart
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: GeographicLatitude
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: GlobalShadows
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 31
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 31
+      prop_name: LightingStyle
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 31
+      prop_name: Name
+      prop_type: String
+      values:
+        - Lighting
+  - Prop:
+      type_id: 31
+      prop_name: OutdoorAmbient
+      prop_type: Color3
+      values:
+        - - 0.27450982
+          - 0.27450982
+          - 0.27450982
+  - Prop:
+      type_id: 31
+      prop_name: Outlines
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 31
+      prop_name: PrioritizeLightingQuality
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 31
+      prop_name: ShadowSoftness
+      prop_type: Float32
+      values:
+        - 0.2
+  - Prop:
+      type_id: 31
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 31
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 31
+      prop_name: Technology
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 31
+      prop_name: TimeOfDay
+      prop_type: String
+      values:
+        - "14:30:00"
+  - Prop:
+      type_id: 31
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b0
+  - Prop:
+      type_id: 32
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 32
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 32
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 32
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 32
+      prop_name: Name
+      prop_type: String
+      values:
+        - LocalizationService
+  - Prop:
+      type_id: 32
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 32
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 32
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000363
+  - Prop:
+      type_id: 33
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 33
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 33
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 33
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 33
+      prop_name: Name
+      prop_type: String
+      values:
+        - Instance
+  - Prop:
+      type_id: 33
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 33
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 33
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b1
+  - Prop:
+      type_id: 34
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 34
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 34
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 34
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 34
+      prop_name: Name
+      prop_type: String
+      values:
+        - LuaWebService
+  - Prop:
+      type_id: 34
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 34
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 34
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000f22
+  - Prop:
+      type_id: 35
+      prop_name: AsphaltName
+      prop_type: String
+      values:
+        - Asphalt
+  - Prop:
+      type_id: 35
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 35
+      prop_name: BasaltName
+      prop_type: String
+      values:
+        - Basalt
+  - Prop:
+      type_id: 35
+      prop_name: BrickName
+      prop_type: String
+      values:
+        - Brick
+  - Prop:
+      type_id: 35
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 35
+      prop_name: CardboardName
+      prop_type: String
+      values:
+        - Cardboard
+  - Prop:
+      type_id: 35
+      prop_name: CarpetName
+      prop_type: String
+      values:
+        - Carpet
+  - Prop:
+      type_id: 35
+      prop_name: CeramicTilesName
+      prop_type: String
+      values:
+        - CeramicTiles
+  - Prop:
+      type_id: 35
+      prop_name: ClayRoofTilesName
+      prop_type: String
+      values:
+        - ClayRoofTiles
+  - Prop:
+      type_id: 35
+      prop_name: CobblestoneName
+      prop_type: String
+      values:
+        - Cobblestone
+  - Prop:
+      type_id: 35
+      prop_name: ConcreteName
+      prop_type: String
+      values:
+        - Concrete
+  - Prop:
+      type_id: 35
+      prop_name: CorrodedMetalName
+      prop_type: String
+      values:
+        - CorrodedMetal
+  - Prop:
+      type_id: 35
+      prop_name: CrackedLavaName
+      prop_type: String
+      values:
+        - CrackedLava
+  - Prop:
+      type_id: 35
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 35
+      prop_name: DiamondPlateName
+      prop_type: String
+      values:
+        - DiamondPlate
+  - Prop:
+      type_id: 35
+      prop_name: FabricName
+      prop_type: String
+      values:
+        - Fabric
+  - Prop:
+      type_id: 35
+      prop_name: FoilName
+      prop_type: String
+      values:
+        - Foil
+  - Prop:
+      type_id: 35
+      prop_name: GlacierName
+      prop_type: String
+      values:
+        - Glacier
+  - Prop:
+      type_id: 35
+      prop_name: GraniteName
+      prop_type: String
+      values:
+        - Granite
+  - Prop:
+      type_id: 35
+      prop_name: GrassName
+      prop_type: String
+      values:
+        - Grass
+  - Prop:
+      type_id: 35
+      prop_name: GroundName
+      prop_type: String
+      values:
+        - Ground
+  - Prop:
+      type_id: 35
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 35
+      prop_name: IceName
+      prop_type: String
+      values:
+        - Ice
+  - Prop:
+      type_id: 35
+      prop_name: LeafyGrassName
+      prop_type: String
+      values:
+        - LeafyGrass
+  - Prop:
+      type_id: 35
+      prop_name: LeatherName
+      prop_type: String
+      values:
+        - Leather
+  - Prop:
+      type_id: 35
+      prop_name: LimestoneName
+      prop_type: String
+      values:
+        - Limestone
+  - Prop:
+      type_id: 35
+      prop_name: MarbleName
+      prop_type: String
+      values:
+        - Marble
+  - Prop:
+      type_id: 35
+      prop_name: MetalName
+      prop_type: String
+      values:
+        - Metal
+  - Prop:
+      type_id: 35
+      prop_name: MudName
+      prop_type: String
+      values:
+        - Mud
+  - Prop:
+      type_id: 35
+      prop_name: Name
+      prop_type: String
+      values:
+        - MaterialService
+  - Prop:
+      type_id: 35
+      prop_name: PavementName
+      prop_type: String
+      values:
+        - Pavement
+  - Prop:
+      type_id: 35
+      prop_name: PebbleName
+      prop_type: String
+      values:
+        - Pebble
+  - Prop:
+      type_id: 35
+      prop_name: PlasterName
+      prop_type: String
+      values:
+        - Plaster
+  - Prop:
+      type_id: 35
+      prop_name: PlasticName
+      prop_type: String
+      values:
+        - Plastic
+  - Prop:
+      type_id: 35
+      prop_name: RockName
+      prop_type: String
+      values:
+        - Rock
+  - Prop:
+      type_id: 35
+      prop_name: RoofShinglesName
+      prop_type: String
+      values:
+        - RoofShingles
+  - Prop:
+      type_id: 35
+      prop_name: RubberName
+      prop_type: String
+      values:
+        - Rubber
+  - Prop:
+      type_id: 35
+      prop_name: SaltName
+      prop_type: String
+      values:
+        - Salt
+  - Prop:
+      type_id: 35
+      prop_name: SandName
+      prop_type: String
+      values:
+        - Sand
+  - Prop:
+      type_id: 35
+      prop_name: SandstoneName
+      prop_type: String
+      values:
+        - Sandstone
+  - Prop:
+      type_id: 35
+      prop_name: SlateName
+      prop_type: String
+      values:
+        - Slate
+  - Prop:
+      type_id: 35
+      prop_name: SmoothPlasticName
+      prop_type: String
+      values:
+        - SmoothPlastic
+  - Prop:
+      type_id: 35
+      prop_name: SnowName
+      prop_type: String
+      values:
+        - Snow
+  - Prop:
+      type_id: 35
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 35
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 35
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000356
+  - Prop:
+      type_id: 35
+      prop_name: Use2022MaterialsXml
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 35
+      prop_name: WoodName
+      prop_type: String
+      values:
+        - Wood
+  - Prop:
+      type_id: 35
+      prop_name: WoodPlanksName
+      prop_type: String
+      values:
+        - WoodPlanks
+  - Prop:
+      type_id: 36
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 36
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 36
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 36
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 36
+      prop_name: Name
+      prop_type: String
+      values:
+        - NonReplicatedCSGDictionaryService
+  - Prop:
+      type_id: 36
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 36
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 36
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000347
+  - Prop:
+      type_id: 37
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 37
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 37
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 37
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 37
+      prop_name: IsDehydrated
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 37
+      prop_name: Name
+      prop_type: String
+      values:
+        - Packages
+  - Prop:
+      type_id: 37
+      prop_name: ShellPackagesCount
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 37
+      prop_name: SkippedInstancesCount
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 37
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 37
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 37
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000383
+  - Prop:
+      type_id: 38
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 38
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 38
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 38
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 38
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 38
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - -8
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - -8
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 38
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+        - Default
+  - Prop:
+      type_id: 38
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 91
+          - 91
+          - 91
+        - - 91
+          - 91
+          - 91
+  - Prop:
+      type_id: 38
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+        - Default
+  - Prop:
+      type_id: 38
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+        - false
+  - Prop:
+      type_id: 38
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 38
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 38
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+        - 7ae0e5570bbb7d4c0a5586bb000003b9
+  - Prop:
+      type_id: 38
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 38
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 38
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 38
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+        - false
+  - Prop:
+      type_id: 38
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+        - 256
+  - Prop:
+      type_id: 38
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 38
+      prop_name: Name
+      prop_type: String
+      values:
+        - Baseplate
+        - Baseplate
+  - Prop:
+      type_id: 38
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 38
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 38
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 38
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 38
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+  - Prop:
+      type_id: 38
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 1
+        - 2
+  - Prop:
+      type_id: 38
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+        - -0.5
+  - Prop:
+      type_id: 38
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+        - 0.5
+  - Prop:
+      type_id: 38
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b9
+        - 7ae0e5570bbb7d4c0a5586bb000008b3
+  - Prop:
+      type_id: 38
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 38
+      prop_name: formFactorRaw
+      prop_type: Enum
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 38
+      prop_name: shape
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 38
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 2048
+          - 16
+          - 2048
+        - - 2048
+          - 16
+          - 2048
+  - Prop:
+      type_id: 39
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 39
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 39
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 39
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 39
+      prop_name: Name
+      prop_type: String
+      values:
+        - PermissionsService
+  - Prop:
+      type_id: 39
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 39
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 39
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7edfffb096708e650a5620f100000e07
+  - Prop:
+      type_id: 40
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 40
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 40
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 40
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 40
+      prop_name: Name
+      prop_type: String
+      values:
+        - PhysicsService
+  - Prop:
+      type_id: 40
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 40
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 40
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000369
+  - Prop:
+      type_id: 41
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 41
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 41
+      prop_name: CustomPoliciesEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 41
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 41
+      prop_name: EmulatedCountryCode
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 41
+      prop_name: EmulatedGameLocale
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 41
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 41
+      prop_name: Name
+      prop_type: String
+      values:
+        - PlayerEmulatorService
+  - Prop:
+      type_id: 41
+      prop_name: PlayerEmulationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 41
+      prop_name: PseudolocalizationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 41
+      prop_name: SerializedEmulatedPolicyInfo
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 41
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 41
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 41
+      prop_name: TextElongationFactor
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 41
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000035a
+  - Prop:
+      type_id: 42
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 42
+      prop_name: BanningEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 42
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 42
+      prop_name: CharacterAutoLoads
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 42
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 42
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 42
+      prop_name: MaxPlayersInternal
+      prop_type: Int32
+      values:
+        - 60
+  - Prop:
+      type_id: 42
+      prop_name: Name
+      prop_type: String
+      values:
+        - Players
+  - Prop:
+      type_id: 42
+      prop_name: PreferredPlayersInternal
+      prop_type: Int32
+      values:
+        - 60
+  - Prop:
+      type_id: 42
+      prop_name: RespawnTime
+      prop_type: Float32
+      values:
+        - 3
+  - Prop:
+      type_id: 42
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 42
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 42
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000350
+  - Prop:
+      type_id: 42
+      prop_name: UseStrafingAnimations
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 43
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 43
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 43
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 43
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 43
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 43
+      prop_name: MaxIndicatorsVisible
+      prop_type: Int32
+      values:
+        - 16
+  - Prop:
+      type_id: 43
+      prop_name: MaxPromptsVisible
+      prop_type: Int32
+      values:
+        - 16
+  - Prop:
+      type_id: 43
+      prop_name: Name
+      prop_type: String
+      values:
+        - ProximityPromptService
+  - Prop:
+      type_id: 43
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 43
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 43
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b2
+  - Prop:
+      type_id: 44
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 44
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 44
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 44
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 44
+      prop_name: Name
+      prop_type: String
+      values:
+        - ReplicatedFirst
+  - Prop:
+      type_id: 44
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 44
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 44
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000353
+  - Prop:
+      type_id: 45
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 45
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 45
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 45
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 45
+      prop_name: Name
+      prop_type: String
+      values:
+        - ReplicatedStorage
+  - Prop:
+      type_id: 45
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 45
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 45
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000398
+  - Prop:
+      type_id: 46
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 46
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 46
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 46
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 46
+      prop_name: Name
+      prop_type: String
+      values:
+        - Instance
+  - Prop:
+      type_id: 46
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 46
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 46
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000376
+  - Prop:
+      type_id: 47
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 47
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 47
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 47
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 47
+      prop_name: Name
+      prop_type: String
+      values:
+        - Selection
+  - Prop:
+      type_id: 47
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 47
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 47
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000370
+  - Prop:
+      type_id: 48
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 48
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 48
+      prop_name: LoadStringEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 48
+      prop_name: Name
+      prop_type: String
+      values:
+        - ServerScriptService
+  - Prop:
+      type_id: 48
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 48
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 48
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000399
+  - Prop:
+      type_id: 49
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 49
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 49
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 49
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 49
+      prop_name: Name
+      prop_type: String
+      values:
+        - ServerStorage
+  - Prop:
+      type_id: 49
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 49
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 49
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000039a
+  - Prop:
+      type_id: 50
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 50
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 50
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 50
+      prop_name: HiddenServices
+      prop_type: String
+      values:
+        - "\u0000\u0000\u0000\u0000"
+  - Prop:
+      type_id: 50
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 50
+      prop_name: Name
+      prop_type: String
+      values:
+        - ServiceVisibilityService
+  - Prop:
+      type_id: 50
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 50
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 50
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003a1
+  - Prop:
+      type_id: 50
+      prop_name: VisibleServices
+      prop_type: String
+      values:
+        - "\u0000\u0000\u0000\u0000"
+  - Prop:
+      type_id: 51
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 51
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: CelestialBodiesShown
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 51
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 51
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 51
+      prop_name: MoonAngularSize
+      prop_type: Float32
+      values:
+        - 11
+  - Prop:
+      type_id: 51
+      prop_name: MoonTextureId
+      prop_type: String
+      values:
+        - "rbxassetid://6444320592"
+  - Prop:
+      type_id: 51
+      prop_name: Name
+      prop_type: String
+      values:
+        - Sky
+  - Prop:
+      type_id: 51
+      prop_name: SkyboxBk
+      prop_type: String
+      values:
+        - "rbxassetid://6444884337"
+  - Prop:
+      type_id: 51
+      prop_name: SkyboxDn
+      prop_type: String
+      values:
+        - "rbxassetid://6444884785"
+  - Prop:
+      type_id: 51
+      prop_name: SkyboxFt
+      prop_type: String
+      values:
+        - "rbxassetid://6444884337"
+  - Prop:
+      type_id: 51
+      prop_name: SkyboxLf
+      prop_type: String
+      values:
+        - "rbxassetid://6444884337"
+  - Prop:
+      type_id: 51
+      prop_name: SkyboxOrientation
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 51
+      prop_name: SkyboxRt
+      prop_type: String
+      values:
+        - "rbxassetid://6444884337"
+  - Prop:
+      type_id: 51
+      prop_name: SkyboxUp
+      prop_type: String
+      values:
+        - "rbxassetid://6412503613"
+  - Prop:
+      type_id: 51
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - 332039975
+  - Prop:
+      type_id: 51
+      prop_name: StarCount
+      prop_type: Int32
+      values:
+        - 3000
+  - Prop:
+      type_id: 51
+      prop_name: SunAngularSize
+      prop_type: Float32
+      values:
+        - 11
+  - Prop:
+      type_id: 51
+      prop_name: SunTextureId
+      prop_type: String
+      values:
+        - "rbxassetid://6196665106"
+  - Prop:
+      type_id: 51
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 51
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c2
+  - Prop:
+      type_id: 52
+      prop_name: AcousticSimulationEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: AmbientReverb
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 52
+      prop_name: AudioApiByDefault
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: CharacterSoundsUseNewApi
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: DefaultListenerLocation
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 52
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: DiffractionEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 52
+      prop_name: DistanceFactor
+      prop_type: Float32
+      values:
+        - 3.33
+  - Prop:
+      type_id: 52
+      prop_name: DopplerScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 52
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 52
+      prop_name: IsNewExpForAudioApiByDefault
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 52
+      prop_name: ListenerCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 52
+      prop_name: ListenerObject
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 52
+      prop_name: ListenerType
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: Name
+      prop_type: String
+      values:
+        - SoundService
+  - Prop:
+      type_id: 52
+      prop_name: OcclusionEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 52
+      prop_name: RespectFilteringEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 52
+      prop_name: ReverbEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 52
+      prop_name: RolloffScale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 52
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 52
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 52
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000033a
+  - Prop:
+      type_id: 52
+      prop_name: VolumetricAudio
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 53
+      prop_name: AllowTeamChangeOnTouch
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 53
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 53
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 53
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 53
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 53
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0.5
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 53
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+  - Prop:
+      type_id: 53
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 163
+          - 162
+          - 165
+  - Prop:
+      type_id: 53
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+  - Prop:
+      type_id: 53
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: Duration
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 53
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 53
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 53
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 53
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 53
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 53
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+  - Prop:
+      type_id: 53
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 53
+      prop_name: Name
+      prop_type: String
+      values:
+        - SpawnLocation
+  - Prop:
+      type_id: 53
+      prop_name: Neutral
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 53
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 53
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 53
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 53
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 53
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 53
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: TeamColor
+      prop_type: BrickColor
+      values:
+        - 194
+  - Prop:
+      type_id: 53
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 53
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 53
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 53
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bc
+  - Prop:
+      type_id: 53
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 53
+      prop_name: formFactorRaw
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 53
+      prop_name: shape
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 53
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 12
+          - 1
+          - 12
+  - Prop:
+      type_id: 54
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 54
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 54
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 54
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 54
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterCharacterScripts
+  - Prop:
+      type_id: 54
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 54
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 54
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c0
+  - Prop:
+      type_id: 55
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 55
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 55
+      prop_name: ClipsDescendantsSupportsRotation
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 55
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 55
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 55
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterGui
+  - Prop:
+      type_id: 55
+      prop_name: ResetPlayerGuiOnSpawn
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 55
+      prop_name: RtlTextSupport
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 55
+      prop_name: ScreenOrientation
+      prop_type: Enum
+      values:
+        - 4
+  - Prop:
+      type_id: 55
+      prop_name: ShowDevelopmentGui
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 55
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 55
+      prop_name: StudioDefaultStyleSheet
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 55
+      prop_name: StudioInsertWidgetLayerCollectorAutoLinkStyleSheet
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 55
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 55
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000361
+  - Prop:
+      type_id: 55
+      prop_name: VirtualCursorMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 56
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 56
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 56
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 56
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 56
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterPack
+  - Prop:
+      type_id: 56
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 56
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 56
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000360
+  - Prop:
+      type_id: 57
+      prop_name: AllowCustomAnimations
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 57
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 57
+      prop_name: AutoJumpEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 57
+      prop_name: AvatarJointUpgrade_SerializedRollout
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 57
+      prop_name: CameraMaxZoomDistance
+      prop_type: Float32
+      values:
+        - 128
+  - Prop:
+      type_id: 57
+      prop_name: CameraMinZoomDistance
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 57
+      prop_name: CameraMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: CharacterBreakJointsOnDeath
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 57
+      prop_name: CharacterJumpHeight
+      prop_type: Float32
+      values:
+        - 7.2
+  - Prop:
+      type_id: 57
+      prop_name: CharacterJumpPower
+      prop_type: Float32
+      values:
+        - 50
+  - Prop:
+      type_id: 57
+      prop_name: CharacterMaxSlopeAngle
+      prop_type: Float32
+      values:
+        - 89
+  - Prop:
+      type_id: 57
+      prop_name: CharacterUseJumpPower
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 57
+      prop_name: CharacterWalkSpeed
+      prop_type: Float32
+      values:
+        - 16
+  - Prop:
+      type_id: 57
+      prop_name: ClassicDeath
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 57
+      prop_name: CreateDefaultPlayerModule
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 57
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 57
+      prop_name: DevCameraOcclusionMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: DevComputerCameraMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: DevComputerMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: DevTouchCameraMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: DevTouchMovementMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: EnableDynamicHeads
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: EnableMouseLockOption
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDFace
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDHead
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDLeftArm
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDLeftLeg
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDPants
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDRightArm
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDRightLeg
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDShirt
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDTeeShirt
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAssetIDTorso
+      prop_type: Int64
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsAvatar
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsR15Collision
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsScaleRangeBodyType
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsScaleRangeHead
+      prop_type: NumberRange
+      values:
+        - - 0.95
+          - 1
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsScaleRangeHeight
+      prop_type: NumberRange
+      values:
+        - - 0.9
+          - 1.05
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsScaleRangeProportion
+      prop_type: NumberRange
+      values:
+        - - 0
+          - 1
+  - Prop:
+      type_id: 57
+      prop_name: GameSettingsScaleRangeWidth
+      prop_type: NumberRange
+      values:
+        - - 0.7
+          - 1
+  - Prop:
+      type_id: 57
+      prop_name: HealthDisplayDistance
+      prop_type: Float32
+      values:
+        - 100
+  - Prop:
+      type_id: 57
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 57
+      prop_name: LoadCharacterAppearance
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 57
+      prop_name: LoadCharacterLayeredClothing
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: LuaCharacterController
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterPlayer
+  - Prop:
+      type_id: 57
+      prop_name: NameDisplayDistance
+      prop_type: Float32
+      values:
+        - 100
+  - Prop:
+      type_id: 57
+      prop_name: PlayerModuleStatus
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 57
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 57
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000035f
+  - Prop:
+      type_id: 57
+      prop_name: UserEmotesEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 58
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 58
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 58
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 58
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 58
+      prop_name: Name
+      prop_type: String
+      values:
+        - StarterPlayerScripts
+  - Prop:
+      type_id: 58
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 58
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 58
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bf
+  - Prop:
+      type_id: 59
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 59
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 59
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 59
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 59
+      prop_name: Name
+      prop_type: String
+      values:
+        - InsertionHash
+  - Prop:
+      type_id: 59
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 59
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 59
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c1
+  - Prop:
+      type_id: 59
+      prop_name: Value
+      prop_type: String
+      values:
+        - "{a4b4fc84-d3fa-4580-b9d0-98390afa7f7f}"
+  - Prop:
+      type_id: 60
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 60
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 60
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 60
+      prop_name: EnableScriptCollabByDefaultOnLoad
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 60
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 60
+      prop_name: Name
+      prop_type: String
+      values:
+        - StudioData
+  - Prop:
+      type_id: 60
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 60
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 60
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb0000035d
+  - Prop:
+      type_id: 61
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 61
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 61
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 61
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 61
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 61
+      prop_name: Intensity
+      prop_type: Float32
+      values:
+        - 0.01
+  - Prop:
+      type_id: 61
+      prop_name: Name
+      prop_type: String
+      values:
+        - SunRays
+  - Prop:
+      type_id: 61
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 61
+      prop_name: Spread
+      prop_type: Float32
+      values:
+        - 0.1
+  - Prop:
+      type_id: 61
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 61
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003c3
+  - Prop:
+      type_id: 62
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 62
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 62
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 62
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 62
+      prop_name: Name
+      prop_type: String
+      values:
+        - Teams
+  - Prop:
+      type_id: 62
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 62
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 62
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b3
+  - Prop:
+      type_id: 63
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 63
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 63
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 63
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 63
+      prop_name: Name
+      prop_type: String
+      values:
+        - Teleport Service
+  - Prop:
+      type_id: 63
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 63
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 63
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000367
+  - Prop:
+      type_id: 64
+      prop_name: AcquisitionMethod
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: Anchored
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 64
+      prop_name: AudioCanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: BackParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 64
+      prop_name: BackParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 64
+      prop_name: BackSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: BackSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: BottomParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 64
+      prop_name: BottomParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 64
+      prop_name: BottomSurface
+      prop_type: Enum
+      values:
+        - 4
+  - Prop:
+      type_id: 64
+      prop_name: BottomSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: CFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 64
+      prop_name: CanCollide
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: CanQuery
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: CanTouch
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: CastShadow
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: CollisionGroup
+      prop_type: String
+      values:
+        - Default
+  - Prop:
+      type_id: 64
+      prop_name: CollisionGroupId
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: Color3uint8
+      prop_type: Color3uint8
+      values:
+        - - 163
+          - 162
+          - 165
+  - Prop:
+      type_id: 64
+      prop_name: CustomPhysicalProperties
+      prop_type: PhysicalProperties
+      values:
+        - Default
+  - Prop:
+      type_id: 64
+      prop_name: Decoration
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 64
+      prop_name: EnableFluidForces
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: FrontParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 64
+      prop_name: FrontParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 64
+      prop_name: FrontSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: FrontSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: GrassLength
+      prop_type: Float32
+      values:
+        - 0.7
+  - Prop:
+      type_id: 64
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 64
+      prop_name: LeftParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 64
+      prop_name: LeftParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 64
+      prop_name: LeftSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: LeftSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: Locked
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 64
+      prop_name: Massless
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 64
+      prop_name: Material
+      prop_type: Enum
+      values:
+        - 256
+  - Prop:
+      type_id: 64
+      prop_name: MaterialColors
+      prop_type: String
+      values:
+        - 00 00 00 00 00 00 6f 7e 3e 58 59 56 98 98 98 8a 61 49 cf cb a7 ac 94 6c 63 64 66 dd e4 e5 eb fd ff 94 7c 5f 79 70 62 4b 4a 4a 8c 82 68 ff 18 43 50 54 54 86 86 76 cc d2 df 6a 86 40 ff ff fe ff f3 c0 8f 90 87
+  - Prop:
+      type_id: 64
+      prop_name: MaterialVariantSerialized
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 64
+      prop_name: Materials
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: Name
+      prop_type: String
+      values:
+        - Terrain
+  - Prop:
+      type_id: 64
+      prop_name: PhysicsGrid
+      prop_type: String
+      values:
+        - "\u0002\u0003\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+  - Prop:
+      type_id: 64
+      prop_name: PivotOffset
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 64
+      prop_name: Reflectance
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: RightParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 64
+      prop_name: RightParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 64
+      prop_name: RightSurface
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: RightSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: RootPriority
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: RotVelocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 64
+      prop_name: SmoothGrid
+      prop_type: String
+      values:
+        - "\u0001\u0005"
+  - Prop:
+      type_id: 64
+      prop_name: SmoothVoxelsUpgraded
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 64
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 64
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: TopParamA
+      prop_type: Float32
+      values:
+        - -0.5
+  - Prop:
+      type_id: 64
+      prop_name: TopParamB
+      prop_type: Float32
+      values:
+        - 0.5
+  - Prop:
+      type_id: 64
+      prop_name: TopSurface
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 64
+      prop_name: TopSurfaceInput
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 64
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003bb
+  - Prop:
+      type_id: 64
+      prop_name: Velocity
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 64
+      prop_name: WaterColor
+      prop_type: Color3
+      values:
+        - - 0.04705883
+          - 0.32941177
+          - 0.36078432
+  - Prop:
+      type_id: 64
+      prop_name: WaterReflectance
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 64
+      prop_name: WaterTransparency
+      prop_type: Float32
+      values:
+        - 0.3
+  - Prop:
+      type_id: 64
+      prop_name: WaterWaveSize
+      prop_type: Float32
+      values:
+        - 0.15
+  - Prop:
+      type_id: 64
+      prop_name: WaterWaveSpeed
+      prop_type: Float32
+      values:
+        - 10
+  - Prop:
+      type_id: 64
+      prop_name: size
+      prop_type: Vector3
+      values:
+        - - 2044
+          - 252
+          - 2044
+  - Prop:
+      type_id: 65
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 65
+      prop_name: AutoRuns
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 65
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 65
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 65
+      prop_name: Description
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 65
+      prop_name: ExecuteWithStudioRun
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 65
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 65
+      prop_name: IsPhysicsEnvironmentalThrottled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 65
+      prop_name: IsSleepAllowed
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 65
+      prop_name: Name
+      prop_type: String
+      values:
+        - TestService
+  - Prop:
+      type_id: 65
+      prop_name: NumberOfPlayers
+      prop_type: Int32
+      values:
+        - 0
+  - Prop:
+      type_id: 65
+      prop_name: SimulateSecondsLag
+      prop_type: Float64
+      values:
+        - 0
+  - Prop:
+      type_id: 65
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 65
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 65
+      prop_name: ThrottlePhysicsToRealtime
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 65
+      prop_name: Timeout
+      prop_type: Float64
+      values:
+        - 10
+  - Prop:
+      type_id: 65
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b4
+  - Prop:
+      type_id: 66
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 66
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 66
+      prop_name: ChatTranslationFTUXShown
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 66
+      prop_name: ChatTranslationToggleEnabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 66
+      prop_name: ChatVersion
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 66
+      prop_name: CreateDefaultCommands
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 66
+      prop_name: CreateDefaultTextChannels
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 66
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 66
+      prop_name: EnableProtectedChat
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 66
+      prop_name: HasSeenDeprecationDialog
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 66
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 66
+      prop_name: IsLegacyChatDisabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 66
+      prop_name: Name
+      prop_type: String
+      values:
+        - TextChatService
+  - Prop:
+      type_id: 66
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 66
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 66
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000357
+  - Prop:
+      type_id: 67
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 67
+      prop_name: AutoLocalize
+      prop_type: Bool
+      values:
+        - true
+        - true
+  - Prop:
+      type_id: 67
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: Color3
+      prop_type: Color3
+      values:
+        - - 0
+          - 0
+          - 0
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 67
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+        - false
+  - Prop:
+      type_id: 67
+      prop_name: Face
+      prop_type: Enum
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 67
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+        - 7ae0e5570bbb7d4c0a5586bb000003ba
+  - Prop:
+      type_id: 67
+      prop_name: MetalnessMap
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 67
+      prop_name: Name
+      prop_type: String
+      values:
+        - Texture
+        - Texture
+  - Prop:
+      type_id: 67
+      prop_name: NormalMap
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 67
+      prop_name: OffsetStudsU
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: OffsetStudsV
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: RoughnessMap
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 67
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+        - -1
+  - Prop:
+      type_id: 67
+      prop_name: StudsPerTileU
+      prop_type: Float32
+      values:
+        - 8
+        - 8
+  - Prop:
+      type_id: 67
+      prop_name: StudsPerTileV
+      prop_type: Float32
+      values:
+        - 8
+        - 8
+  - Prop:
+      type_id: 67
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+        - 0
+  - Prop:
+      type_id: 67
+      prop_name: Texture
+      prop_type: String
+      values:
+        - "rbxassetid://6372755229"
+        - "rbxassetid://6372755229"
+  - Prop:
+      type_id: 67
+      prop_name: TexturePack
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 67
+      prop_name: TexturePackMetadata
+      prop_type: String
+      values:
+        - ""
+        - ""
+  - Prop:
+      type_id: 67
+      prop_name: Transparency
+      prop_type: Float32
+      values:
+        - 0.8
+        - 0.8
+  - Prop:
+      type_id: 67
+      prop_name: UVOffset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+        - - 0
+          - 0
+  - Prop:
+      type_id: 67
+      prop_name: UVScale
+      prop_type: Vector2
+      values:
+        - - 1
+          - 1
+        - - 1
+          - 1
+  - Prop:
+      type_id: 67
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ba
+        - 7ae0e5570bbb7d4c0a5586bb000008b4
+  - Prop:
+      type_id: 67
+      prop_name: ZIndex
+      prop_type: Int32
+      values:
+        - 1
+        - 1
+  - Prop:
+      type_id: 68
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 68
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 68
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 68
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 68
+      prop_name: Name
+      prop_type: String
+      values:
+        - Instance
+  - Prop:
+      type_id: 68
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 68
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 68
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000338
+  - Prop:
+      type_id: 69
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 69
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 69
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 69
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 69
+      prop_name: Name
+      prop_type: String
+      values:
+        - TouchInputService
+  - Prop:
+      type_id: 69
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 69
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 69
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000379
+  - Prop:
+      type_id: 70
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 70
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 70
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 70
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 70
+      prop_name: Name
+      prop_type: String
+      values:
+        - TweenService
+  - Prop:
+      type_id: 70
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 70
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 70
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000355
+  - Prop:
+      type_id: 71
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 71
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 71
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 71
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 71
+      prop_name: Name
+      prop_type: String
+      values:
+        - UGCAvatarService
+  - Prop:
+      type_id: 71
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 71
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 71
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b5
+  - Prop:
+      type_id: 72
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 72
+      prop_name: BottomLeftRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 72
+      prop_name: BottomRightRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 72
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 72
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 72
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 72
+      prop_name: Name
+      prop_type: String
+      values:
+        - UICorner
+  - Prop:
+      type_id: 72
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 72
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 72
+      prop_name: TopLeftRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 72
+      prop_name: TopRightRadius
+      prop_type: UDim
+      values:
+        - - 0
+          - 12
+  - Prop:
+      type_id: 72
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003cc
+  - Prop:
+      type_id: 73
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 73
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 73
+      prop_name: Color
+      prop_type: ColorSequence
+      values:
+        - keypoints:
+            - time: 0
+              color:
+                - 1
+                - 1
+                - 1
+            - time: 1
+              color:
+                - 1
+                - 1
+                - 1
+  - Prop:
+      type_id: 73
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 73
+      prop_name: Enabled
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 73
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 73
+      prop_name: Name
+      prop_type: String
+      values:
+        - UIGradient
+  - Prop:
+      type_id: 73
+      prop_name: Offset
+      prop_type: Vector2
+      values:
+        - - 0
+          - 0
+  - Prop:
+      type_id: 73
+      prop_name: Rotation
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 73
+      prop_name: Scale
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 73
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 73
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 73
+      prop_name: TileMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 73
+      prop_name: Transparency
+      prop_type: NumberSequence
+      values:
+        - keypoints:
+            - time: 0
+              value: 0
+              envelope: 0
+            - time: 1
+              value: 0
+              envelope: 0
+  - Prop:
+      type_id: 73
+      prop_name: Type
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 73
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003ca
+  - Prop:
+      type_id: 74
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 74
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 74
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 74
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 74
+      prop_name: Name
+      prop_type: String
+      values:
+        - UIPadding
+  - Prop:
+      type_id: 74
+      prop_name: PaddingBottom
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 74
+      prop_name: PaddingLeft
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 74
+      prop_name: PaddingRight
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 74
+      prop_name: PaddingTop
+      prop_type: UDim
+      values:
+        - - 0
+          - 8
+  - Prop:
+      type_id: 74
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 74
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 74
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003cd
+  - Prop:
+      type_id: 75
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 75
+      prop_name: AutomaticScaling
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 75
+      prop_name: AvatarGestures
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 75
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 75
+      prop_name: ControllerModels
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 75
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 75
+      prop_name: FadeOutViewOnCollision
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 75
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 75
+      prop_name: LaserPointer
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 75
+      prop_name: Name
+      prop_type: String
+      values:
+        - VRService
+  - Prop:
+      type_id: 75
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 75
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 75
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000374
+  - Prop:
+      type_id: 76
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 76
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 76
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 76
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 76
+      prop_name: Name
+      prop_type: String
+      values:
+        - VideoCaptureService
+  - Prop:
+      type_id: 76
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 76
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 76
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000346
+  - Prop:
+      type_id: 77
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 77
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 77
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 77
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 77
+      prop_name: Name
+      prop_type: String
+      values:
+        - VideoService
+  - Prop:
+      type_id: 77
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 77
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 77
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003da
+  - Prop:
+      type_id: 78
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 78
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 78
+      prop_name: DefaultDistanceAttenuation
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 78
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 78
+      prop_name: EnableDefaultVoice
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 78
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 78
+      prop_name: Name
+      prop_type: String
+      values:
+        - VoiceChatService
+  - Prop:
+      type_id: 78
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 78
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 78
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb000003b7
+  - Prop:
+      type_id: 78
+      prop_name: UseAudioApi
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 79
+      prop_name: AirDensity
+      prop_type: Float32
+      values:
+        - 0.0012
+  - Prop:
+      type_id: 79
+      prop_name: AirTurbulenceIntensity
+      prop_type: Float32
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: AllowThirdPartySales
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 79
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+  - Prop:
+      type_id: 79
+      prop_name: AuthorityMode
+      prop_type: Enum
+      values:
+        - 1
+  - Prop:
+      type_id: 79
+      prop_name: AvatarUnificationMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: Capabilities
+      prop_type: SecurityCapabilities
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ClientAnimatorThrottling
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: CollisionGroupData
+      prop_type: String
+      values:
+        - 01 01 00 04 ff ff ff ff 07 44 65 66 61 75 6c 74
+  - Prop:
+      type_id: 79
+      prop_name: CurrentCamera
+      prop_type: Ref
+      values:
+        - 1
+  - Prop:
+      type_id: 79
+      prop_name: DefinesCapabilities
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 79
+      prop_name: DistributedGameTime
+      prop_type: Float64
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: EnableSLIMAvatars
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ExplicitAutoJoints
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 79
+      prop_name: FallHeightEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 79
+      prop_name: FallenPartsDestroyHeight
+      prop_type: Float32
+      values:
+        - -500
+  - Prop:
+      type_id: 79
+      prop_name: FluidForces
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: GlobalWind
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 79
+      prop_name: Gravity
+      prop_type: Float32
+      values:
+        - 196.2
+  - Prop:
+      type_id: 79
+      prop_name: HistoryId
+      prop_type: UniqueId
+      values:
+        - "00000000000000000000000000000000"
+  - Prop:
+      type_id: 79
+      prop_name: IKControlConstraintSupport
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ImprovedAnimationConstraint
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ImprovedPhysicsReplication
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: LayeredClothingCacheOptimizations
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: LevelOfDetail
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: LuauTypeCheckMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: MeshPartHeadsAndAccessories
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: MeshStreamingAndImprovedLods
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ModelMeshCFrame
+      prop_type: CFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prop:
+      type_id: 79
+      prop_name: ModelMeshData
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ModelMeshSize
+      prop_type: Vector3
+      values:
+        - - 0
+          - 0
+          - 0
+  - Prop:
+      type_id: 79
+      prop_name: ModelStreamingBehavior
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ModelStreamingMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: Name
+      prop_type: String
+      values:
+        - Workspace
+  - Prop:
+      type_id: 79
+      prop_name: NeedsPivotMigration
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 79
+      prop_name: NextGenerationReplication
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: PathfindingUseImprovedSearch
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: PhysicsSteppingMethod
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: PlayerCharacterDestroyBehavior
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: PlayerScriptsUseInputActionSystem
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: PrimalPhysicsSolver
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: PrimaryPart
+      prop_type: Ref
+      values:
+        - -1
+  - Prop:
+      type_id: 79
+      prop_name: RejectCharacterDeletions
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: RenderingCacheOptimizations
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ReplicateInstanceDestroySetting
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: Retargeting
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: SandboxedInstanceMode
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: ScaleFactor
+      prop_type: Float32
+      values:
+        - 1
+  - Prop:
+      type_id: 79
+      prop_name: SignalBehavior2
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 79
+      prop_name: SlimHash
+      prop_type: SharedString
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: SourceAssetId
+      prop_type: Int64
+      values:
+        - -1
+  - Prop:
+      type_id: 79
+      prop_name: StreamOutBehavior
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 79
+      prop_name: StreamingEnabled
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 79
+      prop_name: StreamingIntegrityMode
+      prop_type: Enum
+      values:
+        - 3
+  - Prop:
+      type_id: 79
+      prop_name: StreamingMinRadius
+      prop_type: Int32
+      values:
+        - 64
+  - Prop:
+      type_id: 79
+      prop_name: StreamingTargetRadius
+      prop_type: Int32
+      values:
+        - 1024
+  - Prop:
+      type_id: 79
+      prop_name: Tags
+      prop_type: SharedString
+      values:
+        - 3
+  - Prop:
+      type_id: 79
+      prop_name: TerrainWeldsFixed
+      prop_type: Bool
+      values:
+        - true
+  - Prop:
+      type_id: 79
+      prop_name: TouchEventsUseCollisionGroups
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: TouchesUseCollisionGroups
+      prop_type: Bool
+      values:
+        - false
+  - Prop:
+      type_id: 79
+      prop_name: UniqueId
+      prop_type: UniqueId
+      values:
+        - 7ae0e5570bbb7d4c0a5586bb00000002
+  - Prop:
+      type_id: 79
+      prop_name: UseFixedSimulation
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: UseNewLuauTypeSolver
+      prop_type: Enum
+      values:
+        - 2
+  - Prop:
+      type_id: 79
+      prop_name: ValidateEnabledProximityPrompt
+      prop_type: Enum
+      values:
+        - 0
+  - Prop:
+      type_id: 79
+      prop_name: WorldPivotData
+      prop_type: OptionalCFrame
+      values:
+        - position:
+            - 0
+            - 0
+            - 0
+          orientation:
+            - - 1
+              - 0
+              - 0
+            - - 0
+              - 1
+              - 0
+            - - 0
+              - 0
+              - 1
+  - Prnt:
+      version: 0
+      links:
+        - - 1
+          - 0
+        - - 3
+          - 2
+        - - 2
+          - 0
+        - - 4
+          - 0
+        - - 6
+          - 5
+        - - 5
+          - 0
+        - - 8
+          - 7
+        - - 7
+          - 0
+        - - 0
+          - -1
+        - - 9
+          - -1
+        - - 10
+          - -1
+        - - 11
+          - -1
+        - - 12
+          - -1
+        - - 13
+          - -1
+        - - 14
+          - -1
+        - - 15
+          - -1
+        - - 16
+          - -1
+        - - 17
+          - -1
+        - - 18
+          - -1
+        - - 20
+          - 19
+        - - 21
+          - 19
+        - - 23
+          - 22
+        - - 24
+          - 22
+        - - 25
+          - 22
+        - - 26
+          - 22
+        - - 22
+          - 19
+        - - 27
+          - 19
+        - - 19
+          - -1
+        - - 28
+          - -1
+        - - 29
+          - -1
+        - - 31
+          - 30
+        - - 32
+          - 30
+        - - 30
+          - -1
+        - - 33
+          - -1
+        - - 34
+          - -1
+        - - 35
+          - -1
+        - - 36
+          - -1
+        - - 37
+          - -1
+        - - 38
+          - -1
+        - - 40
+          - 39
+        - - 39
+          - -1
+        - - 41
+          - -1
+        - - 42
+          - -1
+        - - 43
+          - -1
+        - - 44
+          - -1
+        - - 45
+          - -1
+        - - 46
+          - -1
+        - - 47
+          - -1
+        - - 48
+          - -1
+        - - 49
+          - -1
+        - - 52
+          - 51
+        - - 53
+          - 51
+        - - 54
+          - 51
+        - - 55
+          - 51
+        - - 56
+          - 51
+        - - 57
+          - 51
+        - - 51
+          - 50
+        - - 50
+          - -1
+        - - 58
+          - -1
+        - - 59
+          - -1
+        - - 60
+          - -1
+        - - 61
+          - -1
+        - - 62
+          - -1
+        - - 63
+          - -1
+        - - 65
+          - 64
+        - - 66
+          - 64
+        - - 67
+          - 64
+        - - 68
+          - 64
+        - - 69
+          - 64
+        - - 64
+          - -1
+        - - 70
+          - -1
+        - - 71
+          - -1
+        - - 72
+          - -1
+        - - 73
+          - -1
+        - - 74
+          - -1
+        - - 75
+          - -1
+        - - 76
+          - -1
+        - - 77
+          - -1
+        - - 78
+          - -1
+        - - 79
+          - -1
+        - - 80
+          - -1
+        - - 81
+          - -1
+  - End

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 * Added support for one-to-many property migrations. ([#612])
+* Added support for converting `SharedString` and `NetAssetRef` values to other values when necessary. ([#634])
 
 [#612]: https://github.com/rojo-rbx/rbx-dom/pull/612
+[#634]: https://github.com/rojo-rbx/rbx-dom/pull/634
 
 ## 2.0.1 (2025-11-27)
 * Upgrade rbx-dom dependencies.

--- a/rbx_xml/src/conversion.rs
+++ b/rbx_xml/src/conversion.rs
@@ -66,7 +66,7 @@ impl ConvertVariant for Variant {
             )),
             (Variant::SharedString(value), VariantType::Tags) => Ok(Cow::Owned(
                 Tags::decode(value.data())
-                    .map_err(|_| "Tags contain invalud UTF-8")?
+                    .map_err(|_| "Tags contain invalid UTF-8")?
                     .into(),
             )),
             (Variant::BinaryString(value), VariantType::Attributes) => {

--- a/rbx_xml/src/conversion.rs
+++ b/rbx_xml/src/conversion.rs
@@ -64,6 +64,11 @@ impl ConvertVariant for Variant {
                     .map_err(|_| "Tags contain invalid UTF-8")?
                     .into(),
             )),
+            (Variant::SharedString(value), VariantType::Tags) => Ok(Cow::Owned(
+                Tags::decode(value.data())
+                    .map_err(|_| "Tags contain invalud UTF-8")?
+                    .into(),
+            )),
             (Variant::BinaryString(value), VariantType::Attributes) => {
                 let bytes: &[u8] = value.as_ref();
                 match Attributes::from_reader(bytes) {

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use log::trace;
 use rbx_dom_weak::{
-    types::{Ref, SharedString, Variant},
+    types::{NetAssetRef, Ref, SharedString, Variant, VariantType},
     InstanceBuilder, Ustr, WeakDom,
 };
 use rbx_reflection::{PropertyKind, PropertySerialization, ReflectionDatabase};
@@ -27,8 +27,8 @@ pub fn decode_internal<R: Read>(source: R, options: DecodeOptions) -> Result<Wea
 
     deserialize_root(&mut iterator, &mut state, root_id)?;
     apply_referent_rewrites(&mut state);
-    apply_shared_string_rewrites(&mut state);
-    apply_net_asset_rewrites(&mut state);
+    apply_shared_string_rewrites(&mut state).map_err(|e| iterator.error(e))?;
+    apply_net_asset_rewrites(&mut state).map_err(|e| iterator.error(e))?;
 
     Ok(tree)
 }
@@ -256,40 +256,116 @@ fn apply_referent_rewrites(state: &mut ParseState) {
     }
 }
 
-fn apply_net_asset_rewrites(state: &mut ParseState) {
+fn apply_net_asset_rewrites(state: &mut ParseState) -> Result<(), DecodeErrorKind> {
     for rewrite in &state.net_asset_rewrites {
         let new_value = match state.known_shared_strings.get(&rewrite.hash) {
-            Some(v) => v.clone(),
+            Some(v) => Variant::NetAssetRef(NetAssetRef::from(v.clone())),
             None => continue,
         };
+        let actual_value;
 
         let instance = state.tree.get_by_ref_mut(rewrite.id).expect(
             "rbx_xml bug: had ID in NetAssetRef rewrite list that didn't end up in the tree",
         );
 
-        instance.properties.insert(
-            rewrite.property_name.as_str().into(),
-            Variant::NetAssetRef(new_value.into()),
-        );
+        let maybe_descriptor = if state.options.use_reflection() {
+            find_canonical_property_descriptor(
+                &instance.class,
+                &rewrite.property_name,
+                state.options.database,
+            )
+        } else {
+            None
+        };
+
+        // TODO This does not support migrations or other oddities. It's a
+        // patchwork for converting NetAssetRef into other values, but it
+        // could be more comprehensive.
+        if let Some(descriptor) = maybe_descriptor {
+            let expected_type = descriptor.data_type.ty();
+            // If this property isn't a NetAssetRef property...
+            if expected_type != VariantType::NetAssetRef {
+                actual_value = match new_value.try_convert(instance.class, expected_type) {
+                    Ok(value) => value,
+                    Err(message) => {
+                        return Err(DecodeErrorKind::UnsupportedPropertyConversion {
+                            class_name: instance.class.to_string(),
+                            property_name: rewrite.property_name.to_string(),
+                            expected_type,
+                            actual_type: VariantType::SharedString,
+                            message,
+                        });
+                    }
+                };
+            } else {
+                actual_value = new_value
+            }
+        } else {
+            actual_value = new_value;
+        }
+
+        instance
+            .properties
+            .insert(rewrite.property_name, actual_value);
     }
+
+    Ok(())
 }
 
-fn apply_shared_string_rewrites(state: &mut ParseState) {
+fn apply_shared_string_rewrites(state: &mut ParseState) -> Result<(), DecodeErrorKind> {
     for rewrite in &state.shared_string_rewrites {
         let new_value = match state.known_shared_strings.get(&rewrite.hash) {
-            Some(v) => v.clone(),
+            Some(v) => Variant::SharedString(v.clone()),
             None => continue,
         };
+        let actual_value;
 
         let instance = state.tree.get_by_ref_mut(rewrite.id).expect(
             "rbx_xml bug: had ID in SharedString rewrite list that didn't end up in the tree",
         );
 
-        instance.properties.insert(
-            rewrite.property_name.as_str().into(),
-            Variant::SharedString(new_value),
-        );
+        let maybe_descriptor = if state.options.use_reflection() {
+            find_canonical_property_descriptor(
+                &instance.class,
+                &rewrite.property_name,
+                state.options.database,
+            )
+        } else {
+            None
+        };
+
+        // TODO This does not support migrations or other oddities. It's a
+        // patchwork for converting SharedString into other values, but it
+        // could be more comprehensive.
+        if let Some(descriptor) = maybe_descriptor {
+            let expected_type = descriptor.data_type.ty();
+            // If this property isn't a SharedString property...
+            if expected_type != VariantType::SharedString {
+                actual_value = match new_value.try_convert(instance.class, expected_type) {
+                    Ok(value) => value,
+                    Err(message) => {
+                        return Err(DecodeErrorKind::UnsupportedPropertyConversion {
+                            class_name: instance.class.to_string(),
+                            property_name: rewrite.property_name.to_string(),
+                            expected_type,
+                            actual_type: VariantType::SharedString,
+                            message,
+                        });
+                    }
+                };
+            } else {
+                actual_value = new_value
+            }
+        } else {
+            actual_value = new_value;
+        }
+
+        instance
+            .properties
+            .insert(rewrite.property_name, actual_value);
     }
+
+    Ok(())
 }
 
 fn deserialize_root<R: Read>(

--- a/rbx_xml/src/tests/basic.rs
+++ b/rbx_xml/src/tests/basic.rs
@@ -430,3 +430,35 @@ fn enum_item_to_enum() {
 
     assert_eq!(prop_type, VariantType::Enum);
 }
+
+#[test]
+fn sharedstring_tags() {
+    let _ = env_logger::try_init();
+    let document = r#"
+        <roblox version="4">
+            <Item class="Folder" referent="Unimportant">
+                <Properties>
+                    <SharedString name="Tags">Xp9+1IrNPJ11i2LY/+DKKQ==</SharedString>
+                </Properties>
+            </Item>
+            <SharedStrings>
+                <SharedString md5="Xp9+1IrNPJ11i2LY/+DKKQ==">VGVzdFRhZw==</SharedString>
+            </SharedStrings>
+        </roblox>
+    "#;
+    let tree = crate::from_str_default(document).unwrap();
+
+    let folder = tree.get_by_ref(tree.root().children()[0]).unwrap();
+    assert_eq!(folder.class, "Folder");
+    let tags = folder
+        .properties
+        .get(&"Tags".into())
+        .expect("the read Folder to have Tags");
+
+    let Variant::Tags(inner) = tags else {
+        panic!("read Tags property was a {:?} and not a Tags", tags.ty());
+    };
+
+    assert_eq!(inner.len(), 1);
+    assert_eq!(inner.iter().next(), Some("TestTag"));
+}

--- a/rbx_xml/src/tests/mod.rs
+++ b/rbx_xml/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod basic;
 mod edge_cases;
 mod formatting;
 mod models;
+mod places;
 
 use std::{fmt, fs, path::PathBuf};
 

--- a/rbx_xml/src/tests/places.rs
+++ b/rbx_xml/src/tests/places.rs
@@ -1,0 +1,31 @@
+//! Roundtrip testing for model files from the `test-files` submodule
+
+use std::path::PathBuf;
+
+use heck::ToKebabCase;
+
+use super::test_suite;
+
+macro_rules! place_tests {
+    ($($test_name: ident,)*) => {
+        $(
+            #[test]
+            fn $test_name() {
+                let _ = env_logger::try_init();
+                let mut test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                assert!(test_path.pop());
+
+                test_path.push("test-files");
+                test_path.push("places");
+                test_path.push(stringify!($test_name).to_kebab_case());
+                test_path.push("xml.rbxlx");
+
+                test_suite(test_path).unwrap()
+            }
+        )*
+    };
+}
+
+place_tests! {
+    baseplate_727_with_tags,
+}

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__baseplate-727-with-tags__decoded.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__baseplate-727-with-tags__decoded.snap
@@ -1,0 +1,3633 @@
+---
+source: rbx_xml/src/tests/mod.rs
+assertion_line: 27
+expression: "DomViewer::new().view_children(&decoded)"
+---
+- referent: referent-0
+  name: Workspace
+  class: Workspace
+  properties:
+    AirDensity:
+      Float32: 0.0012
+    AirTurbulenceIntensity:
+      Float32: 0
+    AllowThirdPartySales:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    AuthorityMode:
+      Enum: 1
+    AvatarUnificationMode:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    ClientAnimatorThrottling:
+      Enum: 0
+    CollisionGroupData:
+      BinaryString: AQEABP////8HRGVmYXVsdA==
+    CurrentCamera: referent-1
+    DistributedGameTime:
+      Float64: 0
+    EnableSLIMAvatars:
+      Enum: 0
+    ExplicitAutoJoints:
+      Bool: true
+    FallHeightEnabled:
+      Bool: true
+    FallenPartsDestroyHeight:
+      Float32: -500
+    FluidForces:
+      Enum: 0
+    GlobalWind:
+      Vector3:
+        - 0
+        - 0
+        - 0
+    Gravity:
+      Float32: 196.2
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IKControlConstraintSupport:
+      Enum: 0
+    ImprovedAnimationConstraint:
+      Enum: 0
+    ImprovedPhysicsReplication:
+      Enum: 0
+    LayeredClothingCacheOptimizations:
+      Enum: 0
+    LevelOfDetail:
+      Enum: 0
+    LuauTypeCheckMode:
+      Enum: 0
+    MeshPartHeadsAndAccessories:
+      Enum: 0
+    MeshStreamingAndImprovedLods:
+      Enum: 0
+    ModelMeshCFrame:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Vector3:
+        - 0
+        - 0
+        - 0
+    ModelStreamingBehavior:
+      Enum: 0
+    ModelStreamingMode:
+      Enum: 0
+    NeedsPivotMigration:
+      Bool: false
+    NextGenerationReplication:
+      Enum: 0
+    PathfindingUseImprovedSearch:
+      Enum: 0
+    PhysicsSteppingMethod:
+      Enum: 0
+    PlayerCharacterDestroyBehavior:
+      Enum: 0
+    PlayerScriptsUseInputActionSystem:
+      Enum: 0
+    PrimalPhysicsSolver:
+      Enum: 0
+    PrimaryPart: "null"
+    RejectCharacterDeletions:
+      Enum: 0
+    RenderingCacheOptimizations:
+      Enum: 0
+    ReplicateInstanceDestroySetting:
+      Enum: 0
+    Retargeting:
+      Enum: 0
+    Sandboxed:
+      Bool: false
+    SandboxedInstanceMode:
+      Enum: 0
+    Scale:
+      Float32: 1
+    SignalBehavior:
+      Enum: 2
+    SlimHash:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    SourceAssetId:
+      Int64: -1
+    StreamOutBehavior:
+      Enum: 2
+    StreamingEnabled:
+      Bool: true
+    StreamingIntegrityMode:
+      Enum: 3
+    StreamingMinRadius:
+      Int32: 64
+    StreamingTargetRadius:
+      Int32: 1024
+    Tags:
+      Tags:
+        - hmmmm
+    TerrainWeldsFixed:
+      Bool: true
+    TouchEventsUseCollisionGroups:
+      Enum: 0
+    TouchesUseCollisionGroups:
+      Bool: false
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000002
+    UseFixedSimulation:
+      Enum: 0
+    UseNewLuauTypeSolver:
+      Enum: 2
+    ValidateEnabledProximityPrompt:
+      Enum: 0
+    WorldPivotData:
+      OptionalCFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+  children:
+    - referent: referent-1
+      name: Camera
+      class: Camera
+      properties:
+        Attributes:
+          Attributes: {}
+        CFrame:
+          CFrame:
+            position:
+              - -19.696095
+              - 14.091624
+              - -19.303886
+            orientation:
+              - - -0.7061509
+                - 0.31296578
+                - -0.6351404
+              - - 0.000000014901163
+                - 0.8970132
+                - 0.44200373
+              - - 0.7080614
+                - 0.31212133
+                - -0.63342667
+        CameraSubject: "null"
+        CameraType:
+          Enum: 0
+        Capabilities:
+          SecurityCapabilities: 0
+        FieldOfView:
+          Float32: 70
+        FieldOfViewMode:
+          Enum: 0
+        Focus:
+          CFrame:
+            position:
+              - -18.425814
+              - 13.207617
+              - -18.037033
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        HeadLocked:
+          Bool: true
+        HeadScale:
+          Float32: 1
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b8
+        VRTiltAndRollEnabled:
+          Bool: false
+      children: []
+    - referent: referent-2
+      name: Baseplate
+      class: Part
+      properties:
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - -8
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 91
+            - 91
+            - 91
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        EnableFluidForces:
+          Bool: true
+        FormFactor:
+          Enum: 0
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 2048
+            - 16
+            - 2048
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags:
+            - atag
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b9
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-3
+          name: Texture
+          class: Texture
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 0
+                - 0
+                - 0
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            OffsetStudsU:
+              Float32: 0
+            OffsetStudsV:
+              Float32: 0
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            StudsPerTileU:
+              Float32: 8
+            StudsPerTileV:
+              Float32: 8
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxassetid://6372755229"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0.8
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ba
+            ZIndex:
+              Int32: 1
+          children: []
+    - referent: referent-4
+      name: Terrain
+      class: Terrain
+      properties:
+        AcquisitionMethod:
+          Enum: 0
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 4
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 163
+            - 162
+            - 165
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        Decoration:
+          Bool: true
+        EnableFluidForces:
+          Bool: true
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        GrassLength:
+          Float32: 0.7
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialColors:
+          MaterialColors:
+            Grass:
+              - 111
+              - 126
+              - 62
+            Slate:
+              - 88
+              - 89
+              - 86
+            Concrete:
+              - 152
+              - 152
+              - 152
+            Brick:
+              - 138
+              - 97
+              - 73
+            Sand:
+              - 207
+              - 203
+              - 167
+            WoodPlanks:
+              - 172
+              - 148
+              - 108
+            Rock:
+              - 99
+              - 100
+              - 102
+            Glacier:
+              - 221
+              - 228
+              - 229
+            Snow:
+              - 235
+              - 253
+              - 255
+            Sandstone:
+              - 148
+              - 124
+              - 95
+            Mud:
+              - 121
+              - 112
+              - 98
+            Basalt:
+              - 75
+              - 74
+              - 74
+            Ground:
+              - 140
+              - 130
+              - 104
+            CrackedLava:
+              - 255
+              - 24
+              - 67
+            Asphalt:
+              - 80
+              - 84
+              - 84
+            Cobblestone:
+              - 134
+              - 134
+              - 118
+            Ice:
+              - 204
+              - 210
+              - 223
+            LeafyGrass:
+              - 106
+              - 134
+              - 64
+            Salt:
+              - 255
+              - 255
+              - 254
+            Limestone:
+              - 255
+              - 243
+              - 192
+            Pavement:
+              - 143
+              - 144
+              - 135
+        MaterialVariant:
+          String: ""
+        Materials:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicsGrid:
+          BinaryString: AgMAAAAAAAAAAAAAAAA=
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Size:
+          Vector3:
+            - 2044
+            - 252
+            - 2044
+        SmoothGrid:
+          BinaryString: AQU=
+        SmoothVoxelsUpgraded:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 3
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bb
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        WaterColor:
+          Color3:
+            - 0.04705883
+            - 0.32941177
+            - 0.36078432
+        WaterReflectance:
+          Float32: 1
+        WaterTransparency:
+          Float32: 0.3
+        WaterWaveSize:
+          Float32: 0.15
+        WaterWaveSpeed:
+          Float32: 10
+      children: []
+    - referent: referent-5
+      name: SpawnLocation
+      class: SpawnLocation
+      properties:
+        AllowTeamChangeOnTouch:
+          Bool: false
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - 0.5
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 163
+            - 162
+            - 165
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        Duration:
+          Int32: 0
+        EnableFluidForces:
+          Bool: true
+        Enabled:
+          Bool: true
+        FormFactor:
+          Enum: 1
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        Neutral:
+          Bool: true
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 12
+            - 1
+            - 12
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TeamColor:
+          BrickColor: 194
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bc
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-6
+          name: Decal
+          class: Decal
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxasset://textures/SpawnLocation.png"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bd
+            ZIndex:
+              Int32: 1
+          children: []
+    - referent: referent-7
+      name: Baseplate
+      class: Part
+      properties:
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - -8
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 91
+            - 91
+            - 91
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        EnableFluidForces:
+          Bool: true
+        FormFactor:
+          Enum: 0
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b9
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 2048
+            - 16
+            - 2048
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags:
+            - atag
+            - anothertag
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000008b3
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-8
+          name: Texture
+          class: Texture
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 0
+                - 0
+                - 0
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ba
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            OffsetStudsU:
+              Float32: 0
+            OffsetStudsV:
+              Float32: 0
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            StudsPerTileU:
+              Float32: 8
+            StudsPerTileV:
+              Float32: 8
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxassetid://6372755229"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0.8
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000008b4
+            ZIndex:
+              Int32: 1
+          children: []
+- referent: referent-9
+  name: Instance
+  class: TimerService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000338
+  children: []
+- referent: referent-10
+  name: CollectionService
+  class: CollectionService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000339
+  children: []
+- referent: referent-11
+  name: SoundService
+  class: SoundService
+  properties:
+    AcousticSimulationEnabled:
+      Bool: false
+    AmbientReverb:
+      Enum: 0
+    Attributes:
+      Attributes: {}
+    AudioApiByDefault:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterSoundsUseNewApi:
+      Enum: 0
+    DefaultListenerLocation:
+      Enum: 3
+    DistanceFactor:
+      Float32: 3.33
+    DopplerScale:
+      Float32: 1
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsNewExpForAudioApiByDefault:
+      Bool: false
+    RespectFilteringEnabled:
+      Bool: true
+    RolloffScale:
+      Float32: 1
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000033a
+    VolumetricAudio:
+      Enum: 1
+  children: []
+- referent: referent-12
+  name: VideoCaptureService
+  class: VideoCaptureService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000346
+  children: []
+- referent: referent-13
+  name: NonReplicatedCSGDictionaryService
+  class: NonReplicatedCSGDictionaryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000347
+  children: []
+- referent: referent-14
+  name: CSGDictionaryService
+  class: CSGDictionaryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000348
+  children: []
+- referent: referent-15
+  name: Chat
+  class: Chat
+  properties:
+    Attributes:
+      Attributes: {}
+    BubbleChatEnabled:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsAutoMigrated:
+      Bool: true
+    LoadDefaultChat:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000034e
+  children: []
+- referent: referent-16
+  name: Players
+  class: Players
+  properties:
+    Attributes:
+      Attributes: {}
+    BanningEnabled:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterAutoLoads:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxPlayers:
+      Int32: 60
+    PreferredPlayers:
+      Int32: 60
+    RespawnTime:
+      Float32: 3
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000350
+    UseStrafingAnimations:
+      Bool: false
+  children: []
+- referent: referent-17
+  name: ReplicatedFirst
+  class: ReplicatedFirst
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000353
+  children: []
+- referent: referent-18
+  name: TweenService
+  class: TweenService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000355
+  children: []
+- referent: referent-19
+  name: MaterialService
+  class: MaterialService
+  properties:
+    AsphaltName:
+      String: Asphalt
+    Attributes:
+      Attributes: {}
+    BasaltName:
+      String: Basalt
+    BrickName:
+      String: Brick
+    Capabilities:
+      SecurityCapabilities: 0
+    CardboardName:
+      String: Cardboard
+    CarpetName:
+      String: Carpet
+    CeramicTilesName:
+      String: CeramicTiles
+    ClayRoofTilesName:
+      String: ClayRoofTiles
+    CobblestoneName:
+      String: Cobblestone
+    ConcreteName:
+      String: Concrete
+    CorrodedMetalName:
+      String: CorrodedMetal
+    CrackedLavaName:
+      String: CrackedLava
+    DiamondPlateName:
+      String: DiamondPlate
+    FabricName:
+      String: Fabric
+    FoilName:
+      String: Foil
+    GlacierName:
+      String: Glacier
+    GraniteName:
+      String: Granite
+    GrassName:
+      String: Grass
+    GroundName:
+      String: Ground
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IceName:
+      String: Ice
+    LeafyGrassName:
+      String: LeafyGrass
+    LeatherName:
+      String: Leather
+    LimestoneName:
+      String: Limestone
+    MarbleName:
+      String: Marble
+    MetalName:
+      String: Metal
+    MudName:
+      String: Mud
+    PavementName:
+      String: Pavement
+    PebbleName:
+      String: Pebble
+    PlasterName:
+      String: Plaster
+    PlasticName:
+      String: Plastic
+    RockName:
+      String: Rock
+    RoofShinglesName:
+      String: RoofShingles
+    RubberName:
+      String: Rubber
+    SaltName:
+      String: Salt
+    SandName:
+      String: Sand
+    Sandboxed:
+      Bool: false
+    SandstoneName:
+      String: Sandstone
+    SlateName:
+      String: Slate
+    SmoothPlasticName:
+      String: SmoothPlastic
+    SnowName:
+      String: Snow
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000356
+    Use2022MaterialsXml:
+      Bool: true
+    WoodName:
+      String: Wood
+    WoodPlanksName:
+      String: WoodPlanks
+  children: []
+- referent: referent-20
+  name: TextChatService
+  class: TextChatService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    ChatTranslationFTUXShown:
+      Bool: true
+    ChatTranslationToggleEnabled:
+      Bool: false
+    ChatVersion:
+      Enum: 1
+    CreateDefaultCommands:
+      Bool: true
+    CreateDefaultTextChannels:
+      Bool: true
+    HasSeenDeprecationDialog:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsLegacyChatDisabled:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000357
+  children:
+    - referent: referent-21
+      name: ChatWindowConfiguration
+      class: ChatWindowConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0.3
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HeightScale:
+          Float32: 1
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        HorizontalAlignment:
+          Enum: 1
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 0.5
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c7
+        VerticalAlignment:
+          Enum: 1
+        WidthScale:
+          Float32: 1
+      children: []
+    - referent: referent-22
+      name: ChatInputBarConfiguration
+      class: ChatInputBarConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        AutocompleteEnabled:
+          Bool: true
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0.2
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        KeyboardKeyCode:
+          Enum: 47
+        PlaceholderColor3:
+          Color3:
+            - 0.69803923
+            - 0.69803923
+            - 0.69803923
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TargetTextChannel: "null"
+        TextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 0.5
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c8
+      children: []
+    - referent: referent-23
+      name: BubbleChatConfiguration
+      class: BubbleChatConfiguration
+      properties:
+        AdorneeName:
+          String: HumanoidRootPart
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.98039216
+            - 0.98039216
+            - 0.98039216
+        BackgroundTransparency:
+          Float64: 0.1
+        BubbleDuration:
+          Float32: 15
+        BubblesSpacing:
+          Float32: 6
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        Font:
+          Enum: 47
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LocalPlayerStudsOffset:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        MaxBubbles:
+          Float32: 3
+        MaxDistance:
+          Float32: 100
+        MinimizeDistance:
+          Float32: 40
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TailVisible:
+          Bool: true
+        TextColor3:
+          Color3:
+            - 0.22352941
+            - 0.23137255
+            - 0.23921569
+        TextSize:
+          Int64: 20
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c9
+        VerticalStudsOffset:
+          Float32: 0
+      children:
+        - referent: referent-24
+          name: UIGradient
+          class: UIGradient
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color:
+              ColorSequence:
+                keypoints:
+                  - time: 0
+                    color:
+                      - 1
+                      - 1
+                      - 1
+                  - time: 1
+                    color:
+                      - 1
+                      - 1
+                      - 1
+            Enabled:
+              Bool: false
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Offset:
+              Vector2:
+                - 0
+                - 0
+            Rotation:
+              Float32: 0
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            Transparency:
+              NumberSequence:
+                keypoints:
+                  - time: 0
+                    value: 0
+                    envelope: 0
+                  - time: 1
+                    value: 0
+                    envelope: 0
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ca
+          children: []
+        - referent: referent-25
+          name: ImageLabel
+          class: ImageLabel
+          properties:
+            Active:
+              Bool: false
+            AnchorPoint:
+              Vector2:
+                - 0
+                - 0
+            Attributes:
+              Attributes: {}
+            AutoLocalize:
+              Bool: true
+            AutomaticSize:
+              Enum: 0
+            BackgroundColor3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            BackgroundTransparency:
+              Float32: 0
+            BorderColor3:
+              Color3:
+                - 0.10588236
+                - 0.16470589
+                - 0.20784315
+            BorderMode:
+              Enum: 0
+            BorderSizePixel:
+              Int32: 1
+            Capabilities:
+              SecurityCapabilities: 0
+            ClipsDescendants:
+              Bool: false
+            Draggable:
+              Bool: false
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            ImageColor3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            ImageContent:
+              Content: None
+            ImageRectOffset:
+              Vector2:
+                - 0
+                - 0
+            ImageRectSize:
+              Vector2:
+                - 0
+                - 0
+            ImageTransparency:
+              Float32: 0
+            InputSink:
+              Enum: 0
+            Interactable:
+              Bool: true
+            LayoutOrder:
+              Int32: 0
+            NextSelectionDown: "null"
+            NextSelectionLeft: "null"
+            NextSelectionRight: "null"
+            NextSelectionUp: "null"
+            Position:
+              UDim2:
+                - - 0
+                  - 0
+                - - 0
+                  - 0
+            ResampleMode:
+              Enum: 0
+            RootLocalizationTable: "null"
+            Rotation:
+              Float32: 0
+            Sandboxed:
+              Bool: false
+            ScaleType:
+              Enum: 0
+            Selectable:
+              Bool: false
+            SelectionBehaviorDown:
+              Enum: 0
+            SelectionBehaviorLeft:
+              Enum: 0
+            SelectionBehaviorRight:
+              Enum: 0
+            SelectionBehaviorUp:
+              Enum: 0
+            SelectionGroup:
+              Bool: false
+            SelectionImageObject: "null"
+            SelectionOrder:
+              Int32: 0
+            Size:
+              UDim2:
+                - - 0
+                  - 100
+                - - 0
+                  - 100
+            SizeConstraint:
+              Enum: 0
+            SliceCenter:
+              Rect:
+                - - 0
+                  - 0
+                - - 0
+                  - 0
+            SliceScale:
+              Float32: 1
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TileSize:
+              UDim2:
+                - - 1
+                  - 0
+                - - 1
+                  - 0
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cb
+            Visible:
+              Bool: true
+            ZIndex:
+              Int32: 1
+          children: []
+        - referent: referent-26
+          name: UICorner
+          class: UICorner
+          properties:
+            Attributes:
+              Attributes: {}
+            BottomLeftRadius:
+              UDim:
+                - 0
+                - 12
+            BottomRightRadius:
+              UDim:
+                - 0
+                - 12
+            Capabilities:
+              SecurityCapabilities: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TopLeftRadius:
+              UDim:
+                - 0
+                - 12
+            TopRightRadius:
+              UDim:
+                - 0
+                - 12
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cc
+          children: []
+        - referent: referent-27
+          name: UIPadding
+          class: UIPadding
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            PaddingBottom:
+              UDim:
+                - 0
+                - 8
+            PaddingLeft:
+              UDim:
+                - 0
+                - 8
+            PaddingRight:
+              UDim:
+                - 0
+                - 8
+            PaddingTop:
+              UDim:
+                - 0
+                - 8
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cd
+          children: []
+    - referent: referent-28
+      name: ChannelTabsConfiguration
+      class: ChannelTabsConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: false
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Bold
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Bold.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        HoverBackgroundColor3:
+          Color3:
+            - 0.49019608
+            - 0.49019608
+            - 0.49019608
+        Sandboxed:
+          Bool: false
+        SelectedTabTextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TextColor3:
+          Color3:
+            - 0.6862745
+            - 0.6862745
+            - 0.6862745
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 1
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ce
+      children: []
+- referent: referent-29
+  name: PermissionsService
+  class: PermissionsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7edfffb096708e650a5620f100000e07
+  children: []
+- referent: referent-30
+  name: PlayerEmulatorService
+  class: PlayerEmulatorService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    CustomPoliciesEnabled:
+      Bool: false
+    EmulatedCountryCode:
+      String: ""
+    EmulatedGameLocale:
+      String: ""
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    PlayerEmulationEnabled:
+      Bool: false
+    PseudolocalizationEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SerializedEmulatedPolicyInfo:
+      BinaryString: ""
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    TextElongationFactor:
+      Int32: 0
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035a
+  children: []
+- referent: referent-31
+  name: StudioData
+  class: StudioData
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    EnableScriptCollabByDefaultOnLoad:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035d
+  children: []
+- referent: referent-32
+  name: StarterPlayer
+  class: StarterPlayer
+  properties:
+    AllowCustomAnimations:
+      Bool: true
+    Attributes:
+      Attributes: {}
+    AutoJumpEnabled:
+      Bool: true
+    AvatarJointUpgrade:
+      Enum: 2
+    CameraMaxZoomDistance:
+      Float32: 128
+    CameraMinZoomDistance:
+      Float32: 0.5
+    CameraMode:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterBreakJointsOnDeath:
+      Bool: false
+    CharacterJumpHeight:
+      Float32: 7.2
+    CharacterJumpPower:
+      Float32: 50
+    CharacterMaxSlopeAngle:
+      Float32: 89
+    CharacterUseJumpPower:
+      Bool: false
+    CharacterWalkSpeed:
+      Float32: 16
+    ClassicDeath:
+      Bool: true
+    CreateDefaultPlayerModule:
+      Bool: true
+    DevCameraOcclusionMode:
+      Enum: 0
+    DevComputerCameraMovementMode:
+      Enum: 0
+    DevComputerMovementMode:
+      Enum: 0
+    DevTouchCameraMovementMode:
+      Enum: 0
+    DevTouchMovementMode:
+      Enum: 0
+    EnableDynamicHeads:
+      Enum: 0
+    EnableMouseLockOption:
+      Bool: true
+    GameSettingsAssetIDFace:
+      Int64: 0
+    GameSettingsAssetIDHead:
+      Int64: 0
+    GameSettingsAssetIDLeftArm:
+      Int64: 0
+    GameSettingsAssetIDLeftLeg:
+      Int64: 0
+    GameSettingsAssetIDPants:
+      Int64: 0
+    GameSettingsAssetIDRightArm:
+      Int64: 0
+    GameSettingsAssetIDRightLeg:
+      Int64: 0
+    GameSettingsAssetIDShirt:
+      Int64: 0
+    GameSettingsAssetIDTeeShirt:
+      Int64: 0
+    GameSettingsAssetIDTorso:
+      Int64: 0
+    GameSettingsAvatar:
+      Enum: 1
+    GameSettingsR15Collision:
+      Enum: 0
+    GameSettingsScaleRangeBodyType:
+      NumberRange:
+        - 0
+        - 1
+    GameSettingsScaleRangeHead:
+      NumberRange:
+        - 0.95
+        - 1
+    GameSettingsScaleRangeHeight:
+      NumberRange:
+        - 0.9
+        - 1.05
+    GameSettingsScaleRangeProportion:
+      NumberRange:
+        - 0
+        - 1
+    GameSettingsScaleRangeWidth:
+      NumberRange:
+        - 0.7
+        - 1
+    HealthDisplayDistance:
+      Float32: 100
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LoadCharacterAppearance:
+      Bool: true
+    LoadCharacterLayeredClothing:
+      Enum: 0
+    LuaCharacterController:
+      Enum: 0
+    NameDisplayDistance:
+      Float32: 100
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035f
+    UserEmotesEnabled:
+      Bool: true
+  children:
+    - referent: referent-33
+      name: StarterPlayerScripts
+      class: StarterPlayerScripts
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bf
+      children: []
+    - referent: referent-34
+      name: StarterCharacterScripts
+      class: StarterCharacterScripts
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c0
+      children: []
+- referent: referent-35
+  name: StarterPack
+  class: StarterPack
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000360
+  children: []
+- referent: referent-36
+  name: StarterGui
+  class: StarterGui
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    ClipsDescendantsSupportsRotation:
+      Enum: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    ResetPlayerGuiOnSpawn:
+      Bool: true
+    RtlTextSupport:
+      Enum: 0
+    Sandboxed:
+      Bool: false
+    ScreenOrientation:
+      Enum: 4
+    ShowDevelopmentGui:
+      Bool: true
+    SourceAssetId:
+      Int64: -1
+    StudioDefaultStyleSheet: "null"
+    StudioInsertWidgetLayerCollectorAutoLinkStyleSheet: "null"
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000361
+    VirtualCursorMode:
+      Enum: 0
+  children: []
+- referent: referent-37
+  name: LocalizationService
+  class: LocalizationService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000363
+  children: []
+- referent: referent-38
+  name: Teleport Service
+  class: TeleportService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000367
+  children: []
+- referent: referent-39
+  name: PhysicsService
+  class: PhysicsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000369
+  children: []
+- referent: referent-40
+  name: InsertService
+  class: InsertService
+  properties:
+    AllowInsertFreeModels:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036c
+  children:
+    - referent: referent-41
+      name: InsertionHash
+      class: StringValue
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c1
+        Value:
+          String: "{a4b4fc84-d3fa-4580-b9d0-98390afa7f7f}"
+      children: []
+- referent: referent-42
+  name: GamePassService
+  class: GamePassService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036d
+  children: []
+- referent: referent-43
+  name: Debris
+  class: Debris
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxItems:
+      Int32: 1000
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036e
+  children: []
+- referent: referent-44
+  name: CookiesService
+  class: CookiesService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036f
+  children: []
+- referent: referent-45
+  name: Selection
+  class: Selection
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000370
+  children: []
+- referent: referent-46
+  name: VRService
+  class: VRService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutomaticScaling:
+      Enum: 0
+    AvatarGestures:
+      Bool: false
+    Capabilities:
+      SecurityCapabilities: 0
+    ControllerModels:
+      Enum: 1
+    FadeOutViewOnCollision:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LaserPointer:
+      Enum: 1
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000374
+  children: []
+- referent: referent-47
+  name: ContextActionService
+  class: ContextActionService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000375
+  children: []
+- referent: referent-48
+  name: Instance
+  class: ScriptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000376
+  children: []
+- referent: referent-49
+  name: AssetService
+  class: AssetService
+  properties:
+    AllowInsertFreeAssets:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000377
+  children: []
+- referent: referent-50
+  name: TouchInputService
+  class: TouchInputService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000379
+  children: []
+- referent: referent-51
+  name: AvatarSettings
+  class: AvatarSettings
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000037f
+  children:
+    - referent: referent-52
+      name: DefaultAvatarRules
+      class: AvatarRules
+      properties:
+        Attributes:
+          Attributes: {}
+        AvatarType:
+          Enum: 1
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7edfffb096708e650a5620f100000e00
+      children:
+        - referent: referent-53
+          name: AvatarBodyRules
+          class: AvatarBodyRules
+          properties:
+            AppearanceMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            BuildMode:
+              Enum: 0
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomBodyBundleId:
+              Int64: 0
+            CustomBodyType:
+              Enum: 0
+            CustomBodyTypeScale:
+              NumberRange:
+                - 0
+                - 1
+            CustomEyebrowEnabled:
+              Bool: false
+            CustomEyebrowId:
+              Int64: 0
+            CustomEyelashEnabled:
+              Bool: false
+            CustomEyelashId:
+              Int64: 0
+            CustomFaceEnabled:
+              Bool: false
+            CustomFaceId:
+              Int64: 0
+            CustomHeadEnabled:
+              Bool: false
+            CustomHeadId:
+              Int64: 0
+            CustomHeadScale:
+              NumberRange:
+                - 0.95
+                - 1
+            CustomHeight:
+              NumberRange:
+                - 5.5
+                - 5.5
+            CustomHeightScale:
+              NumberRange:
+                - 0.9
+                - 1.05
+            CustomLeftArmEnabled:
+              Bool: false
+            CustomLeftArmId:
+              Int64: 0
+            CustomLeftLegEnabled:
+              Bool: false
+            CustomLeftLegId:
+              Int64: 0
+            CustomMoodEnabled:
+              Bool: false
+            CustomMoodId:
+              Int64: 0
+            CustomProportionsScale:
+              NumberRange:
+                - 0
+                - 1
+            CustomRightArmEnabled:
+              Bool: false
+            CustomRightArmId:
+              Int64: 0
+            CustomRightLegEnabled:
+              Bool: false
+            CustomRightLegId:
+              Int64: 0
+            CustomTorsoEnabled:
+              Bool: false
+            CustomTorsoId:
+              Int64: 0
+            CustomWidthScale:
+              NumberRange:
+                - 0.7
+                - 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            KeepPlayerHead:
+              Bool: true
+            Sandboxed:
+              Bool: false
+            ScaleMode:
+              Enum: 0
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e01
+          children: []
+        - referent: referent-54
+          name: AvatarCollisionRules
+          class: AvatarCollisionRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CollisionMode:
+              Enum: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            HitAndTouchDetectionMode:
+              Enum: 0
+            LegacyCollisionMode:
+              Enum: 1
+            Sandboxed:
+              Bool: false
+            SingleColliderSize:
+              Vector3:
+                - 2
+                - 3
+                - 1
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e02
+          children: []
+        - referent: referent-55
+          name: AvatarAbilityRules
+          class: AvatarAbilityRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CharacterControllerMode:
+              Enum: 0
+            EnableClimbing:
+              Bool: true
+            EnableCrouching:
+              Bool: true
+            EnableFallingDown:
+              Bool: true
+            EnableGettingUp:
+              Bool: true
+            EnableHolding:
+              Bool: true
+            EnableJumping:
+              Bool: true
+            EnableReaching:
+              Bool: true
+            EnableRunning:
+              Bool: true
+            EnableSitting:
+              Bool: true
+            EnableSprinting:
+              Bool: true
+            EnableStrafing:
+              Bool: true
+            EnableSwimming:
+              Bool: true
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e03
+          children: []
+        - referent: referent-56
+          name: AvatarAnimationRules
+          class: AvatarAnimationRules
+          properties:
+            AnimationClipsMode:
+              Enum: 0
+            AnimationPacksMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomClimbAnimationEnabled:
+              Bool: false
+            CustomClimbAnimationId:
+              Int64: 0
+            CustomFallAnimationEnabled:
+              Bool: false
+            CustomFallAnimationId:
+              Int64: 0
+            CustomIdleAlt1AnimationEnabled:
+              Bool: false
+            CustomIdleAlt1AnimationId:
+              Int64: 0
+            CustomIdleAlt2AnimationEnabled:
+              Bool: false
+            CustomIdleAlt2AnimationId:
+              Int64: 0
+            CustomIdleAnimationEnabled:
+              Bool: false
+            CustomIdleAnimationId:
+              Int64: 0
+            CustomJumpAnimationEnabled:
+              Bool: false
+            CustomJumpAnimationId:
+              Int64: 0
+            CustomRunAnimationEnabled:
+              Bool: false
+            CustomRunAnimationId:
+              Int64: 0
+            CustomSwimAnimationEnabled:
+              Bool: false
+            CustomSwimAnimationId:
+              Int64: 0
+            CustomSwimIdleAnimationEnabled:
+              Bool: false
+            CustomSwimIdleAnimationId:
+              Int64: 0
+            CustomWalkAnimationEnabled:
+              Bool: false
+            CustomWalkAnimationId:
+              Int64: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e04
+          children: []
+        - referent: referent-57
+          name: AvatarAccessoryRules
+          class: AvatarAccessoryRules
+          properties:
+            AccessoryMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomAccessoryMode:
+              Enum: 0
+            CustomBackAccessoryEnabled:
+              Bool: false
+            CustomBackAccessoryId:
+              Int64: 0
+            CustomFaceAccessoryEnabled:
+              Bool: false
+            CustomFaceAccessoryId:
+              Int64: 0
+            CustomFrontAccessoryEnabled:
+              Bool: false
+            CustomFrontAccessoryId:
+              Int64: 0
+            CustomHairAccessoryEnabled:
+              Bool: false
+            CustomHairAccessoryId:
+              Int64: 0
+            CustomHeadAccessoryEnabled:
+              Bool: false
+            CustomHeadAccessoryId:
+              Int64: 0
+            CustomNeckAccessoryEnabled:
+              Bool: false
+            CustomNeckAccessoryId:
+              Int64: 0
+            CustomShoulderAccessoryEnabled:
+              Bool: false
+            CustomShoulderAccessoryId:
+              Int64: 0
+            CustomWaistAccessoryEnabled:
+              Bool: false
+            CustomWaistAccessoryId:
+              Int64: 0
+            EnableSound:
+              Bool: true
+            EnableVFX:
+              Bool: true
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            LimitBounds:
+              Vector3:
+                - 0
+                - 0
+                - 0
+            LimitMethod:
+              Enum: 1
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e05
+          children: []
+        - referent: referent-58
+          name: AvatarClothingRules
+          class: AvatarClothingRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            ClothingMode:
+              Enum: 0
+            CustomClassicPantsAccessoryEnabled:
+              Bool: false
+            CustomClassicPantsAccessoryId:
+              Int64: 0
+            CustomClassicShirtsAccessoryEnabled:
+              Bool: false
+            CustomClassicShirtsAccessoryId:
+              Int64: 0
+            CustomClassicTShirtsAccessoryEnabled:
+              Bool: false
+            CustomClassicTShirtsAccessoryId:
+              Int64: 0
+            CustomClothingMode:
+              Enum: 0
+            CustomDressSkirtAccessoryEnabled:
+              Bool: false
+            CustomDressSkirtAccessoryId:
+              Int64: 0
+            CustomJacketAccessoryEnabled:
+              Bool: false
+            CustomJacketAccessoryId:
+              Int64: 0
+            CustomLeftShoesAccessoryEnabled:
+              Bool: false
+            CustomLeftShoesAccessoryId:
+              Int64: 0
+            CustomPantsAccessoryEnabled:
+              Bool: false
+            CustomPantsAccessoryId:
+              Int64: 0
+            CustomRightShoesAccessoryEnabled:
+              Bool: false
+            CustomRightShoesAccessoryId:
+              Int64: 0
+            CustomShirtAccessoryEnabled:
+              Bool: false
+            CustomShirtAccessoryId:
+              Int64: 0
+            CustomShortsAccessoryEnabled:
+              Bool: false
+            CustomShortsAccessoryId:
+              Int64: 0
+            CustomSweaterAccessoryEnabled:
+              Bool: false
+            CustomSweaterAccessoryId:
+              Int64: 0
+            CustomTShirtAccessoryEnabled:
+              Bool: false
+            CustomTShirtAccessoryId:
+              Int64: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            LimitBounds:
+              Vector3:
+                - 0
+                - 0
+                - 0
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e06
+          children: []
+- referent: referent-59
+  name: Packages
+  class: Packages
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsDehydrated:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    ShellPackagesCount:
+      Int32: 0
+    SkippedInstancesCount:
+      Int32: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000383
+  children: []
+- referent: referent-60
+  name: GuidRegistryService
+  class: GuidRegistryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000384
+  children: []
+- referent: referent-61
+  name: LuaWebService
+  class: LuaWebService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7edfffb096708e650a5620f100000f22
+  children: []
+- referent: referent-62
+  name: ProcessInstancePhysicsService
+  class: ProcessInstancePhysicsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 1f0379dd5b8107880a56e26b0000038c
+  children: []
+- referent: referent-63
+  name: ReplicatedStorage
+  class: ReplicatedStorage
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000398
+  children: []
+- referent: referent-64
+  name: ServerScriptService
+  class: ServerScriptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LoadStringEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000399
+  children: []
+- referent: referent-65
+  name: ServerStorage
+  class: ServerStorage
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000039a
+  children: []
+- referent: referent-66
+  name: ServiceVisibilityService
+  class: ServiceVisibilityService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HiddenServices:
+      BinaryString: AAAAAA==
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003a1
+    VisibleServices:
+      BinaryString: AAAAAA==
+  children: []
+- referent: referent-67
+  name: HttpService
+  class: HttpService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    HttpEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ac
+  children: []
+- referent: referent-68
+  name: DataStoreService
+  class: DataStoreService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutomaticRetry:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LegacyNamingScheme:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003af
+  children: []
+- referent: referent-69
+  name: Lighting
+  class: Lighting
+  properties:
+    Ambient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Attributes:
+      Attributes:
+        RBX_LightingTechnologyUnifiedMigration:
+          Bool: true
+        RBX_OriginalTechnologyOnFileLoad:
+          Int32: 3
+    Brightness:
+      Float32: 3
+    Capabilities:
+      SecurityCapabilities: 0
+    ColorShift_Bottom:
+      Color3:
+        - 0
+        - 0
+        - 0
+    ColorShift_Top:
+      Color3:
+        - 0
+        - 0
+        - 0
+    EnvironmentDiffuseScale:
+      Float32: 1
+    EnvironmentSpecularScale:
+      Float32: 1
+    ExposureCompensation:
+      Float32: 0
+    ExtendLightRangeTo120:
+      Enum: 0
+    FogColor:
+      Color3:
+        - 0.75294125
+        - 0.75294125
+        - 0.75294125
+    FogEnd:
+      Float32: 100000
+    FogStart:
+      Float32: 0
+    GeographicLatitude:
+      Float32: 0
+    GlobalShadows:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LightingStyle:
+      Enum: 1
+    OutdoorAmbient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Outlines:
+      Bool: false
+    PrioritizeLightingQuality:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    ShadowSoftness:
+      Float32: 0.2
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Technology:
+      Enum: 3
+    TimeOfDay:
+      String: "14:30:00"
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b0
+  children:
+    - referent: referent-70
+      name: Sky
+      class: Sky
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        CelestialBodiesShown:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        MoonAngularSize:
+          Float32: 11
+        MoonTextureContent:
+          Content:
+            Uri: "rbxassetid://6444320592"
+        Sandboxed:
+          Bool: false
+        SkyboxBackContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxDownContent:
+          Content:
+            Uri: "rbxassetid://6444884785"
+        SkyboxFrontContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxLeftContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxOrientation:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        SkyboxRightContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxUpContent:
+          Content:
+            Uri: "rbxassetid://6412503613"
+        SourceAssetId:
+          Int64: 332039975
+        StarCount:
+          Int32: 3000
+        SunAngularSize:
+          Float32: 11
+        SunTextureContent:
+          Content:
+            Uri: "rbxassetid://6196665106"
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c2
+      children: []
+    - referent: referent-71
+      name: SunRays
+      class: SunRaysEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Intensity:
+          Float32: 0.01
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Spread:
+          Float32: 0.1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c3
+      children: []
+    - referent: referent-72
+      name: Atmosphere
+      class: Atmosphere
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Color:
+          Color3:
+            - 0.78039217
+            - 0.78039217
+            - 0.78039217
+        Decay:
+          Color3:
+            - 0.41568628
+            - 0.4392157
+            - 0.49019608
+        Density:
+          Float32: 0.3
+        Glare:
+          Float32: 0
+        Haze:
+          Float32: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Offset:
+          Float32: 0.25
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c4
+      children: []
+    - referent: referent-73
+      name: Bloom
+      class: BloomEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Intensity:
+          Float32: 1
+        Sandboxed:
+          Bool: false
+        Size:
+          Float32: 24
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        Threshold:
+          Float32: 2
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c5
+      children: []
+    - referent: referent-74
+      name: DepthOfField
+      class: DepthOfFieldEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: false
+        FarIntensity:
+          Float32: 0.1
+        FocusDistance:
+          Float32: 0.05
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        InFocusRadius:
+          Float32: 30
+        NearIntensity:
+          Float32: 0.75
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c6
+      children: []
+- referent: referent-75
+  name: Instance
+  class: LodDataService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b1
+  children: []
+- referent: referent-76
+  name: ProximityPromptService
+  class: ProximityPromptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    Enabled:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxIndicatorsVisible:
+      Int32: 16
+    MaxPromptsVisible:
+      Int32: 16
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b2
+  children: []
+- referent: referent-77
+  name: Teams
+  class: Teams
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b3
+  children: []
+- referent: referent-78
+  name: TestService
+  class: TestService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutoRuns:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    Description:
+      String: ""
+    ExecuteWithStudioRun:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsPhysicsEnvironmentalThrottled:
+      Bool: true
+    IsSleepAllowed:
+      Bool: true
+    NumberOfPlayers:
+      Int32: 0
+    Sandboxed:
+      Bool: false
+    SimulateSecondsLag:
+      Float64: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    ThrottlePhysicsToRealtime:
+      Bool: true
+    Timeout:
+      Float64: 10
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b4
+  children: []
+- referent: referent-79
+  name: UGCAvatarService
+  class: UGCAvatarService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b5
+  children: []
+- referent: referent-80
+  name: VideoService
+  class: VideoService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003da
+  children: []
+- referent: referent-81
+  name: VoiceChatService
+  class: VoiceChatService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    DefaultDistanceAttenuation:
+      Enum: 0
+    EnableDefaultVoice:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b7
+    UseAudioApi:
+      Enum: 2
+  children: []
+- referent: referent-82
+  name: SerializationService
+  class: SerializationService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 1f0379dd5b8107880a56e26b0000080d
+  children: []

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__baseplate-727-with-tags__encoded.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__baseplate-727-with-tags__encoded.snap
@@ -1,0 +1,2300 @@
+---
+source: rbx_xml/src/tests/mod.rs
+assertion_line: 38
+expression: encoded_text
+---
+<roblox version="4">
+  <Item class="Workspace" referent="0">
+    <Properties>
+      <string name="Name">Workspace</string>
+      <float name="AirDensity">0.0012</float>
+      <float name="AirTurbulenceIntensity">0</float>
+      <bool name="AllowThirdPartySales">false</bool>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <token name="AuthorityMode">1</token>
+      <token name="AvatarUnificationMode">0</token>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <token name="ClientAnimatorThrottling">0</token>
+      <BinaryString name="CollisionGroupData"><![CDATA[AQEABP////8HRGVmYXVsdA==]]></BinaryString>
+      <Ref name="CurrentCamera">1</Ref>
+      <double name="DistributedGameTime">0</double>
+      <token name="EnableSLIMAvatars">0</token>
+      <bool name="ExplicitAutoJoints">true</bool>
+      <bool name="FallHeightEnabled">true</bool>
+      <float name="FallenPartsDestroyHeight">-500</float>
+      <token name="FluidForces">0</token>
+      <Vector3 name="GlobalWind">
+        <X>0</X>
+        <Y>0</Y>
+        <Z>0</Z>
+      </Vector3>
+      <float name="Gravity">196.2</float>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <token name="IKControlConstraintSupport">0</token>
+      <token name="ImprovedAnimationConstraint">0</token>
+      <token name="ImprovedPhysicsReplication">0</token>
+      <token name="LayeredClothingCacheOptimizations">0</token>
+      <token name="LevelOfDetail">0</token>
+      <token name="LuauTypeCheckMode">0</token>
+      <token name="MeshPartHeadsAndAccessories">0</token>
+      <token name="MeshStreamingAndImprovedLods">0</token>
+      <CoordinateFrame name="ModelMeshCFrame">
+        <X>0</X>
+        <Y>0</Y>
+        <Z>0</Z>
+        <R00>1</R00>
+        <R01>0</R01>
+        <R02>0</R02>
+        <R10>0</R10>
+        <R11>1</R11>
+        <R12>0</R12>
+        <R20>0</R20>
+        <R21>0</R21>
+        <R22>1</R22>
+      </CoordinateFrame>
+      <SharedString name="ModelMeshData">rxNJufX5oaagQE3qNtzJSQ==</SharedString>
+      <Vector3 name="ModelMeshSize">
+        <X>0</X>
+        <Y>0</Y>
+        <Z>0</Z>
+      </Vector3>
+      <token name="ModelStreamingBehavior">0</token>
+      <token name="ModelStreamingMode">0</token>
+      <bool name="NeedsPivotMigration">false</bool>
+      <token name="NextGenerationReplication">0</token>
+      <token name="PathfindingUseImprovedSearch">0</token>
+      <token name="PhysicsSteppingMethod">0</token>
+      <token name="PlayerCharacterDestroyBehavior">0</token>
+      <token name="PlayerScriptsUseInputActionSystem">0</token>
+      <token name="PrimalPhysicsSolver">0</token>
+      <Ref name="PrimaryPart">null</Ref>
+      <token name="RejectCharacterDeletions">0</token>
+      <token name="RenderingCacheOptimizations">0</token>
+      <token name="ReplicateInstanceDestroySetting">0</token>
+      <token name="Retargeting">0</token>
+      <bool name="DefinesCapabilities">false</bool>
+      <token name="SandboxedInstanceMode">0</token>
+      <float name="ScaleFactor">1</float>
+      <token name="SignalBehavior2">2</token>
+      <SharedString name="SlimHash">rxNJufX5oaagQE3qNtzJSQ==</SharedString>
+      <int64 name="SourceAssetId">-1</int64>
+      <token name="StreamOutBehavior">2</token>
+      <bool name="StreamingEnabled">true</bool>
+      <token name="StreamingIntegrityMode">3</token>
+      <int name="StreamingMinRadius">64</int>
+      <int name="StreamingTargetRadius">1024</int>
+      <BinaryString name="Tags">aG1tbW0=</BinaryString>
+      <bool name="TerrainWeldsFixed">true</bool>
+      <token name="TouchEventsUseCollisionGroups">0</token>
+      <bool name="TouchesUseCollisionGroups">false</bool>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000002</UniqueId>
+      <token name="UseFixedSimulation">0</token>
+      <token name="UseNewLuauTypeSolver">2</token>
+      <token name="ValidateEnabledProximityPrompt">0</token>
+      <OptionalCoordinateFrame name="WorldPivotData">
+        <CFrame>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CFrame>
+      </OptionalCoordinateFrame>
+    </Properties>
+    <Item class="Camera" referent="1">
+      <Properties>
+        <string name="Name">Camera</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <CoordinateFrame name="CFrame">
+          <X>-19.696095</X>
+          <Y>14.091624</Y>
+          <Z>-19.303886</Z>
+          <R00>-0.7061509</R00>
+          <R01>0.31296578</R01>
+          <R02>-0.6351404</R02>
+          <R10>0.000000014901163</R10>
+          <R11>0.8970132</R11>
+          <R12>0.44200373</R12>
+          <R20>0.7080614</R20>
+          <R21>0.31212133</R21>
+          <R22>-0.63342667</R22>
+        </CoordinateFrame>
+        <Ref name="CameraSubject">null</Ref>
+        <token name="CameraType">0</token>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <float name="FieldOfView">70</float>
+        <token name="FieldOfViewMode">0</token>
+        <CoordinateFrame name="Focus">
+          <X>-18.425814</X>
+          <Y>13.207617</Y>
+          <Z>-18.037033</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <bool name="HeadLocked">true</bool>
+        <float name="HeadScale">1</float>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b8</UniqueId>
+        <bool name="VRTiltAndRollEnabled">false</bool>
+      </Properties>
+    </Item>
+    <Item class="Part" referent="2">
+      <Properties>
+        <string name="Name">Baseplate</string>
+        <bool name="Anchored">true</bool>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <bool name="AudioCanCollide">true</bool>
+        <float name="BackParamA">-0.5</float>
+        <float name="BackParamB">0.5</float>
+        <token name="BackSurface">0</token>
+        <token name="BackSurfaceInput">0</token>
+        <float name="BottomParamA">-0.5</float>
+        <float name="BottomParamB">0.5</float>
+        <token name="BottomSurface">0</token>
+        <token name="BottomSurfaceInput">0</token>
+        <CoordinateFrame name="CFrame">
+          <X>0</X>
+          <Y>-8</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <bool name="CanCollide">true</bool>
+        <bool name="CanQuery">true</bool>
+        <bool name="CanTouch">true</bool>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="CastShadow">true</bool>
+        <string name="CollisionGroup">Default</string>
+        <int name="CollisionGroupId">0</int>
+        <Color3uint8 name="Color3uint8">5987163</Color3uint8>
+        <PhysicalProperties name="CustomPhysicalProperties">
+          <CustomPhysics>false</CustomPhysics>
+        </PhysicalProperties>
+        <bool name="EnableFluidForces">true</bool>
+        <token name="formFactorRaw">0</token>
+        <float name="FrontParamA">-0.5</float>
+        <float name="FrontParamB">0.5</float>
+        <token name="FrontSurface">0</token>
+        <token name="FrontSurfaceInput">0</token>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="LeftParamA">-0.5</float>
+        <float name="LeftParamB">0.5</float>
+        <token name="LeftSurface">0</token>
+        <token name="LeftSurfaceInput">0</token>
+        <bool name="Locked">true</bool>
+        <bool name="Massless">false</bool>
+        <token name="Material">256</token>
+        <string name="MaterialVariantSerialized"></string>
+        <CoordinateFrame name="PivotOffset">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <float name="Reflectance">0</float>
+        <float name="RightParamA">-0.5</float>
+        <float name="RightParamB">0.5</float>
+        <token name="RightSurface">0</token>
+        <token name="RightSurfaceInput">0</token>
+        <int name="RootPriority">0</int>
+        <Vector3 name="RotVelocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+        <bool name="DefinesCapabilities">false</bool>
+        <token name="shape">1</token>
+        <Vector3 name="size">
+          <X>2048</X>
+          <Y>16</Y>
+          <Z>2048</Z>
+        </Vector3>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags">YXRhZw==</BinaryString>
+        <float name="TopParamA">-0.5</float>
+        <float name="TopParamB">0.5</float>
+        <token name="TopSurface">0</token>
+        <token name="TopSurfaceInput">0</token>
+        <float name="Transparency">0</float>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b9</UniqueId>
+        <Vector3 name="Velocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+      </Properties>
+      <Item class="Texture" referent="3">
+        <Properties>
+          <string name="Name">Texture</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <Color3 name="Color3">
+            <R>0</R>
+            <G>0</G>
+            <B>0</B>
+          </Color3>
+          <token name="Face">1</token>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <Content name="MetalnessMapContent">
+            <null>
+            </null>
+          </Content>
+          <Content name="NormalMapContent">
+            <null>
+            </null>
+          </Content>
+          <float name="OffsetStudsU">0</float>
+          <float name="OffsetStudsV">0</float>
+          <float name="Rotation">0</float>
+          <Content name="RoughnessMapContent">
+            <null>
+            </null>
+          </Content>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <float name="StudsPerTileU">8</float>
+          <float name="StudsPerTileV">8</float>
+          <BinaryString name="Tags"></BinaryString>
+          <Content name="TextureContent">
+            <uri>rbxassetid://6372755229</uri>
+          </Content>
+          <ContentId name="TexturePack">
+            <null>
+            </null>
+          </ContentId>
+          <string name="TexturePackMetadata"></string>
+          <float name="Transparency">0.8</float>
+          <Vector2 name="UVOffset">
+            <X>0</X>
+            <Y>0</Y>
+          </Vector2>
+          <Vector2 name="UVScale">
+            <X>1</X>
+            <Y>1</Y>
+          </Vector2>
+          <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003ba</UniqueId>
+          <int name="ZIndex">1</int>
+        </Properties>
+      </Item>
+    </Item>
+    <Item class="Terrain" referent="4">
+      <Properties>
+        <string name="Name">Terrain</string>
+        <token name="AcquisitionMethod">0</token>
+        <bool name="Anchored">true</bool>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <bool name="AudioCanCollide">true</bool>
+        <float name="BackParamA">-0.5</float>
+        <float name="BackParamB">0.5</float>
+        <token name="BackSurface">0</token>
+        <token name="BackSurfaceInput">0</token>
+        <float name="BottomParamA">-0.5</float>
+        <float name="BottomParamB">0.5</float>
+        <token name="BottomSurface">4</token>
+        <token name="BottomSurfaceInput">0</token>
+        <CoordinateFrame name="CFrame">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <bool name="CanCollide">true</bool>
+        <bool name="CanQuery">true</bool>
+        <bool name="CanTouch">true</bool>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="CastShadow">true</bool>
+        <string name="CollisionGroup">Default</string>
+        <int name="CollisionGroupId">0</int>
+        <Color3uint8 name="Color3uint8">10724005</Color3uint8>
+        <PhysicalProperties name="CustomPhysicalProperties">
+          <CustomPhysics>false</CustomPhysics>
+        </PhysicalProperties>
+        <bool name="Decoration">true</bool>
+        <bool name="EnableFluidForces">true</bool>
+        <float name="FrontParamA">-0.5</float>
+        <float name="FrontParamB">0.5</float>
+        <token name="FrontSurface">0</token>
+        <token name="FrontSurfaceInput">0</token>
+        <float name="GrassLength">0.7</float>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="LeftParamA">-0.5</float>
+        <float name="LeftParamB">0.5</float>
+        <token name="LeftSurface">0</token>
+        <token name="LeftSurfaceInput">0</token>
+        <bool name="Locked">true</bool>
+        <bool name="Massless">false</bool>
+        <token name="Material">256</token>
+        <BinaryString name="MaterialColors">AAAAAAAAb34+WFlWmJiYimFJz8unrJRsY2Rm3eTl6/3/lHxfeXBiS0pKjIJo/xhDUFRUhoZ2zNLfaoZA///+//PAj5CH</BinaryString>
+        <string name="MaterialVariantSerialized"></string>
+        <SharedString name="Materials">rxNJufX5oaagQE3qNtzJSQ==</SharedString>
+        <BinaryString name="PhysicsGrid"><![CDATA[AgMAAAAAAAAAAAAAAAA=]]></BinaryString>
+        <CoordinateFrame name="PivotOffset">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <float name="Reflectance">0</float>
+        <float name="RightParamA">-0.5</float>
+        <float name="RightParamB">0.5</float>
+        <token name="RightSurface">0</token>
+        <token name="RightSurfaceInput">0</token>
+        <int name="RootPriority">0</int>
+        <Vector3 name="RotVelocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+        <bool name="DefinesCapabilities">false</bool>
+        <Vector3 name="size">
+          <X>2044</X>
+          <Y>252</Y>
+          <Z>2044</Z>
+        </Vector3>
+        <BinaryString name="SmoothGrid"><![CDATA[AQU=]]></BinaryString>
+        <bool name="SmoothVoxelsUpgraded">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <float name="TopParamA">-0.5</float>
+        <float name="TopParamB">0.5</float>
+        <token name="TopSurface">3</token>
+        <token name="TopSurfaceInput">0</token>
+        <float name="Transparency">0</float>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003bb</UniqueId>
+        <Vector3 name="Velocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+        <Color3 name="WaterColor">
+          <R>0.04705883</R>
+          <G>0.32941177</G>
+          <B>0.36078432</B>
+        </Color3>
+        <float name="WaterReflectance">1</float>
+        <float name="WaterTransparency">0.3</float>
+        <float name="WaterWaveSize">0.15</float>
+        <float name="WaterWaveSpeed">10</float>
+      </Properties>
+    </Item>
+    <Item class="SpawnLocation" referent="5">
+      <Properties>
+        <string name="Name">SpawnLocation</string>
+        <bool name="AllowTeamChangeOnTouch">false</bool>
+        <bool name="Anchored">true</bool>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <bool name="AudioCanCollide">true</bool>
+        <float name="BackParamA">-0.5</float>
+        <float name="BackParamB">0.5</float>
+        <token name="BackSurface">0</token>
+        <token name="BackSurfaceInput">0</token>
+        <float name="BottomParamA">-0.5</float>
+        <float name="BottomParamB">0.5</float>
+        <token name="BottomSurface">0</token>
+        <token name="BottomSurfaceInput">0</token>
+        <CoordinateFrame name="CFrame">
+          <X>0</X>
+          <Y>0.5</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <bool name="CanCollide">true</bool>
+        <bool name="CanQuery">true</bool>
+        <bool name="CanTouch">true</bool>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="CastShadow">true</bool>
+        <string name="CollisionGroup">Default</string>
+        <int name="CollisionGroupId">0</int>
+        <Color3uint8 name="Color3uint8">10724005</Color3uint8>
+        <PhysicalProperties name="CustomPhysicalProperties">
+          <CustomPhysics>false</CustomPhysics>
+        </PhysicalProperties>
+        <int name="Duration">0</int>
+        <bool name="EnableFluidForces">true</bool>
+        <bool name="Enabled">true</bool>
+        <token name="formFactorRaw">1</token>
+        <float name="FrontParamA">-0.5</float>
+        <float name="FrontParamB">0.5</float>
+        <token name="FrontSurface">0</token>
+        <token name="FrontSurfaceInput">0</token>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="LeftParamA">-0.5</float>
+        <float name="LeftParamB">0.5</float>
+        <token name="LeftSurface">0</token>
+        <token name="LeftSurfaceInput">0</token>
+        <bool name="Locked">false</bool>
+        <bool name="Massless">false</bool>
+        <token name="Material">256</token>
+        <string name="MaterialVariantSerialized"></string>
+        <bool name="Neutral">true</bool>
+        <CoordinateFrame name="PivotOffset">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <float name="Reflectance">0</float>
+        <float name="RightParamA">-0.5</float>
+        <float name="RightParamB">0.5</float>
+        <token name="RightSurface">0</token>
+        <token name="RightSurfaceInput">0</token>
+        <int name="RootPriority">0</int>
+        <Vector3 name="RotVelocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+        <bool name="DefinesCapabilities">false</bool>
+        <token name="shape">1</token>
+        <Vector3 name="size">
+          <X>12</X>
+          <Y>1</Y>
+          <Z>12</Z>
+        </Vector3>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <int name="TeamColor">194</int>
+        <float name="TopParamA">-0.5</float>
+        <float name="TopParamB">0.5</float>
+        <token name="TopSurface">0</token>
+        <token name="TopSurfaceInput">0</token>
+        <float name="Transparency">0</float>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003bc</UniqueId>
+        <Vector3 name="Velocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+      </Properties>
+      <Item class="Decal" referent="6">
+        <Properties>
+          <string name="Name">Decal</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <Color3 name="Color3">
+            <R>1</R>
+            <G>1</G>
+            <B>1</B>
+          </Color3>
+          <token name="Face">1</token>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <Content name="MetalnessMapContent">
+            <null>
+            </null>
+          </Content>
+          <Content name="NormalMapContent">
+            <null>
+            </null>
+          </Content>
+          <float name="Rotation">0</float>
+          <Content name="RoughnessMapContent">
+            <null>
+            </null>
+          </Content>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <Content name="TextureContent">
+            <uri>rbxasset://textures/SpawnLocation.png</uri>
+          </Content>
+          <ContentId name="TexturePack">
+            <null>
+            </null>
+          </ContentId>
+          <string name="TexturePackMetadata"></string>
+          <float name="Transparency">0</float>
+          <Vector2 name="UVOffset">
+            <X>0</X>
+            <Y>0</Y>
+          </Vector2>
+          <Vector2 name="UVScale">
+            <X>1</X>
+            <Y>1</Y>
+          </Vector2>
+          <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003bd</UniqueId>
+          <int name="ZIndex">1</int>
+        </Properties>
+      </Item>
+    </Item>
+    <Item class="Part" referent="7">
+      <Properties>
+        <string name="Name">Baseplate</string>
+        <bool name="Anchored">true</bool>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <bool name="AudioCanCollide">true</bool>
+        <float name="BackParamA">-0.5</float>
+        <float name="BackParamB">0.5</float>
+        <token name="BackSurface">0</token>
+        <token name="BackSurfaceInput">0</token>
+        <float name="BottomParamA">-0.5</float>
+        <float name="BottomParamB">0.5</float>
+        <token name="BottomSurface">0</token>
+        <token name="BottomSurfaceInput">0</token>
+        <CoordinateFrame name="CFrame">
+          <X>0</X>
+          <Y>-8</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <bool name="CanCollide">true</bool>
+        <bool name="CanQuery">true</bool>
+        <bool name="CanTouch">true</bool>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="CastShadow">true</bool>
+        <string name="CollisionGroup">Default</string>
+        <int name="CollisionGroupId">0</int>
+        <Color3uint8 name="Color3uint8">5987163</Color3uint8>
+        <PhysicalProperties name="CustomPhysicalProperties">
+          <CustomPhysics>false</CustomPhysics>
+        </PhysicalProperties>
+        <bool name="EnableFluidForces">true</bool>
+        <token name="formFactorRaw">0</token>
+        <float name="FrontParamA">-0.5</float>
+        <float name="FrontParamB">0.5</float>
+        <token name="FrontSurface">0</token>
+        <token name="FrontSurfaceInput">0</token>
+        <UniqueId name="HistoryId">7ae0e5570bbb7d4c0a5586bb000003b9</UniqueId>
+        <float name="LeftParamA">-0.5</float>
+        <float name="LeftParamB">0.5</float>
+        <token name="LeftSurface">0</token>
+        <token name="LeftSurfaceInput">0</token>
+        <bool name="Locked">true</bool>
+        <bool name="Massless">false</bool>
+        <token name="Material">256</token>
+        <string name="MaterialVariantSerialized"></string>
+        <CoordinateFrame name="PivotOffset">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <R00>1</R00>
+          <R01>0</R01>
+          <R02>0</R02>
+          <R10>0</R10>
+          <R11>1</R11>
+          <R12>0</R12>
+          <R20>0</R20>
+          <R21>0</R21>
+          <R22>1</R22>
+        </CoordinateFrame>
+        <float name="Reflectance">0</float>
+        <float name="RightParamA">-0.5</float>
+        <float name="RightParamB">0.5</float>
+        <token name="RightSurface">0</token>
+        <token name="RightSurfaceInput">0</token>
+        <int name="RootPriority">0</int>
+        <Vector3 name="RotVelocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+        <bool name="DefinesCapabilities">false</bool>
+        <token name="shape">1</token>
+        <Vector3 name="size">
+          <X>2048</X>
+          <Y>16</Y>
+          <Z>2048</Z>
+        </Vector3>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags">YXRhZwBhbm90aGVydGFn</BinaryString>
+        <float name="TopParamA">-0.5</float>
+        <float name="TopParamB">0.5</float>
+        <token name="TopSurface">0</token>
+        <token name="TopSurfaceInput">0</token>
+        <float name="Transparency">0</float>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000008b3</UniqueId>
+        <Vector3 name="Velocity">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+      </Properties>
+      <Item class="Texture" referent="8">
+        <Properties>
+          <string name="Name">Texture</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <Color3 name="Color3">
+            <R>0</R>
+            <G>0</G>
+            <B>0</B>
+          </Color3>
+          <token name="Face">1</token>
+          <UniqueId name="HistoryId">7ae0e5570bbb7d4c0a5586bb000003ba</UniqueId>
+          <Content name="MetalnessMapContent">
+            <null>
+            </null>
+          </Content>
+          <Content name="NormalMapContent">
+            <null>
+            </null>
+          </Content>
+          <float name="OffsetStudsU">0</float>
+          <float name="OffsetStudsV">0</float>
+          <float name="Rotation">0</float>
+          <Content name="RoughnessMapContent">
+            <null>
+            </null>
+          </Content>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <float name="StudsPerTileU">8</float>
+          <float name="StudsPerTileV">8</float>
+          <BinaryString name="Tags"></BinaryString>
+          <Content name="TextureContent">
+            <uri>rbxassetid://6372755229</uri>
+          </Content>
+          <ContentId name="TexturePack">
+            <null>
+            </null>
+          </ContentId>
+          <string name="TexturePackMetadata"></string>
+          <float name="Transparency">0.8</float>
+          <Vector2 name="UVOffset">
+            <X>0</X>
+            <Y>0</Y>
+          </Vector2>
+          <Vector2 name="UVScale">
+            <X>1</X>
+            <Y>1</Y>
+          </Vector2>
+          <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000008b4</UniqueId>
+          <int name="ZIndex">1</int>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+  <Item class="TimerService" referent="9">
+    <Properties>
+      <string name="Name">Instance</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000338</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="CollectionService" referent="10">
+    <Properties>
+      <string name="Name">CollectionService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000339</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="SoundService" referent="11">
+    <Properties>
+      <string name="Name">SoundService</string>
+      <bool name="AcousticSimulationEnabled">false</bool>
+      <token name="AmbientReverb">0</token>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <token name="AudioApiByDefault">0</token>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <token name="CharacterSoundsUseNewApi">0</token>
+      <token name="DefaultListenerLocation">3</token>
+      <float name="DistanceFactor">3.33</float>
+      <float name="DopplerScale">1</float>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="IsNewExpForAudioApiByDefault">false</bool>
+      <bool name="RespectFilteringEnabled">true</bool>
+      <float name="RolloffScale">1</float>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000033a</UniqueId>
+      <token name="VolumetricAudio">1</token>
+    </Properties>
+  </Item>
+  <Item class="VideoCaptureService" referent="12">
+    <Properties>
+      <string name="Name">VideoCaptureService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000346</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="NonReplicatedCSGDictionaryService" referent="13">
+    <Properties>
+      <string name="Name">NonReplicatedCSGDictionaryService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000347</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="CSGDictionaryService" referent="14">
+    <Properties>
+      <string name="Name">CSGDictionaryService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000348</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="Chat" referent="15">
+    <Properties>
+      <string name="Name">Chat</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <bool name="BubbleChatEnabled">true</bool>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="IsAutoMigrated">true</bool>
+      <bool name="LoadDefaultChat">true</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000034e</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="Players" referent="16">
+    <Properties>
+      <string name="Name">Players</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <bool name="BanningEnabled">true</bool>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <bool name="CharacterAutoLoads">true</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <int name="MaxPlayersInternal">60</int>
+      <int name="PreferredPlayersInternal">60</int>
+      <float name="RespawnTime">3</float>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000350</UniqueId>
+      <bool name="UseStrafingAnimations">false</bool>
+    </Properties>
+  </Item>
+  <Item class="ReplicatedFirst" referent="17">
+    <Properties>
+      <string name="Name">ReplicatedFirst</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000353</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="TweenService" referent="18">
+    <Properties>
+      <string name="Name">TweenService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000355</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="MaterialService" referent="19">
+    <Properties>
+      <string name="Name">MaterialService</string>
+      <string name="AsphaltName">Asphalt</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <string name="BasaltName">Basalt</string>
+      <string name="BrickName">Brick</string>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <string name="CardboardName">Cardboard</string>
+      <string name="CarpetName">Carpet</string>
+      <string name="CeramicTilesName">CeramicTiles</string>
+      <string name="ClayRoofTilesName">ClayRoofTiles</string>
+      <string name="CobblestoneName">Cobblestone</string>
+      <string name="ConcreteName">Concrete</string>
+      <string name="CorrodedMetalName">CorrodedMetal</string>
+      <string name="CrackedLavaName">CrackedLava</string>
+      <string name="DiamondPlateName">DiamondPlate</string>
+      <string name="FabricName">Fabric</string>
+      <string name="FoilName">Foil</string>
+      <string name="GlacierName">Glacier</string>
+      <string name="GraniteName">Granite</string>
+      <string name="GrassName">Grass</string>
+      <string name="GroundName">Ground</string>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <string name="IceName">Ice</string>
+      <string name="LeafyGrassName">LeafyGrass</string>
+      <string name="LeatherName">Leather</string>
+      <string name="LimestoneName">Limestone</string>
+      <string name="MarbleName">Marble</string>
+      <string name="MetalName">Metal</string>
+      <string name="MudName">Mud</string>
+      <string name="PavementName">Pavement</string>
+      <string name="PebbleName">Pebble</string>
+      <string name="PlasterName">Plaster</string>
+      <string name="PlasticName">Plastic</string>
+      <string name="RockName">Rock</string>
+      <string name="RoofShinglesName">RoofShingles</string>
+      <string name="RubberName">Rubber</string>
+      <string name="SaltName">Salt</string>
+      <string name="SandName">Sand</string>
+      <bool name="DefinesCapabilities">false</bool>
+      <string name="SandstoneName">Sandstone</string>
+      <string name="SlateName">Slate</string>
+      <string name="SmoothPlasticName">SmoothPlastic</string>
+      <string name="SnowName">Snow</string>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000356</UniqueId>
+      <bool name="Use2022MaterialsXml">true</bool>
+      <string name="WoodName">Wood</string>
+      <string name="WoodPlanksName">WoodPlanks</string>
+    </Properties>
+  </Item>
+  <Item class="TextChatService" referent="20">
+    <Properties>
+      <string name="Name">TextChatService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <bool name="ChatTranslationFTUXShown">true</bool>
+      <bool name="ChatTranslationToggleEnabled">false</bool>
+      <token name="ChatVersion">1</token>
+      <bool name="CreateDefaultCommands">true</bool>
+      <bool name="CreateDefaultTextChannels">true</bool>
+      <bool name="HasSeenDeprecationDialog">false</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="IsLegacyChatDisabled">true</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000357</UniqueId>
+    </Properties>
+    <Item class="ChatWindowConfiguration" referent="21">
+      <Properties>
+        <string name="Name">ChatWindowConfiguration</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <Color3 name="BackgroundColor3">
+          <R>0.09803922</R>
+          <G>0.105882354</G>
+          <B>0.11372549</B>
+        </Color3>
+        <double name="BackgroundTransparency">0.3</double>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="Enabled">true</bool>
+        <Font name="FontFace">
+          <Family>
+            <url>rbxasset://fonts/families/BuilderSans.json</url>
+          </Family>
+          <Weight>500</Weight>
+          <Style>Normal</Style>
+          <CachedFaceId>
+            <url>rbxasset://fonts/BuilderSans-Medium.otf</url>
+          </CachedFaceId>
+        </Font>
+        <float name="HeightScale">1</float>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <token name="HorizontalAlignment">1</token>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <Color3 name="TextColor3">
+          <R>1</R>
+          <G>1</G>
+          <B>1</B>
+        </Color3>
+        <int64 name="TextSize">18</int64>
+        <Color3 name="TextStrokeColor3">
+          <R>0</R>
+          <G>0</G>
+          <B>0</B>
+        </Color3>
+        <double name="TextStrokeTransparency">0.5</double>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c7</UniqueId>
+        <token name="VerticalAlignment">1</token>
+        <float name="WidthScale">1</float>
+      </Properties>
+    </Item>
+    <Item class="ChatInputBarConfiguration" referent="22">
+      <Properties>
+        <string name="Name">ChatInputBarConfiguration</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <bool name="AutocompleteEnabled">true</bool>
+        <Color3 name="BackgroundColor3">
+          <R>0.09803922</R>
+          <G>0.105882354</G>
+          <B>0.11372549</B>
+        </Color3>
+        <double name="BackgroundTransparency">0.2</double>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="Enabled">true</bool>
+        <Font name="FontFace">
+          <Family>
+            <url>rbxasset://fonts/families/BuilderSans.json</url>
+          </Family>
+          <Weight>500</Weight>
+          <Style>Normal</Style>
+          <CachedFaceId>
+            <url>rbxasset://fonts/BuilderSans-Medium.otf</url>
+          </CachedFaceId>
+        </Font>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <token name="KeyboardKeyCode">47</token>
+        <Color3 name="PlaceholderColor3">
+          <R>0.69803923</R>
+          <G>0.69803923</G>
+          <B>0.69803923</B>
+        </Color3>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <Ref name="TargetTextChannel">null</Ref>
+        <Color3 name="TextColor3">
+          <R>1</R>
+          <G>1</G>
+          <B>1</B>
+        </Color3>
+        <int64 name="TextSize">18</int64>
+        <Color3 name="TextStrokeColor3">
+          <R>0</R>
+          <G>0</G>
+          <B>0</B>
+        </Color3>
+        <double name="TextStrokeTransparency">0.5</double>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c8</UniqueId>
+      </Properties>
+    </Item>
+    <Item class="BubbleChatConfiguration" referent="23">
+      <Properties>
+        <string name="Name">BubbleChatConfiguration</string>
+        <string name="AdorneeName">HumanoidRootPart</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <Color3 name="BackgroundColor3">
+          <R>0.98039216</R>
+          <G>0.98039216</G>
+          <B>0.98039216</B>
+        </Color3>
+        <double name="BackgroundTransparency">0.1</double>
+        <float name="BubbleDuration">15</float>
+        <float name="BubblesSpacing">6</float>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="Enabled">true</bool>
+        <token name="Font">47</token>
+        <Font name="FontFace">
+          <Family>
+            <url>rbxasset://fonts/families/BuilderSans.json</url>
+          </Family>
+          <Weight>500</Weight>
+          <Style>Normal</Style>
+          <CachedFaceId>
+            <url>rbxasset://fonts/BuilderSans-Medium.otf</url>
+          </CachedFaceId>
+        </Font>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <Vector3 name="LocalPlayerStudsOffset">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+        <float name="MaxBubbles">3</float>
+        <float name="MaxDistance">100</float>
+        <float name="MinimizeDistance">40</float>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <bool name="TailVisible">true</bool>
+        <Color3 name="TextColor3">
+          <R>0.22352941</R>
+          <G>0.23137255</G>
+          <B>0.23921569</B>
+        </Color3>
+        <int64 name="TextSize">20</int64>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c9</UniqueId>
+        <float name="VerticalStudsOffset">0</float>
+      </Properties>
+      <Item class="UIGradient" referent="24">
+        <Properties>
+          <string name="Name">UIGradient</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <ColorSequence name="Color">0 1 1 1 0 1 1 1 1 0 </ColorSequence>
+          <bool name="Enabled">false</bool>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <Vector2 name="Offset">
+            <X>0</X>
+            <Y>0</Y>
+          </Vector2>
+          <float name="Rotation">0</float>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <NumberSequence name="Transparency">0 0 0 1 0 0 </NumberSequence>
+          <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003ca</UniqueId>
+        </Properties>
+      </Item>
+      <Item class="ImageLabel" referent="25">
+        <Properties>
+          <string name="Name">ImageLabel</string>
+          <bool name="Active">false</bool>
+          <Vector2 name="AnchorPoint">
+            <X>0</X>
+            <Y>0</Y>
+          </Vector2>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <bool name="AutoLocalize">true</bool>
+          <token name="AutomaticSize">0</token>
+          <Color3 name="BackgroundColor3">
+            <R>1</R>
+            <G>1</G>
+            <B>1</B>
+          </Color3>
+          <float name="BackgroundTransparency">0</float>
+          <Color3 name="BorderColor3">
+            <R>0.10588236</R>
+            <G>0.16470589</G>
+            <B>0.20784315</B>
+          </Color3>
+          <token name="BorderMode">0</token>
+          <int name="BorderSizePixel">1</int>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <bool name="ClipsDescendants">false</bool>
+          <bool name="Draggable">false</bool>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <Color3 name="ImageColor3">
+            <R>1</R>
+            <G>1</G>
+            <B>1</B>
+          </Color3>
+          <Content name="ImageContent">
+            <null>
+            </null>
+          </Content>
+          <Vector2 name="ImageRectOffset">
+            <X>0</X>
+            <Y>0</Y>
+          </Vector2>
+          <Vector2 name="ImageRectSize">
+            <X>0</X>
+            <Y>0</Y>
+          </Vector2>
+          <float name="ImageTransparency">0</float>
+          <token name="InputSink">0</token>
+          <bool name="Interactable">true</bool>
+          <int name="LayoutOrder">0</int>
+          <Ref name="NextSelectionDown">null</Ref>
+          <Ref name="NextSelectionLeft">null</Ref>
+          <Ref name="NextSelectionRight">null</Ref>
+          <Ref name="NextSelectionUp">null</Ref>
+          <UDim2 name="Position">
+            <XS>0</XS>
+            <XO>0</XO>
+            <YS>0</YS>
+            <YO>0</YO>
+          </UDim2>
+          <token name="ResampleMode">0</token>
+          <Ref name="RootLocalizationTable">null</Ref>
+          <float name="Rotation">0</float>
+          <bool name="DefinesCapabilities">false</bool>
+          <token name="ScaleType">0</token>
+          <bool name="Selectable">false</bool>
+          <token name="SelectionBehaviorDown">0</token>
+          <token name="SelectionBehaviorLeft">0</token>
+          <token name="SelectionBehaviorRight">0</token>
+          <token name="SelectionBehaviorUp">0</token>
+          <bool name="SelectionGroup">false</bool>
+          <Ref name="SelectionImageObject">null</Ref>
+          <int name="SelectionOrder">0</int>
+          <UDim2 name="Size">
+            <XS>0</XS>
+            <XO>100</XO>
+            <YS>0</YS>
+            <YO>100</YO>
+          </UDim2>
+          <token name="SizeConstraint">0</token>
+          <Rect2D name="SliceCenter">
+            <min>
+              <X>0</X>
+              <Y>0</Y>
+            </min>
+            <max>
+              <X>0</X>
+              <Y>0</Y>
+            </max>
+          </Rect2D>
+          <float name="SliceScale">1</float>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UDim2 name="TileSize">
+            <XS>1</XS>
+            <XO>0</XO>
+            <YS>1</YS>
+            <YO>0</YO>
+          </UDim2>
+          <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003cb</UniqueId>
+          <bool name="Visible">true</bool>
+          <int name="ZIndex">1</int>
+        </Properties>
+      </Item>
+      <Item class="UICorner" referent="26">
+        <Properties>
+          <string name="Name">UICorner</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <UDim name="BottomLeftRadius">
+            <S>0</S>
+            <O>12</O>
+          </UDim>
+          <UDim name="BottomRightRadius">
+            <S>0</S>
+            <O>12</O>
+          </UDim>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UDim name="TopLeftRadius">
+            <S>0</S>
+            <O>12</O>
+          </UDim>
+          <UDim name="TopRightRadius">
+            <S>0</S>
+            <O>12</O>
+          </UDim>
+          <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003cc</UniqueId>
+        </Properties>
+      </Item>
+      <Item class="UIPadding" referent="27">
+        <Properties>
+          <string name="Name">UIPadding</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <UDim name="PaddingBottom">
+            <S>0</S>
+            <O>8</O>
+          </UDim>
+          <UDim name="PaddingLeft">
+            <S>0</S>
+            <O>8</O>
+          </UDim>
+          <UDim name="PaddingRight">
+            <S>0</S>
+            <O>8</O>
+          </UDim>
+          <UDim name="PaddingTop">
+            <S>0</S>
+            <O>8</O>
+          </UDim>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003cd</UniqueId>
+        </Properties>
+      </Item>
+    </Item>
+    <Item class="ChannelTabsConfiguration" referent="28">
+      <Properties>
+        <string name="Name">ChannelTabsConfiguration</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <Color3 name="BackgroundColor3">
+          <R>0.09803922</R>
+          <G>0.105882354</G>
+          <B>0.11372549</B>
+        </Color3>
+        <double name="BackgroundTransparency">0</double>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="Enabled">false</bool>
+        <Font name="FontFace">
+          <Family>
+            <url>rbxasset://fonts/families/BuilderSans.json</url>
+          </Family>
+          <Weight>700</Weight>
+          <Style>Normal</Style>
+          <CachedFaceId>
+            <url>rbxasset://fonts/BuilderSans-Bold.otf</url>
+          </CachedFaceId>
+        </Font>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <Color3 name="HoverBackgroundColor3">
+          <R>0.49019608</R>
+          <G>0.49019608</G>
+          <B>0.49019608</B>
+        </Color3>
+        <bool name="DefinesCapabilities">false</bool>
+        <Color3 name="SelectedTabTextColor3">
+          <R>1</R>
+          <G>1</G>
+          <B>1</B>
+        </Color3>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <Color3 name="TextColor3">
+          <R>0.6862745</R>
+          <G>0.6862745</G>
+          <B>0.6862745</B>
+        </Color3>
+        <int64 name="TextSize">18</int64>
+        <Color3 name="TextStrokeColor3">
+          <R>0</R>
+          <G>0</G>
+          <B>0</B>
+        </Color3>
+        <double name="TextStrokeTransparency">1</double>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003ce</UniqueId>
+      </Properties>
+    </Item>
+  </Item>
+  <Item class="PermissionsService" referent="29">
+    <Properties>
+      <string name="Name">PermissionsService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e07</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="PlayerEmulatorService" referent="30">
+    <Properties>
+      <string name="Name">PlayerEmulatorService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <bool name="CustomPoliciesEnabled">false</bool>
+      <string name="EmulatedCountryCode"></string>
+      <string name="EmulatedGameLocale"></string>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="PlayerEmulationEnabled">false</bool>
+      <bool name="PseudolocalizationEnabled">false</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <BinaryString name="SerializedEmulatedPolicyInfo">
+      </BinaryString>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <int name="TextElongationFactor">0</int>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000035a</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="StudioData" referent="31">
+    <Properties>
+      <string name="Name">StudioData</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <bool name="EnableScriptCollabByDefaultOnLoad">false</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000035d</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="StarterPlayer" referent="32">
+    <Properties>
+      <string name="Name">StarterPlayer</string>
+      <bool name="AllowCustomAnimations">true</bool>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <bool name="AutoJumpEnabled">true</bool>
+      <token name="AvatarJointUpgrade_SerializedRollout">2</token>
+      <float name="CameraMaxZoomDistance">128</float>
+      <float name="CameraMinZoomDistance">0.5</float>
+      <token name="CameraMode">0</token>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <bool name="CharacterBreakJointsOnDeath">false</bool>
+      <float name="CharacterJumpHeight">7.2</float>
+      <float name="CharacterJumpPower">50</float>
+      <float name="CharacterMaxSlopeAngle">89</float>
+      <bool name="CharacterUseJumpPower">false</bool>
+      <float name="CharacterWalkSpeed">16</float>
+      <bool name="ClassicDeath">true</bool>
+      <bool name="CreateDefaultPlayerModule">true</bool>
+      <token name="DevCameraOcclusionMode">0</token>
+      <token name="DevComputerCameraMovementMode">0</token>
+      <token name="DevComputerMovementMode">0</token>
+      <token name="DevTouchCameraMovementMode">0</token>
+      <token name="DevTouchMovementMode">0</token>
+      <token name="EnableDynamicHeads">0</token>
+      <bool name="EnableMouseLockOption">true</bool>
+      <int64 name="GameSettingsAssetIDFace">0</int64>
+      <int64 name="GameSettingsAssetIDHead">0</int64>
+      <int64 name="GameSettingsAssetIDLeftArm">0</int64>
+      <int64 name="GameSettingsAssetIDLeftLeg">0</int64>
+      <int64 name="GameSettingsAssetIDPants">0</int64>
+      <int64 name="GameSettingsAssetIDRightArm">0</int64>
+      <int64 name="GameSettingsAssetIDRightLeg">0</int64>
+      <int64 name="GameSettingsAssetIDShirt">0</int64>
+      <int64 name="GameSettingsAssetIDTeeShirt">0</int64>
+      <int64 name="GameSettingsAssetIDTorso">0</int64>
+      <token name="GameSettingsAvatar">1</token>
+      <token name="GameSettingsR15Collision">0</token>
+      <NumberRange name="GameSettingsScaleRangeBodyType">0 1 </NumberRange>
+      <NumberRange name="GameSettingsScaleRangeHead">0.95 1 </NumberRange>
+      <NumberRange name="GameSettingsScaleRangeHeight">0.9 1.05 </NumberRange>
+      <NumberRange name="GameSettingsScaleRangeProportion">0 1 </NumberRange>
+      <NumberRange name="GameSettingsScaleRangeWidth">0.7 1 </NumberRange>
+      <float name="HealthDisplayDistance">100</float>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="LoadCharacterAppearance">true</bool>
+      <token name="LoadCharacterLayeredClothing">0</token>
+      <token name="LuaCharacterController">0</token>
+      <float name="NameDisplayDistance">100</float>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000035f</UniqueId>
+      <bool name="UserEmotesEnabled">true</bool>
+    </Properties>
+    <Item class="StarterPlayerScripts" referent="33">
+      <Properties>
+        <string name="Name">StarterPlayerScripts</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003bf</UniqueId>
+      </Properties>
+    </Item>
+    <Item class="StarterCharacterScripts" referent="34">
+      <Properties>
+        <string name="Name">StarterCharacterScripts</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c0</UniqueId>
+      </Properties>
+    </Item>
+  </Item>
+  <Item class="StarterPack" referent="35">
+    <Properties>
+      <string name="Name">StarterPack</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000360</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="StarterGui" referent="36">
+    <Properties>
+      <string name="Name">StarterGui</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <token name="ClipsDescendantsSupportsRotation">0</token>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="ResetPlayerGuiOnSpawn">true</bool>
+      <token name="RtlTextSupport">0</token>
+      <bool name="DefinesCapabilities">false</bool>
+      <token name="ScreenOrientation">4</token>
+      <bool name="ShowDevelopmentGui">true</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <Ref name="StudioDefaultStyleSheet">null</Ref>
+      <Ref name="StudioInsertWidgetLayerCollectorAutoLinkStyleSheet">null</Ref>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000361</UniqueId>
+      <token name="VirtualCursorMode">0</token>
+    </Properties>
+  </Item>
+  <Item class="LocalizationService" referent="37">
+    <Properties>
+      <string name="Name">LocalizationService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000363</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="TeleportService" referent="38">
+    <Properties>
+      <string name="Name">Teleport Service</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000367</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="PhysicsService" referent="39">
+    <Properties>
+      <string name="Name">PhysicsService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000369</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="InsertService" referent="40">
+    <Properties>
+      <string name="Name">InsertService</string>
+      <bool name="AllowInsertFreeModels">false</bool>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000036c</UniqueId>
+    </Properties>
+    <Item class="StringValue" referent="41">
+      <Properties>
+        <string name="Name">InsertionHash</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c1</UniqueId>
+        <string name="Value">{a4b4fc84-d3fa-4580-b9d0-98390afa7f7f}</string>
+      </Properties>
+    </Item>
+  </Item>
+  <Item class="GamePassService" referent="42">
+    <Properties>
+      <string name="Name">GamePassService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000036d</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="Debris" referent="43">
+    <Properties>
+      <string name="Name">Debris</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <int name="MaxItems">1000</int>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000036e</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="CookiesService" referent="44">
+    <Properties>
+      <string name="Name">CookiesService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000036f</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="Selection" referent="45">
+    <Properties>
+      <string name="Name">Selection</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000370</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="VRService" referent="46">
+    <Properties>
+      <string name="Name">VRService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <token name="AutomaticScaling">0</token>
+      <bool name="AvatarGestures">false</bool>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <token name="ControllerModels">1</token>
+      <bool name="FadeOutViewOnCollision">true</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <token name="LaserPointer">1</token>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000374</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ContextActionService" referent="47">
+    <Properties>
+      <string name="Name">ContextActionService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000375</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ScriptService" referent="48">
+    <Properties>
+      <string name="Name">Instance</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000376</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="AssetService" referent="49">
+    <Properties>
+      <string name="Name">AssetService</string>
+      <bool name="AllowInsertFreeAssets">false</bool>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000377</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="TouchInputService" referent="50">
+    <Properties>
+      <string name="Name">TouchInputService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000379</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="AvatarSettings" referent="51">
+    <Properties>
+      <string name="Name">AvatarSettings</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000037f</UniqueId>
+    </Properties>
+    <Item class="AvatarRules" referent="52">
+      <Properties>
+        <string name="Name">DefaultAvatarRules</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <token name="AvatarType">1</token>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e00</UniqueId>
+      </Properties>
+      <Item class="AvatarBodyRules" referent="53">
+        <Properties>
+          <string name="Name">AvatarBodyRules</string>
+          <token name="AppearanceMode">0</token>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <token name="BuildMode">0</token>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <int64 name="CustomBodyBundleId">0</int64>
+          <token name="CustomBodyType">0</token>
+          <NumberRange name="CustomBodyTypeScale">0 1 </NumberRange>
+          <bool name="CustomEyebrowEnabled">false</bool>
+          <int64 name="CustomEyebrowId">0</int64>
+          <bool name="CustomEyelashEnabled">false</bool>
+          <int64 name="CustomEyelashId">0</int64>
+          <bool name="CustomFaceEnabled">false</bool>
+          <int64 name="CustomFaceId">0</int64>
+          <bool name="CustomHeadEnabled">false</bool>
+          <int64 name="CustomHeadId">0</int64>
+          <NumberRange name="CustomHeadScale">0.95 1 </NumberRange>
+          <NumberRange name="CustomHeight">5.5 5.5 </NumberRange>
+          <NumberRange name="CustomHeightScale">0.9 1.05 </NumberRange>
+          <bool name="CustomLeftArmEnabled">false</bool>
+          <int64 name="CustomLeftArmId">0</int64>
+          <bool name="CustomLeftLegEnabled">false</bool>
+          <int64 name="CustomLeftLegId">0</int64>
+          <bool name="CustomMoodEnabled">false</bool>
+          <int64 name="CustomMoodId">0</int64>
+          <NumberRange name="CustomProportionsScale">0 1 </NumberRange>
+          <bool name="CustomRightArmEnabled">false</bool>
+          <int64 name="CustomRightArmId">0</int64>
+          <bool name="CustomRightLegEnabled">false</bool>
+          <int64 name="CustomRightLegId">0</int64>
+          <bool name="CustomTorsoEnabled">false</bool>
+          <int64 name="CustomTorsoId">0</int64>
+          <NumberRange name="CustomWidthScale">0.7 1 </NumberRange>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <bool name="KeepPlayerHead">true</bool>
+          <bool name="DefinesCapabilities">false</bool>
+          <token name="ScaleMode">0</token>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e01</UniqueId>
+        </Properties>
+      </Item>
+      <Item class="AvatarCollisionRules" referent="54">
+        <Properties>
+          <string name="Name">AvatarCollisionRules</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <token name="CollisionMode">0</token>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <token name="HitAndTouchDetectionMode">0</token>
+          <token name="LegacyCollisionMode">1</token>
+          <bool name="DefinesCapabilities">false</bool>
+          <Vector3 name="SingleColliderSize">
+            <X>2</X>
+            <Y>3</Y>
+            <Z>1</Z>
+          </Vector3>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e02</UniqueId>
+        </Properties>
+      </Item>
+      <Item class="AvatarAbilityRules" referent="55">
+        <Properties>
+          <string name="Name">AvatarAbilityRules</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <token name="CharacterControllerMode">0</token>
+          <bool name="EnableClimbing">true</bool>
+          <bool name="EnableCrouching">true</bool>
+          <bool name="EnableFallingDown">true</bool>
+          <bool name="EnableGettingUp">true</bool>
+          <bool name="EnableHolding">true</bool>
+          <bool name="EnableJumping">true</bool>
+          <bool name="EnableReaching">true</bool>
+          <bool name="EnableRunning">true</bool>
+          <bool name="EnableSitting">true</bool>
+          <bool name="EnableSprinting">true</bool>
+          <bool name="EnableStrafing">true</bool>
+          <bool name="EnableSwimming">true</bool>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e03</UniqueId>
+        </Properties>
+      </Item>
+      <Item class="AvatarAnimationRules" referent="56">
+        <Properties>
+          <string name="Name">AvatarAnimationRules</string>
+          <token name="AnimationClipsMode">0</token>
+          <token name="AnimationPacksMode">0</token>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <bool name="CustomClimbAnimationEnabled">false</bool>
+          <int64 name="CustomClimbAnimationId">0</int64>
+          <bool name="CustomFallAnimationEnabled">false</bool>
+          <int64 name="CustomFallAnimationId">0</int64>
+          <bool name="CustomIdleAlt1AnimationEnabled">false</bool>
+          <int64 name="CustomIdleAlt1AnimationId">0</int64>
+          <bool name="CustomIdleAlt2AnimationEnabled">false</bool>
+          <int64 name="CustomIdleAlt2AnimationId">0</int64>
+          <bool name="CustomIdleAnimationEnabled">false</bool>
+          <int64 name="CustomIdleAnimationId">0</int64>
+          <bool name="CustomJumpAnimationEnabled">false</bool>
+          <int64 name="CustomJumpAnimationId">0</int64>
+          <bool name="CustomRunAnimationEnabled">false</bool>
+          <int64 name="CustomRunAnimationId">0</int64>
+          <bool name="CustomSwimAnimationEnabled">false</bool>
+          <int64 name="CustomSwimAnimationId">0</int64>
+          <bool name="CustomSwimIdleAnimationEnabled">false</bool>
+          <int64 name="CustomSwimIdleAnimationId">0</int64>
+          <bool name="CustomWalkAnimationEnabled">false</bool>
+          <int64 name="CustomWalkAnimationId">0</int64>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e04</UniqueId>
+        </Properties>
+      </Item>
+      <Item class="AvatarAccessoryRules" referent="57">
+        <Properties>
+          <string name="Name">AvatarAccessoryRules</string>
+          <token name="AccessoryMode">0</token>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <token name="CustomAccessoryMode">0</token>
+          <bool name="CustomBackAccessoryEnabled">false</bool>
+          <int64 name="CustomBackAccessoryId">0</int64>
+          <bool name="CustomFaceAccessoryEnabled">false</bool>
+          <int64 name="CustomFaceAccessoryId">0</int64>
+          <bool name="CustomFrontAccessoryEnabled">false</bool>
+          <int64 name="CustomFrontAccessoryId">0</int64>
+          <bool name="CustomHairAccessoryEnabled">false</bool>
+          <int64 name="CustomHairAccessoryId">0</int64>
+          <bool name="CustomHeadAccessoryEnabled">false</bool>
+          <int64 name="CustomHeadAccessoryId">0</int64>
+          <bool name="CustomNeckAccessoryEnabled">false</bool>
+          <int64 name="CustomNeckAccessoryId">0</int64>
+          <bool name="CustomShoulderAccessoryEnabled">false</bool>
+          <int64 name="CustomShoulderAccessoryId">0</int64>
+          <bool name="CustomWaistAccessoryEnabled">false</bool>
+          <int64 name="CustomWaistAccessoryId">0</int64>
+          <bool name="EnableSound">true</bool>
+          <bool name="EnableVFX">true</bool>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <Vector3 name="LimitBounds">
+            <X>0</X>
+            <Y>0</Y>
+            <Z>0</Z>
+          </Vector3>
+          <token name="LimitMethod">1</token>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e05</UniqueId>
+        </Properties>
+      </Item>
+      <Item class="AvatarClothingRules" referent="58">
+        <Properties>
+          <string name="Name">AvatarClothingRules</string>
+          <BinaryString name="AttributesSerialize"></BinaryString>
+          <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+          <token name="ClothingMode">0</token>
+          <bool name="CustomClassicPantsAccessoryEnabled">false</bool>
+          <int64 name="CustomClassicPantsAccessoryId">0</int64>
+          <bool name="CustomClassicShirtsAccessoryEnabled">false</bool>
+          <int64 name="CustomClassicShirtsAccessoryId">0</int64>
+          <bool name="CustomClassicTShirtsAccessoryEnabled">false</bool>
+          <int64 name="CustomClassicTShirtsAccessoryId">0</int64>
+          <token name="CustomClothingMode">0</token>
+          <bool name="CustomDressSkirtAccessoryEnabled">false</bool>
+          <int64 name="CustomDressSkirtAccessoryId">0</int64>
+          <bool name="CustomJacketAccessoryEnabled">false</bool>
+          <int64 name="CustomJacketAccessoryId">0</int64>
+          <bool name="CustomLeftShoesAccessoryEnabled">false</bool>
+          <int64 name="CustomLeftShoesAccessoryId">0</int64>
+          <bool name="CustomPantsAccessoryEnabled">false</bool>
+          <int64 name="CustomPantsAccessoryId">0</int64>
+          <bool name="CustomRightShoesAccessoryEnabled">false</bool>
+          <int64 name="CustomRightShoesAccessoryId">0</int64>
+          <bool name="CustomShirtAccessoryEnabled">false</bool>
+          <int64 name="CustomShirtAccessoryId">0</int64>
+          <bool name="CustomShortsAccessoryEnabled">false</bool>
+          <int64 name="CustomShortsAccessoryId">0</int64>
+          <bool name="CustomSweaterAccessoryEnabled">false</bool>
+          <int64 name="CustomSweaterAccessoryId">0</int64>
+          <bool name="CustomTShirtAccessoryEnabled">false</bool>
+          <int64 name="CustomTShirtAccessoryId">0</int64>
+          <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+          <Vector3 name="LimitBounds">
+            <X>0</X>
+            <Y>0</Y>
+            <Z>0</Z>
+          </Vector3>
+          <bool name="DefinesCapabilities">false</bool>
+          <int64 name="SourceAssetId">-1</int64>
+          <BinaryString name="Tags"></BinaryString>
+          <UniqueId name="UniqueId">7edfffb096708e650a5620f100000e06</UniqueId>
+        </Properties>
+      </Item>
+    </Item>
+  </Item>
+  <Item class="Packages" referent="59">
+    <Properties>
+      <string name="Name">Packages</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="IsDehydrated">false</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <int name="ShellPackagesCount">0</int>
+      <int name="SkippedInstancesCount">0</int>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000383</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="GuidRegistryService" referent="60">
+    <Properties>
+      <string name="Name">GuidRegistryService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000384</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="LuaWebService" referent="61">
+    <Properties>
+      <string name="Name">LuaWebService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7edfffb096708e650a5620f100000f22</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ProcessInstancePhysicsService" referent="62">
+    <Properties>
+      <string name="Name">ProcessInstancePhysicsService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">1f0379dd5b8107880a56e26b0000038c</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ReplicatedStorage" referent="63">
+    <Properties>
+      <string name="Name">ReplicatedStorage</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000398</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ServerScriptService" referent="64">
+    <Properties>
+      <string name="Name">ServerScriptService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="LoadStringEnabled">false</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb00000399</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ServerStorage" referent="65">
+    <Properties>
+      <string name="Name">ServerStorage</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb0000039a</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ServiceVisibilityService" referent="66">
+    <Properties>
+      <string name="Name">ServiceVisibilityService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <BinaryString name="HiddenServices"><![CDATA[AAAAAA==]]></BinaryString>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003a1</UniqueId>
+      <BinaryString name="VisibleServices"><![CDATA[AAAAAA==]]></BinaryString>
+    </Properties>
+  </Item>
+  <Item class="HttpService" referent="67">
+    <Properties>
+      <string name="Name">HttpService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="HttpEnabled">false</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003ac</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="DataStoreService" referent="68">
+    <Properties>
+      <string name="Name">DataStoreService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <bool name="AutomaticRetry">true</bool>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="LegacyNamingScheme">false</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003af</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="Lighting" referent="69">
+    <Properties>
+      <string name="Name">Lighting</string>
+      <Color3 name="Ambient">
+        <R>0.27450982</R>
+        <G>0.27450982</G>
+        <B>0.27450982</B>
+      </Color3>
+      <BinaryString name="AttributesSerialize">AgAAACYAAABSQlhfTGlnaHRpbmdUZWNobm9sb2d5VW5pZmllZE1pZ3JhdGlvbgMBIAAAAFJCWF9PcmlnaW5hbFRlY2hub2xvZ3lPbkZpbGVMb2FkBAMAAAA=</BinaryString>
+      <float name="Brightness">3</float>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <Color3 name="ColorShift_Bottom">
+        <R>0</R>
+        <G>0</G>
+        <B>0</B>
+      </Color3>
+      <Color3 name="ColorShift_Top">
+        <R>0</R>
+        <G>0</G>
+        <B>0</B>
+      </Color3>
+      <float name="EnvironmentDiffuseScale">1</float>
+      <float name="EnvironmentSpecularScale">1</float>
+      <float name="ExposureCompensation">0</float>
+      <token name="ExtendLightRangeTo120">0</token>
+      <Color3 name="FogColor">
+        <R>0.75294125</R>
+        <G>0.75294125</G>
+        <B>0.75294125</B>
+      </Color3>
+      <float name="FogEnd">100000</float>
+      <float name="FogStart">0</float>
+      <float name="GeographicLatitude">0</float>
+      <bool name="GlobalShadows">true</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <token name="LightingStyle">1</token>
+      <Color3 name="OutdoorAmbient">
+        <R>0.27450982</R>
+        <G>0.27450982</G>
+        <B>0.27450982</B>
+      </Color3>
+      <bool name="Outlines">false</bool>
+      <bool name="PrioritizeLightingQuality">true</bool>
+      <bool name="DefinesCapabilities">false</bool>
+      <float name="ShadowSoftness">0.2</float>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <token name="Technology">3</token>
+      <string name="TimeOfDay">14:30:00</string>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b0</UniqueId>
+    </Properties>
+    <Item class="Sky" referent="70">
+      <Properties>
+        <string name="Name">Sky</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="CelestialBodiesShown">true</bool>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="MoonAngularSize">11</float>
+        <Content name="MoonTextureContent">
+          <uri>rbxassetid://6444320592</uri>
+        </Content>
+        <bool name="DefinesCapabilities">false</bool>
+        <Content name="SkyboxBackContent">
+          <uri>rbxassetid://6444884337</uri>
+        </Content>
+        <Content name="SkyboxDownContent">
+          <uri>rbxassetid://6444884785</uri>
+        </Content>
+        <Content name="SkyboxFrontContent">
+          <uri>rbxassetid://6444884337</uri>
+        </Content>
+        <Content name="SkyboxLeftContent">
+          <uri>rbxassetid://6444884337</uri>
+        </Content>
+        <Vector3 name="SkyboxOrientation">
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+        </Vector3>
+        <Content name="SkyboxRightContent">
+          <uri>rbxassetid://6444884337</uri>
+        </Content>
+        <Content name="SkyboxUpContent">
+          <uri>rbxassetid://6412503613</uri>
+        </Content>
+        <int64 name="SourceAssetId">332039975</int64>
+        <int name="StarCount">3000</int>
+        <float name="SunAngularSize">11</float>
+        <Content name="SunTextureContent">
+          <uri>rbxassetid://6196665106</uri>
+        </Content>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c2</UniqueId>
+      </Properties>
+    </Item>
+    <Item class="SunRaysEffect" referent="71">
+      <Properties>
+        <string name="Name">SunRays</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="Enabled">true</bool>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="Intensity">0.01</float>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <float name="Spread">0.1</float>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c3</UniqueId>
+      </Properties>
+    </Item>
+    <Item class="Atmosphere" referent="72">
+      <Properties>
+        <string name="Name">Atmosphere</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <Color3 name="Color">
+          <R>0.78039217</R>
+          <G>0.78039217</G>
+          <B>0.78039217</B>
+        </Color3>
+        <Color3 name="Decay">
+          <R>0.41568628</R>
+          <G>0.4392157</G>
+          <B>0.49019608</B>
+        </Color3>
+        <float name="Density">0.3</float>
+        <float name="Glare">0</float>
+        <float name="Haze">0</float>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="Offset">0.25</float>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c4</UniqueId>
+      </Properties>
+    </Item>
+    <Item class="BloomEffect" referent="73">
+      <Properties>
+        <string name="Name">Bloom</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="Enabled">true</bool>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="Intensity">1</float>
+        <bool name="DefinesCapabilities">false</bool>
+        <float name="Size">24</float>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <float name="Threshold">2</float>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c5</UniqueId>
+      </Properties>
+    </Item>
+    <Item class="DepthOfFieldEffect" referent="74">
+      <Properties>
+        <string name="Name">DepthOfField</string>
+        <BinaryString name="AttributesSerialize"></BinaryString>
+        <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+        <bool name="Enabled">false</bool>
+        <float name="FarIntensity">0.1</float>
+        <float name="FocusDistance">0.05</float>
+        <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+        <float name="InFocusRadius">30</float>
+        <float name="NearIntensity">0.75</float>
+        <bool name="DefinesCapabilities">false</bool>
+        <int64 name="SourceAssetId">-1</int64>
+        <BinaryString name="Tags"></BinaryString>
+        <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003c6</UniqueId>
+      </Properties>
+    </Item>
+  </Item>
+  <Item class="LodDataService" referent="75">
+    <Properties>
+      <string name="Name">Instance</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b1</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="ProximityPromptService" referent="76">
+    <Properties>
+      <string name="Name">ProximityPromptService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <bool name="Enabled">true</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <int name="MaxIndicatorsVisible">16</int>
+      <int name="MaxPromptsVisible">16</int>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b2</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="Teams" referent="77">
+    <Properties>
+      <string name="Name">Teams</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b3</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="TestService" referent="78">
+    <Properties>
+      <string name="Name">TestService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <bool name="AutoRuns">true</bool>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <string name="Description"></string>
+      <bool name="ExecuteWithStudioRun">false</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="IsPhysicsEnvironmentalThrottled">true</bool>
+      <bool name="IsSleepAllowed">true</bool>
+      <int name="NumberOfPlayers">0</int>
+      <bool name="DefinesCapabilities">false</bool>
+      <double name="SimulateSecondsLag">0</double>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <bool name="ThrottlePhysicsToRealtime">true</bool>
+      <double name="Timeout">10</double>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b4</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="UGCAvatarService" referent="79">
+    <Properties>
+      <string name="Name">UGCAvatarService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b5</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="VideoService" referent="80">
+    <Properties>
+      <string name="Name">VideoService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003da</UniqueId>
+    </Properties>
+  </Item>
+  <Item class="VoiceChatService" referent="81">
+    <Properties>
+      <string name="Name">VoiceChatService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <token name="DefaultDistanceAttenuation">0</token>
+      <bool name="EnableDefaultVoice">true</bool>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">7ae0e5570bbb7d4c0a5586bb000003b7</UniqueId>
+      <token name="UseAudioApi">2</token>
+    </Properties>
+  </Item>
+  <Item class="SerializationService" referent="82">
+    <Properties>
+      <string name="Name">SerializationService</string>
+      <BinaryString name="AttributesSerialize"></BinaryString>
+      <SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+      <UniqueId name="HistoryId">00000000000000000000000000000000</UniqueId>
+      <bool name="DefinesCapabilities">false</bool>
+      <int64 name="SourceAssetId">-1</int64>
+      <BinaryString name="Tags"></BinaryString>
+      <UniqueId name="UniqueId">1f0379dd5b8107880a56e26b0000080d</UniqueId>
+    </Properties>
+  </Item>
+  <SharedStrings>
+    <SharedString md5="rxNJufX5oaagQE3qNtzJSQ=="></SharedString>
+  </SharedStrings>
+</roblox>

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__baseplate-727-with-tags__roundtrip.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__baseplate-727-with-tags__roundtrip.snap
@@ -1,0 +1,3633 @@
+---
+source: rbx_xml/src/tests/mod.rs
+assertion_line: 42
+expression: "DomViewer::new().view_children(&roundtrip)"
+---
+- referent: referent-0
+  name: Workspace
+  class: Workspace
+  properties:
+    AirDensity:
+      Float32: 0.0012
+    AirTurbulenceIntensity:
+      Float32: 0
+    AllowThirdPartySales:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    AuthorityMode:
+      Enum: 1
+    AvatarUnificationMode:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    ClientAnimatorThrottling:
+      Enum: 0
+    CollisionGroupData:
+      BinaryString: AQEABP////8HRGVmYXVsdA==
+    CurrentCamera: referent-1
+    DistributedGameTime:
+      Float64: 0
+    EnableSLIMAvatars:
+      Enum: 0
+    ExplicitAutoJoints:
+      Bool: true
+    FallHeightEnabled:
+      Bool: true
+    FallenPartsDestroyHeight:
+      Float32: -500
+    FluidForces:
+      Enum: 0
+    GlobalWind:
+      Vector3:
+        - 0
+        - 0
+        - 0
+    Gravity:
+      Float32: 196.2
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IKControlConstraintSupport:
+      Enum: 0
+    ImprovedAnimationConstraint:
+      Enum: 0
+    ImprovedPhysicsReplication:
+      Enum: 0
+    LayeredClothingCacheOptimizations:
+      Enum: 0
+    LevelOfDetail:
+      Enum: 0
+    LuauTypeCheckMode:
+      Enum: 0
+    MeshPartHeadsAndAccessories:
+      Enum: 0
+    MeshStreamingAndImprovedLods:
+      Enum: 0
+    ModelMeshCFrame:
+      CFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+    ModelMeshData:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    ModelMeshSize:
+      Vector3:
+        - 0
+        - 0
+        - 0
+    ModelStreamingBehavior:
+      Enum: 0
+    ModelStreamingMode:
+      Enum: 0
+    NeedsPivotMigration:
+      Bool: false
+    NextGenerationReplication:
+      Enum: 0
+    PathfindingUseImprovedSearch:
+      Enum: 0
+    PhysicsSteppingMethod:
+      Enum: 0
+    PlayerCharacterDestroyBehavior:
+      Enum: 0
+    PlayerScriptsUseInputActionSystem:
+      Enum: 0
+    PrimalPhysicsSolver:
+      Enum: 0
+    PrimaryPart: "null"
+    RejectCharacterDeletions:
+      Enum: 0
+    RenderingCacheOptimizations:
+      Enum: 0
+    ReplicateInstanceDestroySetting:
+      Enum: 0
+    Retargeting:
+      Enum: 0
+    Sandboxed:
+      Bool: false
+    SandboxedInstanceMode:
+      Enum: 0
+    Scale:
+      Float32: 1
+    SignalBehavior:
+      Enum: 2
+    SlimHash:
+      len: 0
+      hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+    SourceAssetId:
+      Int64: -1
+    StreamOutBehavior:
+      Enum: 2
+    StreamingEnabled:
+      Bool: true
+    StreamingIntegrityMode:
+      Enum: 3
+    StreamingMinRadius:
+      Int32: 64
+    StreamingTargetRadius:
+      Int32: 1024
+    Tags:
+      Tags:
+        - hmmmm
+    TerrainWeldsFixed:
+      Bool: true
+    TouchEventsUseCollisionGroups:
+      Enum: 0
+    TouchesUseCollisionGroups:
+      Bool: false
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000002
+    UseFixedSimulation:
+      Enum: 0
+    UseNewLuauTypeSolver:
+      Enum: 2
+    ValidateEnabledProximityPrompt:
+      Enum: 0
+    WorldPivotData:
+      OptionalCFrame:
+        position:
+          - 0
+          - 0
+          - 0
+        orientation:
+          - - 1
+            - 0
+            - 0
+          - - 0
+            - 1
+            - 0
+          - - 0
+            - 0
+            - 1
+  children:
+    - referent: referent-1
+      name: Camera
+      class: Camera
+      properties:
+        Attributes:
+          Attributes: {}
+        CFrame:
+          CFrame:
+            position:
+              - -19.696095
+              - 14.091624
+              - -19.303886
+            orientation:
+              - - -0.7061509
+                - 0.31296578
+                - -0.6351404
+              - - 0.000000014901163
+                - 0.8970132
+                - 0.44200373
+              - - 0.7080614
+                - 0.31212133
+                - -0.63342667
+        CameraSubject: "null"
+        CameraType:
+          Enum: 0
+        Capabilities:
+          SecurityCapabilities: 0
+        FieldOfView:
+          Float32: 70
+        FieldOfViewMode:
+          Enum: 0
+        Focus:
+          CFrame:
+            position:
+              - -18.425814
+              - 13.207617
+              - -18.037033
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        HeadLocked:
+          Bool: true
+        HeadScale:
+          Float32: 1
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b8
+        VRTiltAndRollEnabled:
+          Bool: false
+      children: []
+    - referent: referent-2
+      name: Baseplate
+      class: Part
+      properties:
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - -8
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 91
+            - 91
+            - 91
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        EnableFluidForces:
+          Bool: true
+        FormFactor:
+          Enum: 0
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 2048
+            - 16
+            - 2048
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags:
+            - atag
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b9
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-3
+          name: Texture
+          class: Texture
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 0
+                - 0
+                - 0
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            OffsetStudsU:
+              Float32: 0
+            OffsetStudsV:
+              Float32: 0
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            StudsPerTileU:
+              Float32: 8
+            StudsPerTileV:
+              Float32: 8
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxassetid://6372755229"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0.8
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ba
+            ZIndex:
+              Int32: 1
+          children: []
+    - referent: referent-4
+      name: Terrain
+      class: Terrain
+      properties:
+        AcquisitionMethod:
+          Enum: 0
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 4
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 163
+            - 162
+            - 165
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        Decoration:
+          Bool: true
+        EnableFluidForces:
+          Bool: true
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        GrassLength:
+          Float32: 0.7
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialColors:
+          MaterialColors:
+            Grass:
+              - 111
+              - 126
+              - 62
+            Slate:
+              - 88
+              - 89
+              - 86
+            Concrete:
+              - 152
+              - 152
+              - 152
+            Brick:
+              - 138
+              - 97
+              - 73
+            Sand:
+              - 207
+              - 203
+              - 167
+            WoodPlanks:
+              - 172
+              - 148
+              - 108
+            Rock:
+              - 99
+              - 100
+              - 102
+            Glacier:
+              - 221
+              - 228
+              - 229
+            Snow:
+              - 235
+              - 253
+              - 255
+            Sandstone:
+              - 148
+              - 124
+              - 95
+            Mud:
+              - 121
+              - 112
+              - 98
+            Basalt:
+              - 75
+              - 74
+              - 74
+            Ground:
+              - 140
+              - 130
+              - 104
+            CrackedLava:
+              - 255
+              - 24
+              - 67
+            Asphalt:
+              - 80
+              - 84
+              - 84
+            Cobblestone:
+              - 134
+              - 134
+              - 118
+            Ice:
+              - 204
+              - 210
+              - 223
+            LeafyGrass:
+              - 106
+              - 134
+              - 64
+            Salt:
+              - 255
+              - 255
+              - 254
+            Limestone:
+              - 255
+              - 243
+              - 192
+            Pavement:
+              - 143
+              - 144
+              - 135
+        MaterialVariant:
+          String: ""
+        Materials:
+          len: 0
+          hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+        PhysicsGrid:
+          BinaryString: AgMAAAAAAAAAAAAAAAA=
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Size:
+          Vector3:
+            - 2044
+            - 252
+            - 2044
+        SmoothGrid:
+          BinaryString: AQU=
+        SmoothVoxelsUpgraded:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 3
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bb
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        WaterColor:
+          Color3:
+            - 0.04705883
+            - 0.32941177
+            - 0.36078432
+        WaterReflectance:
+          Float32: 1
+        WaterTransparency:
+          Float32: 0.3
+        WaterWaveSize:
+          Float32: 0.15
+        WaterWaveSpeed:
+          Float32: 10
+      children: []
+    - referent: referent-5
+      name: SpawnLocation
+      class: SpawnLocation
+      properties:
+        AllowTeamChangeOnTouch:
+          Bool: false
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - 0.5
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 163
+            - 162
+            - 165
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        Duration:
+          Int32: 0
+        EnableFluidForces:
+          Bool: true
+        Enabled:
+          Bool: true
+        FormFactor:
+          Enum: 1
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: false
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        Neutral:
+          Bool: true
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 12
+            - 1
+            - 12
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TeamColor:
+          BrickColor: 194
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bc
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-6
+          name: Decal
+          class: Decal
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxasset://textures/SpawnLocation.png"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bd
+            ZIndex:
+              Int32: 1
+          children: []
+    - referent: referent-7
+      name: Baseplate
+      class: Part
+      properties:
+        Anchored:
+          Bool: true
+        Attributes:
+          Attributes: {}
+        AudioCanCollide:
+          Bool: true
+        BackParamA:
+          Float32: -0.5
+        BackParamB:
+          Float32: 0.5
+        BackSurface:
+          Enum: 0
+        BackSurfaceInput:
+          Enum: 0
+        BottomParamA:
+          Float32: -0.5
+        BottomParamB:
+          Float32: 0.5
+        BottomSurface:
+          Enum: 0
+        BottomSurfaceInput:
+          Enum: 0
+        CFrame:
+          CFrame:
+            position:
+              - 0
+              - -8
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        CanCollide:
+          Bool: true
+        CanQuery:
+          Bool: true
+        CanTouch:
+          Bool: true
+        Capabilities:
+          SecurityCapabilities: 0
+        CastShadow:
+          Bool: true
+        CollisionGroup:
+          String: Default
+        CollisionGroupId:
+          Int32: 0
+        Color:
+          Color3uint8:
+            - 91
+            - 91
+            - 91
+        CustomPhysicalProperties:
+          PhysicalProperties: Default
+        EnableFluidForces:
+          Bool: true
+        FormFactor:
+          Enum: 0
+        FrontParamA:
+          Float32: -0.5
+        FrontParamB:
+          Float32: 0.5
+        FrontSurface:
+          Enum: 0
+        FrontSurfaceInput:
+          Enum: 0
+        HistoryId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b9
+        LeftParamA:
+          Float32: -0.5
+        LeftParamB:
+          Float32: 0.5
+        LeftSurface:
+          Enum: 0
+        LeftSurfaceInput:
+          Enum: 0
+        Locked:
+          Bool: true
+        Massless:
+          Bool: false
+        Material:
+          Enum: 256
+        MaterialVariant:
+          String: ""
+        PivotOffset:
+          CFrame:
+            position:
+              - 0
+              - 0
+              - 0
+            orientation:
+              - - 1
+                - 0
+                - 0
+              - - 0
+                - 1
+                - 0
+              - - 0
+                - 0
+                - 1
+        Reflectance:
+          Float32: 0
+        RightParamA:
+          Float32: -0.5
+        RightParamB:
+          Float32: 0.5
+        RightSurface:
+          Enum: 0
+        RightSurfaceInput:
+          Enum: 0
+        RootPriority:
+          Int32: 0
+        RotVelocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        Sandboxed:
+          Bool: false
+        Shape:
+          Enum: 1
+        Size:
+          Vector3:
+            - 2048
+            - 16
+            - 2048
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags:
+            - atag
+            - anothertag
+        TopParamA:
+          Float32: -0.5
+        TopParamB:
+          Float32: 0.5
+        TopSurface:
+          Enum: 0
+        TopSurfaceInput:
+          Enum: 0
+        Transparency:
+          Float32: 0
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000008b3
+        Velocity:
+          Vector3:
+            - 0
+            - 0
+            - 0
+      children:
+        - referent: referent-8
+          name: Texture
+          class: Texture
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color3:
+              Color3:
+                - 0
+                - 0
+                - 0
+            Face:
+              Enum: 1
+            HistoryId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ba
+            MetalnessMapContent:
+              Content: None
+            NormalMapContent:
+              Content: None
+            OffsetStudsU:
+              Float32: 0
+            OffsetStudsV:
+              Float32: 0
+            Rotation:
+              Float32: 0
+            RoughnessMapContent:
+              Content: None
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            StudsPerTileU:
+              Float32: 8
+            StudsPerTileV:
+              Float32: 8
+            Tags:
+              Tags: []
+            TextureContent:
+              Content:
+                Uri: "rbxassetid://6372755229"
+            TexturePack:
+              ContentId: ""
+            TexturePackMetadata:
+              String: ""
+            Transparency:
+              Float32: 0.8
+            UVOffset:
+              Vector2:
+                - 0
+                - 0
+            UVScale:
+              Vector2:
+                - 1
+                - 1
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000008b4
+            ZIndex:
+              Int32: 1
+          children: []
+- referent: referent-9
+  name: Instance
+  class: TimerService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000338
+  children: []
+- referent: referent-10
+  name: CollectionService
+  class: CollectionService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000339
+  children: []
+- referent: referent-11
+  name: SoundService
+  class: SoundService
+  properties:
+    AcousticSimulationEnabled:
+      Bool: false
+    AmbientReverb:
+      Enum: 0
+    Attributes:
+      Attributes: {}
+    AudioApiByDefault:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterSoundsUseNewApi:
+      Enum: 0
+    DefaultListenerLocation:
+      Enum: 3
+    DistanceFactor:
+      Float32: 3.33
+    DopplerScale:
+      Float32: 1
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsNewExpForAudioApiByDefault:
+      Bool: false
+    RespectFilteringEnabled:
+      Bool: true
+    RolloffScale:
+      Float32: 1
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000033a
+    VolumetricAudio:
+      Enum: 1
+  children: []
+- referent: referent-12
+  name: VideoCaptureService
+  class: VideoCaptureService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000346
+  children: []
+- referent: referent-13
+  name: NonReplicatedCSGDictionaryService
+  class: NonReplicatedCSGDictionaryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000347
+  children: []
+- referent: referent-14
+  name: CSGDictionaryService
+  class: CSGDictionaryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000348
+  children: []
+- referent: referent-15
+  name: Chat
+  class: Chat
+  properties:
+    Attributes:
+      Attributes: {}
+    BubbleChatEnabled:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsAutoMigrated:
+      Bool: true
+    LoadDefaultChat:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000034e
+  children: []
+- referent: referent-16
+  name: Players
+  class: Players
+  properties:
+    Attributes:
+      Attributes: {}
+    BanningEnabled:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterAutoLoads:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxPlayers:
+      Int32: 60
+    PreferredPlayers:
+      Int32: 60
+    RespawnTime:
+      Float32: 3
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000350
+    UseStrafingAnimations:
+      Bool: false
+  children: []
+- referent: referent-17
+  name: ReplicatedFirst
+  class: ReplicatedFirst
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000353
+  children: []
+- referent: referent-18
+  name: TweenService
+  class: TweenService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000355
+  children: []
+- referent: referent-19
+  name: MaterialService
+  class: MaterialService
+  properties:
+    AsphaltName:
+      String: Asphalt
+    Attributes:
+      Attributes: {}
+    BasaltName:
+      String: Basalt
+    BrickName:
+      String: Brick
+    Capabilities:
+      SecurityCapabilities: 0
+    CardboardName:
+      String: Cardboard
+    CarpetName:
+      String: Carpet
+    CeramicTilesName:
+      String: CeramicTiles
+    ClayRoofTilesName:
+      String: ClayRoofTiles
+    CobblestoneName:
+      String: Cobblestone
+    ConcreteName:
+      String: Concrete
+    CorrodedMetalName:
+      String: CorrodedMetal
+    CrackedLavaName:
+      String: CrackedLava
+    DiamondPlateName:
+      String: DiamondPlate
+    FabricName:
+      String: Fabric
+    FoilName:
+      String: Foil
+    GlacierName:
+      String: Glacier
+    GraniteName:
+      String: Granite
+    GrassName:
+      String: Grass
+    GroundName:
+      String: Ground
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IceName:
+      String: Ice
+    LeafyGrassName:
+      String: LeafyGrass
+    LeatherName:
+      String: Leather
+    LimestoneName:
+      String: Limestone
+    MarbleName:
+      String: Marble
+    MetalName:
+      String: Metal
+    MudName:
+      String: Mud
+    PavementName:
+      String: Pavement
+    PebbleName:
+      String: Pebble
+    PlasterName:
+      String: Plaster
+    PlasticName:
+      String: Plastic
+    RockName:
+      String: Rock
+    RoofShinglesName:
+      String: RoofShingles
+    RubberName:
+      String: Rubber
+    SaltName:
+      String: Salt
+    SandName:
+      String: Sand
+    Sandboxed:
+      Bool: false
+    SandstoneName:
+      String: Sandstone
+    SlateName:
+      String: Slate
+    SmoothPlasticName:
+      String: SmoothPlastic
+    SnowName:
+      String: Snow
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000356
+    Use2022MaterialsXml:
+      Bool: true
+    WoodName:
+      String: Wood
+    WoodPlanksName:
+      String: WoodPlanks
+  children: []
+- referent: referent-20
+  name: TextChatService
+  class: TextChatService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    ChatTranslationFTUXShown:
+      Bool: true
+    ChatTranslationToggleEnabled:
+      Bool: false
+    ChatVersion:
+      Enum: 1
+    CreateDefaultCommands:
+      Bool: true
+    CreateDefaultTextChannels:
+      Bool: true
+    HasSeenDeprecationDialog:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsLegacyChatDisabled:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000357
+  children:
+    - referent: referent-21
+      name: ChatWindowConfiguration
+      class: ChatWindowConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0.3
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HeightScale:
+          Float32: 1
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        HorizontalAlignment:
+          Enum: 1
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 0.5
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c7
+        VerticalAlignment:
+          Enum: 1
+        WidthScale:
+          Float32: 1
+      children: []
+    - referent: referent-22
+      name: ChatInputBarConfiguration
+      class: ChatInputBarConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        AutocompleteEnabled:
+          Bool: true
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0.2
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        KeyboardKeyCode:
+          Enum: 47
+        PlaceholderColor3:
+          Color3:
+            - 0.69803923
+            - 0.69803923
+            - 0.69803923
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TargetTextChannel: "null"
+        TextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 0.5
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c8
+      children: []
+    - referent: referent-23
+      name: BubbleChatConfiguration
+      class: BubbleChatConfiguration
+      properties:
+        AdorneeName:
+          String: HumanoidRootPart
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.98039216
+            - 0.98039216
+            - 0.98039216
+        BackgroundTransparency:
+          Float64: 0.1
+        BubbleDuration:
+          Float32: 15
+        BubblesSpacing:
+          Float32: 6
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        Font:
+          Enum: 47
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Medium
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Medium.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        LocalPlayerStudsOffset:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        MaxBubbles:
+          Float32: 3
+        MaxDistance:
+          Float32: 100
+        MinimizeDistance:
+          Float32: 40
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TailVisible:
+          Bool: true
+        TextColor3:
+          Color3:
+            - 0.22352941
+            - 0.23137255
+            - 0.23921569
+        TextSize:
+          Int64: 20
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c9
+        VerticalStudsOffset:
+          Float32: 0
+      children:
+        - referent: referent-24
+          name: UIGradient
+          class: UIGradient
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            Color:
+              ColorSequence:
+                keypoints:
+                  - time: 0
+                    color:
+                      - 1
+                      - 1
+                      - 1
+                  - time: 1
+                    color:
+                      - 1
+                      - 1
+                      - 1
+            Enabled:
+              Bool: false
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Offset:
+              Vector2:
+                - 0
+                - 0
+            Rotation:
+              Float32: 0
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            Transparency:
+              NumberSequence:
+                keypoints:
+                  - time: 0
+                    value: 0
+                    envelope: 0
+                  - time: 1
+                    value: 0
+                    envelope: 0
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ca
+          children: []
+        - referent: referent-25
+          name: ImageLabel
+          class: ImageLabel
+          properties:
+            Active:
+              Bool: false
+            AnchorPoint:
+              Vector2:
+                - 0
+                - 0
+            Attributes:
+              Attributes: {}
+            AutoLocalize:
+              Bool: true
+            AutomaticSize:
+              Enum: 0
+            BackgroundColor3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            BackgroundTransparency:
+              Float32: 0
+            BorderColor3:
+              Color3:
+                - 0.10588236
+                - 0.16470589
+                - 0.20784315
+            BorderMode:
+              Enum: 0
+            BorderSizePixel:
+              Int32: 1
+            Capabilities:
+              SecurityCapabilities: 0
+            ClipsDescendants:
+              Bool: false
+            Draggable:
+              Bool: false
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            ImageColor3:
+              Color3:
+                - 1
+                - 1
+                - 1
+            ImageContent:
+              Content: None
+            ImageRectOffset:
+              Vector2:
+                - 0
+                - 0
+            ImageRectSize:
+              Vector2:
+                - 0
+                - 0
+            ImageTransparency:
+              Float32: 0
+            InputSink:
+              Enum: 0
+            Interactable:
+              Bool: true
+            LayoutOrder:
+              Int32: 0
+            NextSelectionDown: "null"
+            NextSelectionLeft: "null"
+            NextSelectionRight: "null"
+            NextSelectionUp: "null"
+            Position:
+              UDim2:
+                - - 0
+                  - 0
+                - - 0
+                  - 0
+            ResampleMode:
+              Enum: 0
+            RootLocalizationTable: "null"
+            Rotation:
+              Float32: 0
+            Sandboxed:
+              Bool: false
+            ScaleType:
+              Enum: 0
+            Selectable:
+              Bool: false
+            SelectionBehaviorDown:
+              Enum: 0
+            SelectionBehaviorLeft:
+              Enum: 0
+            SelectionBehaviorRight:
+              Enum: 0
+            SelectionBehaviorUp:
+              Enum: 0
+            SelectionGroup:
+              Bool: false
+            SelectionImageObject: "null"
+            SelectionOrder:
+              Int32: 0
+            Size:
+              UDim2:
+                - - 0
+                  - 100
+                - - 0
+                  - 100
+            SizeConstraint:
+              Enum: 0
+            SliceCenter:
+              Rect:
+                - - 0
+                  - 0
+                - - 0
+                  - 0
+            SliceScale:
+              Float32: 1
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TileSize:
+              UDim2:
+                - - 1
+                  - 0
+                - - 1
+                  - 0
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cb
+            Visible:
+              Bool: true
+            ZIndex:
+              Int32: 1
+          children: []
+        - referent: referent-26
+          name: UICorner
+          class: UICorner
+          properties:
+            Attributes:
+              Attributes: {}
+            BottomLeftRadius:
+              UDim:
+                - 0
+                - 12
+            BottomRightRadius:
+              UDim:
+                - 0
+                - 12
+            Capabilities:
+              SecurityCapabilities: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            TopLeftRadius:
+              UDim:
+                - 0
+                - 12
+            TopRightRadius:
+              UDim:
+                - 0
+                - 12
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cc
+          children: []
+        - referent: referent-27
+          name: UIPadding
+          class: UIPadding
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            PaddingBottom:
+              UDim:
+                - 0
+                - 8
+            PaddingLeft:
+              UDim:
+                - 0
+                - 8
+            PaddingRight:
+              UDim:
+                - 0
+                - 8
+            PaddingTop:
+              UDim:
+                - 0
+                - 8
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7ae0e5570bbb7d4c0a5586bb000003cd
+          children: []
+    - referent: referent-28
+      name: ChannelTabsConfiguration
+      class: ChannelTabsConfiguration
+      properties:
+        Attributes:
+          Attributes: {}
+        BackgroundColor3:
+          Color3:
+            - 0.09803922
+            - 0.105882354
+            - 0.11372549
+        BackgroundTransparency:
+          Float64: 0
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: false
+        FontFace:
+          Font:
+            family: "rbxasset://fonts/families/BuilderSans.json"
+            weight: Bold
+            style: Normal
+            cachedFaceId: "rbxasset://fonts/BuilderSans-Bold.otf"
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        HoverBackgroundColor3:
+          Color3:
+            - 0.49019608
+            - 0.49019608
+            - 0.49019608
+        Sandboxed:
+          Bool: false
+        SelectedTabTextColor3:
+          Color3:
+            - 1
+            - 1
+            - 1
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        TextColor3:
+          Color3:
+            - 0.6862745
+            - 0.6862745
+            - 0.6862745
+        TextSize:
+          Int64: 18
+        TextStrokeColor3:
+          Color3:
+            - 0
+            - 0
+            - 0
+        TextStrokeTransparency:
+          Float64: 1
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ce
+      children: []
+- referent: referent-29
+  name: PermissionsService
+  class: PermissionsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7edfffb096708e650a5620f100000e07
+  children: []
+- referent: referent-30
+  name: PlayerEmulatorService
+  class: PlayerEmulatorService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    CustomPoliciesEnabled:
+      Bool: false
+    EmulatedCountryCode:
+      String: ""
+    EmulatedGameLocale:
+      String: ""
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    PlayerEmulationEnabled:
+      Bool: false
+    PseudolocalizationEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SerializedEmulatedPolicyInfo:
+      BinaryString: ""
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    TextElongationFactor:
+      Int32: 0
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035a
+  children: []
+- referent: referent-31
+  name: StudioData
+  class: StudioData
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    EnableScriptCollabByDefaultOnLoad:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035d
+  children: []
+- referent: referent-32
+  name: StarterPlayer
+  class: StarterPlayer
+  properties:
+    AllowCustomAnimations:
+      Bool: true
+    Attributes:
+      Attributes: {}
+    AutoJumpEnabled:
+      Bool: true
+    AvatarJointUpgrade:
+      Enum: 2
+    CameraMaxZoomDistance:
+      Float32: 128
+    CameraMinZoomDistance:
+      Float32: 0.5
+    CameraMode:
+      Enum: 0
+    Capabilities:
+      SecurityCapabilities: 0
+    CharacterBreakJointsOnDeath:
+      Bool: false
+    CharacterJumpHeight:
+      Float32: 7.2
+    CharacterJumpPower:
+      Float32: 50
+    CharacterMaxSlopeAngle:
+      Float32: 89
+    CharacterUseJumpPower:
+      Bool: false
+    CharacterWalkSpeed:
+      Float32: 16
+    ClassicDeath:
+      Bool: true
+    CreateDefaultPlayerModule:
+      Bool: true
+    DevCameraOcclusionMode:
+      Enum: 0
+    DevComputerCameraMovementMode:
+      Enum: 0
+    DevComputerMovementMode:
+      Enum: 0
+    DevTouchCameraMovementMode:
+      Enum: 0
+    DevTouchMovementMode:
+      Enum: 0
+    EnableDynamicHeads:
+      Enum: 0
+    EnableMouseLockOption:
+      Bool: true
+    GameSettingsAssetIDFace:
+      Int64: 0
+    GameSettingsAssetIDHead:
+      Int64: 0
+    GameSettingsAssetIDLeftArm:
+      Int64: 0
+    GameSettingsAssetIDLeftLeg:
+      Int64: 0
+    GameSettingsAssetIDPants:
+      Int64: 0
+    GameSettingsAssetIDRightArm:
+      Int64: 0
+    GameSettingsAssetIDRightLeg:
+      Int64: 0
+    GameSettingsAssetIDShirt:
+      Int64: 0
+    GameSettingsAssetIDTeeShirt:
+      Int64: 0
+    GameSettingsAssetIDTorso:
+      Int64: 0
+    GameSettingsAvatar:
+      Enum: 1
+    GameSettingsR15Collision:
+      Enum: 0
+    GameSettingsScaleRangeBodyType:
+      NumberRange:
+        - 0
+        - 1
+    GameSettingsScaleRangeHead:
+      NumberRange:
+        - 0.95
+        - 1
+    GameSettingsScaleRangeHeight:
+      NumberRange:
+        - 0.9
+        - 1.05
+    GameSettingsScaleRangeProportion:
+      NumberRange:
+        - 0
+        - 1
+    GameSettingsScaleRangeWidth:
+      NumberRange:
+        - 0.7
+        - 1
+    HealthDisplayDistance:
+      Float32: 100
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LoadCharacterAppearance:
+      Bool: true
+    LoadCharacterLayeredClothing:
+      Enum: 0
+    LuaCharacterController:
+      Enum: 0
+    NameDisplayDistance:
+      Float32: 100
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000035f
+    UserEmotesEnabled:
+      Bool: true
+  children:
+    - referent: referent-33
+      name: StarterPlayerScripts
+      class: StarterPlayerScripts
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003bf
+      children: []
+    - referent: referent-34
+      name: StarterCharacterScripts
+      class: StarterCharacterScripts
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c0
+      children: []
+- referent: referent-35
+  name: StarterPack
+  class: StarterPack
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000360
+  children: []
+- referent: referent-36
+  name: StarterGui
+  class: StarterGui
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    ClipsDescendantsSupportsRotation:
+      Enum: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    ResetPlayerGuiOnSpawn:
+      Bool: true
+    RtlTextSupport:
+      Enum: 0
+    Sandboxed:
+      Bool: false
+    ScreenOrientation:
+      Enum: 4
+    ShowDevelopmentGui:
+      Bool: true
+    SourceAssetId:
+      Int64: -1
+    StudioDefaultStyleSheet: "null"
+    StudioInsertWidgetLayerCollectorAutoLinkStyleSheet: "null"
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000361
+    VirtualCursorMode:
+      Enum: 0
+  children: []
+- referent: referent-37
+  name: LocalizationService
+  class: LocalizationService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000363
+  children: []
+- referent: referent-38
+  name: Teleport Service
+  class: TeleportService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000367
+  children: []
+- referent: referent-39
+  name: PhysicsService
+  class: PhysicsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000369
+  children: []
+- referent: referent-40
+  name: InsertService
+  class: InsertService
+  properties:
+    AllowInsertFreeModels:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036c
+  children:
+    - referent: referent-41
+      name: InsertionHash
+      class: StringValue
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c1
+        Value:
+          String: "{a4b4fc84-d3fa-4580-b9d0-98390afa7f7f}"
+      children: []
+- referent: referent-42
+  name: GamePassService
+  class: GamePassService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036d
+  children: []
+- referent: referent-43
+  name: Debris
+  class: Debris
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxItems:
+      Int32: 1000
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036e
+  children: []
+- referent: referent-44
+  name: CookiesService
+  class: CookiesService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000036f
+  children: []
+- referent: referent-45
+  name: Selection
+  class: Selection
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000370
+  children: []
+- referent: referent-46
+  name: VRService
+  class: VRService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutomaticScaling:
+      Enum: 0
+    AvatarGestures:
+      Bool: false
+    Capabilities:
+      SecurityCapabilities: 0
+    ControllerModels:
+      Enum: 1
+    FadeOutViewOnCollision:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LaserPointer:
+      Enum: 1
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000374
+  children: []
+- referent: referent-47
+  name: ContextActionService
+  class: ContextActionService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000375
+  children: []
+- referent: referent-48
+  name: Instance
+  class: ScriptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000376
+  children: []
+- referent: referent-49
+  name: AssetService
+  class: AssetService
+  properties:
+    AllowInsertFreeAssets:
+      Bool: false
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000377
+  children: []
+- referent: referent-50
+  name: TouchInputService
+  class: TouchInputService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000379
+  children: []
+- referent: referent-51
+  name: AvatarSettings
+  class: AvatarSettings
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000037f
+  children:
+    - referent: referent-52
+      name: DefaultAvatarRules
+      class: AvatarRules
+      properties:
+        Attributes:
+          Attributes: {}
+        AvatarType:
+          Enum: 1
+        Capabilities:
+          SecurityCapabilities: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7edfffb096708e650a5620f100000e00
+      children:
+        - referent: referent-53
+          name: AvatarBodyRules
+          class: AvatarBodyRules
+          properties:
+            AppearanceMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            BuildMode:
+              Enum: 0
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomBodyBundleId:
+              Int64: 0
+            CustomBodyType:
+              Enum: 0
+            CustomBodyTypeScale:
+              NumberRange:
+                - 0
+                - 1
+            CustomEyebrowEnabled:
+              Bool: false
+            CustomEyebrowId:
+              Int64: 0
+            CustomEyelashEnabled:
+              Bool: false
+            CustomEyelashId:
+              Int64: 0
+            CustomFaceEnabled:
+              Bool: false
+            CustomFaceId:
+              Int64: 0
+            CustomHeadEnabled:
+              Bool: false
+            CustomHeadId:
+              Int64: 0
+            CustomHeadScale:
+              NumberRange:
+                - 0.95
+                - 1
+            CustomHeight:
+              NumberRange:
+                - 5.5
+                - 5.5
+            CustomHeightScale:
+              NumberRange:
+                - 0.9
+                - 1.05
+            CustomLeftArmEnabled:
+              Bool: false
+            CustomLeftArmId:
+              Int64: 0
+            CustomLeftLegEnabled:
+              Bool: false
+            CustomLeftLegId:
+              Int64: 0
+            CustomMoodEnabled:
+              Bool: false
+            CustomMoodId:
+              Int64: 0
+            CustomProportionsScale:
+              NumberRange:
+                - 0
+                - 1
+            CustomRightArmEnabled:
+              Bool: false
+            CustomRightArmId:
+              Int64: 0
+            CustomRightLegEnabled:
+              Bool: false
+            CustomRightLegId:
+              Int64: 0
+            CustomTorsoEnabled:
+              Bool: false
+            CustomTorsoId:
+              Int64: 0
+            CustomWidthScale:
+              NumberRange:
+                - 0.7
+                - 1
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            KeepPlayerHead:
+              Bool: true
+            Sandboxed:
+              Bool: false
+            ScaleMode:
+              Enum: 0
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e01
+          children: []
+        - referent: referent-54
+          name: AvatarCollisionRules
+          class: AvatarCollisionRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CollisionMode:
+              Enum: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            HitAndTouchDetectionMode:
+              Enum: 0
+            LegacyCollisionMode:
+              Enum: 1
+            Sandboxed:
+              Bool: false
+            SingleColliderSize:
+              Vector3:
+                - 2
+                - 3
+                - 1
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e02
+          children: []
+        - referent: referent-55
+          name: AvatarAbilityRules
+          class: AvatarAbilityRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CharacterControllerMode:
+              Enum: 0
+            EnableClimbing:
+              Bool: true
+            EnableCrouching:
+              Bool: true
+            EnableFallingDown:
+              Bool: true
+            EnableGettingUp:
+              Bool: true
+            EnableHolding:
+              Bool: true
+            EnableJumping:
+              Bool: true
+            EnableReaching:
+              Bool: true
+            EnableRunning:
+              Bool: true
+            EnableSitting:
+              Bool: true
+            EnableSprinting:
+              Bool: true
+            EnableStrafing:
+              Bool: true
+            EnableSwimming:
+              Bool: true
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e03
+          children: []
+        - referent: referent-56
+          name: AvatarAnimationRules
+          class: AvatarAnimationRules
+          properties:
+            AnimationClipsMode:
+              Enum: 0
+            AnimationPacksMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomClimbAnimationEnabled:
+              Bool: false
+            CustomClimbAnimationId:
+              Int64: 0
+            CustomFallAnimationEnabled:
+              Bool: false
+            CustomFallAnimationId:
+              Int64: 0
+            CustomIdleAlt1AnimationEnabled:
+              Bool: false
+            CustomIdleAlt1AnimationId:
+              Int64: 0
+            CustomIdleAlt2AnimationEnabled:
+              Bool: false
+            CustomIdleAlt2AnimationId:
+              Int64: 0
+            CustomIdleAnimationEnabled:
+              Bool: false
+            CustomIdleAnimationId:
+              Int64: 0
+            CustomJumpAnimationEnabled:
+              Bool: false
+            CustomJumpAnimationId:
+              Int64: 0
+            CustomRunAnimationEnabled:
+              Bool: false
+            CustomRunAnimationId:
+              Int64: 0
+            CustomSwimAnimationEnabled:
+              Bool: false
+            CustomSwimAnimationId:
+              Int64: 0
+            CustomSwimIdleAnimationEnabled:
+              Bool: false
+            CustomSwimIdleAnimationId:
+              Int64: 0
+            CustomWalkAnimationEnabled:
+              Bool: false
+            CustomWalkAnimationId:
+              Int64: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e04
+          children: []
+        - referent: referent-57
+          name: AvatarAccessoryRules
+          class: AvatarAccessoryRules
+          properties:
+            AccessoryMode:
+              Enum: 0
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            CustomAccessoryMode:
+              Enum: 0
+            CustomBackAccessoryEnabled:
+              Bool: false
+            CustomBackAccessoryId:
+              Int64: 0
+            CustomFaceAccessoryEnabled:
+              Bool: false
+            CustomFaceAccessoryId:
+              Int64: 0
+            CustomFrontAccessoryEnabled:
+              Bool: false
+            CustomFrontAccessoryId:
+              Int64: 0
+            CustomHairAccessoryEnabled:
+              Bool: false
+            CustomHairAccessoryId:
+              Int64: 0
+            CustomHeadAccessoryEnabled:
+              Bool: false
+            CustomHeadAccessoryId:
+              Int64: 0
+            CustomNeckAccessoryEnabled:
+              Bool: false
+            CustomNeckAccessoryId:
+              Int64: 0
+            CustomShoulderAccessoryEnabled:
+              Bool: false
+            CustomShoulderAccessoryId:
+              Int64: 0
+            CustomWaistAccessoryEnabled:
+              Bool: false
+            CustomWaistAccessoryId:
+              Int64: 0
+            EnableSound:
+              Bool: true
+            EnableVFX:
+              Bool: true
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            LimitBounds:
+              Vector3:
+                - 0
+                - 0
+                - 0
+            LimitMethod:
+              Enum: 1
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e05
+          children: []
+        - referent: referent-58
+          name: AvatarClothingRules
+          class: AvatarClothingRules
+          properties:
+            Attributes:
+              Attributes: {}
+            Capabilities:
+              SecurityCapabilities: 0
+            ClothingMode:
+              Enum: 0
+            CustomClassicPantsAccessoryEnabled:
+              Bool: false
+            CustomClassicPantsAccessoryId:
+              Int64: 0
+            CustomClassicShirtsAccessoryEnabled:
+              Bool: false
+            CustomClassicShirtsAccessoryId:
+              Int64: 0
+            CustomClassicTShirtsAccessoryEnabled:
+              Bool: false
+            CustomClassicTShirtsAccessoryId:
+              Int64: 0
+            CustomClothingMode:
+              Enum: 0
+            CustomDressSkirtAccessoryEnabled:
+              Bool: false
+            CustomDressSkirtAccessoryId:
+              Int64: 0
+            CustomJacketAccessoryEnabled:
+              Bool: false
+            CustomJacketAccessoryId:
+              Int64: 0
+            CustomLeftShoesAccessoryEnabled:
+              Bool: false
+            CustomLeftShoesAccessoryId:
+              Int64: 0
+            CustomPantsAccessoryEnabled:
+              Bool: false
+            CustomPantsAccessoryId:
+              Int64: 0
+            CustomRightShoesAccessoryEnabled:
+              Bool: false
+            CustomRightShoesAccessoryId:
+              Int64: 0
+            CustomShirtAccessoryEnabled:
+              Bool: false
+            CustomShirtAccessoryId:
+              Int64: 0
+            CustomShortsAccessoryEnabled:
+              Bool: false
+            CustomShortsAccessoryId:
+              Int64: 0
+            CustomSweaterAccessoryEnabled:
+              Bool: false
+            CustomSweaterAccessoryId:
+              Int64: 0
+            CustomTShirtAccessoryEnabled:
+              Bool: false
+            CustomTShirtAccessoryId:
+              Int64: 0
+            HistoryId:
+              UniqueId: "00000000000000000000000000000000"
+            LimitBounds:
+              Vector3:
+                - 0
+                - 0
+                - 0
+            Sandboxed:
+              Bool: false
+            SourceAssetId:
+              Int64: -1
+            Tags:
+              Tags: []
+            UniqueId:
+              UniqueId: 7edfffb096708e650a5620f100000e06
+          children: []
+- referent: referent-59
+  name: Packages
+  class: Packages
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsDehydrated:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    ShellPackagesCount:
+      Int32: 0
+    SkippedInstancesCount:
+      Int32: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000383
+  children: []
+- referent: referent-60
+  name: GuidRegistryService
+  class: GuidRegistryService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000384
+  children: []
+- referent: referent-61
+  name: LuaWebService
+  class: LuaWebService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7edfffb096708e650a5620f100000f22
+  children: []
+- referent: referent-62
+  name: ProcessInstancePhysicsService
+  class: ProcessInstancePhysicsService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 1f0379dd5b8107880a56e26b0000038c
+  children: []
+- referent: referent-63
+  name: ReplicatedStorage
+  class: ReplicatedStorage
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000398
+  children: []
+- referent: referent-64
+  name: ServerScriptService
+  class: ServerScriptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LoadStringEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb00000399
+  children: []
+- referent: referent-65
+  name: ServerStorage
+  class: ServerStorage
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb0000039a
+  children: []
+- referent: referent-66
+  name: ServiceVisibilityService
+  class: ServiceVisibilityService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HiddenServices:
+      BinaryString: AAAAAA==
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003a1
+    VisibleServices:
+      BinaryString: AAAAAA==
+  children: []
+- referent: referent-67
+  name: HttpService
+  class: HttpService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    HttpEnabled:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003ac
+  children: []
+- referent: referent-68
+  name: DataStoreService
+  class: DataStoreService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutomaticRetry:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LegacyNamingScheme:
+      Bool: false
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003af
+  children: []
+- referent: referent-69
+  name: Lighting
+  class: Lighting
+  properties:
+    Ambient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Attributes:
+      Attributes:
+        RBX_LightingTechnologyUnifiedMigration:
+          Bool: true
+        RBX_OriginalTechnologyOnFileLoad:
+          Int32: 3
+    Brightness:
+      Float32: 3
+    Capabilities:
+      SecurityCapabilities: 0
+    ColorShift_Bottom:
+      Color3:
+        - 0
+        - 0
+        - 0
+    ColorShift_Top:
+      Color3:
+        - 0
+        - 0
+        - 0
+    EnvironmentDiffuseScale:
+      Float32: 1
+    EnvironmentSpecularScale:
+      Float32: 1
+    ExposureCompensation:
+      Float32: 0
+    ExtendLightRangeTo120:
+      Enum: 0
+    FogColor:
+      Color3:
+        - 0.75294125
+        - 0.75294125
+        - 0.75294125
+    FogEnd:
+      Float32: 100000
+    FogStart:
+      Float32: 0
+    GeographicLatitude:
+      Float32: 0
+    GlobalShadows:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    LightingStyle:
+      Enum: 1
+    OutdoorAmbient:
+      Color3:
+        - 0.27450982
+        - 0.27450982
+        - 0.27450982
+    Outlines:
+      Bool: false
+    PrioritizeLightingQuality:
+      Bool: true
+    Sandboxed:
+      Bool: false
+    ShadowSoftness:
+      Float32: 0.2
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    Technology:
+      Enum: 3
+    TimeOfDay:
+      String: "14:30:00"
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b0
+  children:
+    - referent: referent-70
+      name: Sky
+      class: Sky
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        CelestialBodiesShown:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        MoonAngularSize:
+          Float32: 11
+        MoonTextureContent:
+          Content:
+            Uri: "rbxassetid://6444320592"
+        Sandboxed:
+          Bool: false
+        SkyboxBackContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxDownContent:
+          Content:
+            Uri: "rbxassetid://6444884785"
+        SkyboxFrontContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxLeftContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxOrientation:
+          Vector3:
+            - 0
+            - 0
+            - 0
+        SkyboxRightContent:
+          Content:
+            Uri: "rbxassetid://6444884337"
+        SkyboxUpContent:
+          Content:
+            Uri: "rbxassetid://6412503613"
+        SourceAssetId:
+          Int64: 332039975
+        StarCount:
+          Int32: 3000
+        SunAngularSize:
+          Float32: 11
+        SunTextureContent:
+          Content:
+            Uri: "rbxassetid://6196665106"
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c2
+      children: []
+    - referent: referent-71
+      name: SunRays
+      class: SunRaysEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Intensity:
+          Float32: 0.01
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Spread:
+          Float32: 0.1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c3
+      children: []
+    - referent: referent-72
+      name: Atmosphere
+      class: Atmosphere
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Color:
+          Color3:
+            - 0.78039217
+            - 0.78039217
+            - 0.78039217
+        Decay:
+          Color3:
+            - 0.41568628
+            - 0.4392157
+            - 0.49019608
+        Density:
+          Float32: 0.3
+        Glare:
+          Float32: 0
+        Haze:
+          Float32: 0
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Offset:
+          Float32: 0.25
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c4
+      children: []
+    - referent: referent-73
+      name: Bloom
+      class: BloomEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: true
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        Intensity:
+          Float32: 1
+        Sandboxed:
+          Bool: false
+        Size:
+          Float32: 24
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        Threshold:
+          Float32: 2
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c5
+      children: []
+    - referent: referent-74
+      name: DepthOfField
+      class: DepthOfFieldEffect
+      properties:
+        Attributes:
+          Attributes: {}
+        Capabilities:
+          SecurityCapabilities: 0
+        Enabled:
+          Bool: false
+        FarIntensity:
+          Float32: 0.1
+        FocusDistance:
+          Float32: 0.05
+        HistoryId:
+          UniqueId: "00000000000000000000000000000000"
+        InFocusRadius:
+          Float32: 30
+        NearIntensity:
+          Float32: 0.75
+        Sandboxed:
+          Bool: false
+        SourceAssetId:
+          Int64: -1
+        Tags:
+          Tags: []
+        UniqueId:
+          UniqueId: 7ae0e5570bbb7d4c0a5586bb000003c6
+      children: []
+- referent: referent-75
+  name: Instance
+  class: LodDataService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b1
+  children: []
+- referent: referent-76
+  name: ProximityPromptService
+  class: ProximityPromptService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    Enabled:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    MaxIndicatorsVisible:
+      Int32: 16
+    MaxPromptsVisible:
+      Int32: 16
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b2
+  children: []
+- referent: referent-77
+  name: Teams
+  class: Teams
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b3
+  children: []
+- referent: referent-78
+  name: TestService
+  class: TestService
+  properties:
+    Attributes:
+      Attributes: {}
+    AutoRuns:
+      Bool: true
+    Capabilities:
+      SecurityCapabilities: 0
+    Description:
+      String: ""
+    ExecuteWithStudioRun:
+      Bool: false
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    IsPhysicsEnvironmentalThrottled:
+      Bool: true
+    IsSleepAllowed:
+      Bool: true
+    NumberOfPlayers:
+      Int32: 0
+    Sandboxed:
+      Bool: false
+    SimulateSecondsLag:
+      Float64: 0
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    ThrottlePhysicsToRealtime:
+      Bool: true
+    Timeout:
+      Float64: 10
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b4
+  children: []
+- referent: referent-79
+  name: UGCAvatarService
+  class: UGCAvatarService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b5
+  children: []
+- referent: referent-80
+  name: VideoService
+  class: VideoService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003da
+  children: []
+- referent: referent-81
+  name: VoiceChatService
+  class: VoiceChatService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    DefaultDistanceAttenuation:
+      Enum: 0
+    EnableDefaultVoice:
+      Bool: true
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 7ae0e5570bbb7d4c0a5586bb000003b7
+    UseAudioApi:
+      Enum: 2
+  children: []
+- referent: referent-82
+  name: SerializationService
+  class: SerializationService
+  properties:
+    Attributes:
+      Attributes: {}
+    Capabilities:
+      SecurityCapabilities: 0
+    HistoryId:
+      UniqueId: "00000000000000000000000000000000"
+    Sandboxed:
+      Bool: false
+    SourceAssetId:
+      Int64: -1
+    Tags:
+      Tags: []
+    UniqueId:
+      UniqueId: 1f0379dd5b8107880a56e26b0000080d
+  children: []


### PR DESCRIPTION
This PR adds support to rbx_binary for decoding Tags blobs that are stored inside the SharedString index.

So far, this change has only been observed for binary files downloaded from the Roblox CDN. For example, from the following endpoints:
* `https://apis.roblox.com/asset-delivery-api/v1/assetId/{placeId}`
* `https://assetdelivery.roblox.com/v1/assetId/{placeId}`

I am not sure if rbx-dom should start encoding Tags this way. It doesn't seem necessary, so I'm erring on the side of not, but I'm interested in arguments for it. 
