### PR TITLE
Support arbitrarily ordered CFrame coordinates in XML format

### DIFF
--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* `CoordinateFrame` (`CFrame`) values are now deserialized independently of the order in which their component tags appear, and duplicate or unknown component tags are now rejected with a clear error.
 
 # 3.0.0 (2026-07-01)
 * Upgraded to `rbx_reflection` v3.0.0

--- a/rbx_xml/src/types/cframe.rs
+++ b/rbx_xml/src/types/cframe.rs
@@ -4,8 +4,8 @@ use rbx_dom_weak::types::CFrame;
 
 use crate::{
     core::XmlType,
-    deserializer_core::XmlEventReader,
-    error::{DecodeError, EncodeError},
+    deserializer_core::{XmlEventReader, XmlReadEvent},
+    error::{DecodeError, DecodeErrorKind, EncodeError},
     serializer_core::XmlEventWriter,
 };
 
@@ -40,11 +40,42 @@ impl XmlType for CFrame {
 
     fn read_xml<R: Read>(reader: &mut XmlEventReader<R>) -> Result<Self, DecodeError> {
         let mut value = CFrame::identity();
+        let mut seen = [false; TAG_NAMES.len()];
 
-        for &tag_name in &TAG_NAMES {
-            let component: f32 = reader.read_value_in_tag(tag_name)?;
+        // Older place files have been observed to serialize CFrame components
+        // out of order, so match each child by its tag name rather than
+        // assuming the canonical `TAG_NAMES` sequence. This lets those files
+        // round-trip instead of failing with an "unexpected XML event" error.
+        for _ in 0..TAG_NAMES.len() {
+            // Look at the next child's name without consuming it, so
+            // `read_value_in_tag` below can still read the whole element.
+            let tag_name = match reader.expect_peek()? {
+                XmlReadEvent::StartElement { name, .. } => name.local_name.clone(),
+                _ => {
+                    return Err(reader.error(DecodeErrorKind::InvalidContent(
+                        "expected a CoordinateFrame component element",
+                    )))
+                }
+            };
 
-            match tag_name {
+            let index = TAG_NAMES
+                .iter()
+                .position(|&candidate| candidate == tag_name)
+                .ok_or_else(|| {
+                    reader.error(DecodeErrorKind::InvalidContent(
+                        "unexpected element in CoordinateFrame",
+                    ))
+                })?;
+
+            if seen[index] {
+                return Err(reader.error(DecodeErrorKind::InvalidContent(
+                    "duplicate component in CoordinateFrame",
+                )));
+            }
+            seen[index] = true;
+
+            let component: f32 = reader.read_value_in_tag(&tag_name)?;
+            match TAG_NAMES[index] {
                 "X" => value.position.x = component,
                 "Y" => value.position.y = component,
                 "Z" => value.position.z = component,
@@ -88,5 +119,39 @@ mod test {
         );
 
         test_util::test_xml_round_trip(&test_input);
+    }
+
+    #[test]
+    fn reads_components_in_any_order() {
+        // The same CFrame as `round_trip`, but with the child components written
+        // in a non-canonical order, as older place files have been observed to
+        // do.
+        let expected = CFrame::new(
+            Vector3::new(123.0, 456.0, 789.0),
+            Matrix3 {
+                x: Vector3::new(987.0, 654.0, 432.0),
+                y: Vector3::new(210.0, 0.0, -12345.0),
+                z: Vector3::new(765.0, 234.0, 123123.0),
+            },
+        );
+
+        let source = r#"
+            <CoordinateFrame name="CFrame">
+                <R11>0</R11>
+                <Y>456</Y>
+                <X>123</X>
+                <R00>987</R00>
+                <Z>789</Z>
+                <R01>654</R01>
+                <R02>432</R02>
+                <R10>210</R10>
+                <R12>-12345</R12>
+                <R20>765</R20>
+                <R21>234</R21>
+                <R22>123123</R22>
+            </CoordinateFrame>
+        "#;
+
+        test_util::test_xml_deserialize(source, &expected);
     }
 }


### PR DESCRIPTION
# Problem

Still investigating which serializers created these places, but I've observed some cases where the ordering for CFrame coordinates isn't exactly what's expected.

I believe these shouldn't break the parser though, as these are named coordinates and shouldn't really be position dependent.

# Solution 

We still want to enforce the right number of tags and that every expected tag is there + only once. The suggested change accomplishes this by tracking which tags its seen and failing on truly incorrect inputs.