### PR TITLE
rbx_types: add Attributes.extend_from_reader

### DIFF
--- a/rbx_types/CHANGELOG.md
+++ b/rbx_types/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rbx_types Changelog
 
+# Unreleased
+* Added `Attributes::extend_from_reader` to extend an existing `Attributes` with values from a reader. ([#643])
+
 # 3.1.0 (2025-11-27)
 * Fixed `serde::Deserialize` implementations for `BinaryString`, `SharedString`, `NetAssetRef`, `Faces`, and `Axes` to properly utilize visitors. ([#563])
 * Added `CFrame::identity` convenience method to construct an identity CFrame. ([#567])

--- a/rbx_types/src/attributes/mod.rs
+++ b/rbx_types/src/attributes/mod.rs
@@ -17,7 +17,7 @@ use std::{
 
 use crate::{Error, Variant};
 
-use self::reader::read_attributes;
+use self::reader::extend_attributes_from_reader;
 use self::writer::write_attributes;
 
 pub(crate) use self::error::AttributeError;
@@ -42,9 +42,15 @@ impl Attributes {
 
     /// Reads from a serialized attributes string, and produces a new `Attributes` from it.
     pub fn from_reader<R: Read>(reader: R) -> Result<Self, Error> {
-        Ok(Attributes {
-            data: read_attributes(reader)?,
-        })
+        let mut attributes = Attributes::new();
+        extend_attributes_from_reader(&mut attributes, reader)?;
+        Ok(attributes)
+    }
+
+    /// Reads from a serialized attributes string, and extends `Self` with the deserialized attributes.
+    pub fn extend_from_reader<R: Read>(&mut self, reader: R) -> Result<(), Error> {
+        extend_attributes_from_reader(self, reader)?;
+        Ok(())
     }
 
     /// Writes the attributes as a serialized string to the writer.

--- a/rbx_types/src/attributes/reader.rs
+++ b/rbx_types/src/attributes/reader.rs
@@ -1,25 +1,21 @@
-use std::{
-    collections::BTreeMap,
-    io::{self, Read},
-};
+use std::io::{self, Read};
 
 use crate::{
-    BinaryString, BrickColor, CFrame, Color3, ColorSequence, ColorSequenceKeypoint, EnumItem, Font,
-    FontStyle, FontWeight, Matrix3, NumberRange, NumberSequence, NumberSequenceKeypoint, Rect,
-    UDim, UDim2, Variant, VariantType, Vector2, Vector3,
+    Attributes, BinaryString, BrickColor, CFrame, Color3, ColorSequence, ColorSequenceKeypoint,
+    EnumItem, Font, FontStyle, FontWeight, Matrix3, NumberRange, NumberSequence,
+    NumberSequenceKeypoint, Rect, UDim, UDim2, VariantType, Vector2, Vector3,
 };
 
 use super::{type_id, AttributeError};
 
 /// Reads through an attribute property (AttributesSerialize) and returns a map of attribute names -> values.
-pub(crate) fn read_attributes<R: Read>(
+pub(crate) fn extend_attributes_from_reader<R: Read>(
+    attributes: &mut Attributes,
     mut value: R,
-) -> Result<BTreeMap<String, Variant>, AttributeError> {
-    let mut attributes = BTreeMap::new();
-
+) -> Result<(), AttributeError> {
     let len = match read_option_u32(&mut value) {
         Ok(Some(len)) => len,
-        Ok(None) => return Ok(attributes),
+        Ok(None) => return Ok(()),
         Err(_) => return Err(AttributeError::InvalidLength),
     };
 
@@ -219,7 +215,7 @@ pub(crate) fn read_attributes<R: Read>(
         attributes.insert(key, value);
     }
 
-    Ok(attributes)
+    Ok(())
 }
 
 fn read_u8<R: Read>(mut reader: R) -> io::Result<u8> {


### PR DESCRIPTION
Useful for migrating InstanceHandle / Ref attributes into the existing Attributes data structure.