### PR TITLE
In `Int64ToContent` migration, convert negative Int64 values to Content::None in

### DIFF
--- a/rbx_reflection/CHANGELOG.md
+++ b/rbx_reflection/CHANGELOG.md
@@ -1,11 +1,18 @@
 # rbx_reflection Changelog
 
 ## Unreleased
+* Corrected migration `Int64ToContent` to convert any value below zero to `Content::None` ([#641])
+
+[#641]: https://github.com/rojo-rbx/rbx-dom/pull/641
+
+## 7.0.0 (2026-07-01)
 * Made `ReflectionDatabase` zero-copy. This involved removing `Cow`. ([#528])
 * Added support for one-to-many property migrations and added migrations for `UICorner.CornerRadius`. ([#612])
+* Added migration `Int64ToContent` for moving legacy ID properties to `Content` ([#628])
 
 [#528]: https://github.com/rojo-rbx/rbx-dom/pull/528
 [#612]: https://github.com/rojo-rbx/rbx-dom/pull/612
+[#628]: https://github.com/rojo-rbx/rbx-dom/pull/628
 
 ## 6.1.0 (2025-11-27)
 * Added `DataType::ty` to convert to `VariantType` infallibly. ([#540])

--- a/rbx_reflection/src/migration.rs
+++ b/rbx_reflection/src/migration.rs
@@ -241,7 +241,7 @@ impl PropertyMigration<'_> {
             }
             MigrationOperation::Int64ToContent => {
                 if let Variant::Int64(id) = input {
-                    if *id == 0 {
+                    if *id <= 0 {
                         Ok(Content::none().into())
                     } else {
                         Ok(Content::from_uri(format!("rbxassetid://{id}")).into())
@@ -288,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn int64_to_content_zero() {
+    fn int64_to_content_none() {
         use rbx_types::ContentType;
 
         let migration = serde_json::from_str::<PropertyMigration>(
@@ -306,10 +306,22 @@ mod tests {
                 panic!("expected Variant::Content, got Variant::{:?}", other.ty())
             }
         }
+
+        let new_value_2 = migration.perform(&Variant::Int64(-1)).unwrap();
+
+        match new_value_2 {
+            Variant::Content(content) => match content.value() {
+                ContentType::None => {}
+                other => panic!("expected ContentType::None, got {:?}", other),
+            },
+            other => {
+                panic!("expected Variant::Content, got Variant::{:?}", other.ty())
+            }
+        }
     }
 
     #[test]
-    fn int64_to_content_non_zero() {
+    fn int64_to_content_some() {
         use rbx_types::ContentType;
 
         let migration = serde_json::from_str::<PropertyMigration>(


### PR DESCRIPTION
`Instance.SourceAssetId` has a migration incoming to convert it to `Instance.SourceContent`. The default value of `SourceAssetId` is `-1`, but after speaking with Roblox the preferred conversion is to `Content::None` rather than `Content::Uri("rbxassetid://-1")`.

This changes the migration so that all negative values become `None`. I considered limiting it to _just_ `-1`, but I can't imagine a world where a negative value was both deliberate and not meant to represent `None` conceptually.