### PR TITLE
Write zero length for empty PropertiesSerialize values 

### DIFF
--- a/rbx_binary/CHANGELOG.md
+++ b/rbx_binary/CHANGELOG.md
@@ -1,6 +1,9 @@
 # rbx_binary Changelog
 
 ## Unreleased
+* Changed serializer to always write a length for empty `PropertiesSerialize` values, which Roblox requires. ([#639])
+
+[#639]: https://github.com/rojo-rbx/rbx-dom/issues/639
 
 # 3.0.0 (2026-07-01)
 * Upgraded to `rbx_reflection` v3.0.0

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -974,6 +974,10 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
 
                 Ok(())
             }
+            // TODO: Remove serialized_name. It's only used for special casing
+            // PropertiesSerialize so to write the 0 length when they're
+            // empty.
+            #[allow(clippy::too_many_arguments)]
             fn write_prop_values<'a, I, TypeMismatch, InvalidValue>(
                 chunk: &mut ChunkBuilder,
                 id_to_referent: &HashMap<Ref, i32>,

--- a/rbx_binary/src/serializer/state.rs
+++ b/rbx_binary/src/serializer/state.rs
@@ -954,6 +954,7 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                         id_to_referent,
                         shared_string_ids,
                         prop_info.prop_type,
+                        prop_info.serialized_name.as_str(),
                         migrated_values.iter().map(Cow::as_ref).enumerate(),
                         type_mismatch,
                         invalid_value,
@@ -964,6 +965,7 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                         id_to_referent,
                         shared_string_ids,
                         prop_info.prop_type,
+                        prop_info.serialized_name.as_str(),
                         prop_info.values.iter().copied().enumerate(),
                         type_mismatch,
                         invalid_value,
@@ -977,6 +979,7 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                 id_to_referent: &HashMap<Ref, i32>,
                 shared_string_ids: &HashMap<SharedString, u32>,
                 prop_type: Type,
+                serialized_name: &str,
                 values: I,
                 type_mismatch: TypeMismatch,
                 invalid_value: InvalidValue,
@@ -1009,6 +1012,15 @@ impl<'dom, 'db: 'dom, W: Write> SerializerState<'dom, 'db, W> {
                                     value
                                         .to_writer(&mut buf)
                                         .map_err(|_| invalid_value(i, rbx_value))?;
+
+                                    // Roblox requires PropertiesSerialize to
+                                    // write its length even when there are no
+                                    // attributes. An empty attributes value
+                                    // serializes to nothing, so we write a 0
+                                    // count in its place.
+                                    if buf.is_empty() && serialized_name == "PropertiesSerialize" {
+                                        buf.extend_from_slice(&0u32.to_le_bytes());
+                                    }
 
                                     chunk.write_binary_string(&buf)?;
                                 }

--- a/rbx_binary/src/tests/serializer.rs
+++ b/rbx_binary/src/tests/serializer.rs
@@ -1,7 +1,7 @@
 use rbx_dom_weak::{
     types::{
-        BrickColor, CFrame, Color3, Color3uint8, Enum, Font, Ref, Region3, SharedString, UDim,
-        Variant, Vector3,
+        Attributes, BrickColor, CFrame, Color3, Color3uint8, Enum, Font, Ref, Region3,
+        SharedString, UDim, Variant, Vector3,
     },
     InstanceBuilder, WeakDom,
 };
@@ -283,6 +283,23 @@ fn default_shared_string() {
     let _ = to_writer(&mut buf, &tree, &[ref_1, ref_2]);
 
     let decoded = DecodedModel::from_reader(buf.as_slice());
+    insta::assert_yaml_snapshot!(decoded);
+}
+
+/// Roblox requires that an empty `PropertiesSerialize` (StyleRule.Properties)
+/// still writes its attribute count. An empty Attributes value normally
+/// serializes to nothing, so the serializer must write a `0` count in its
+/// place. See https://github.com/rojo-rbx/rbx-dom/issues/639.
+#[test]
+fn empty_properties_serialize() {
+    let tree = WeakDom::new(
+        InstanceBuilder::new("StyleRule").with_property("Properties", Attributes::new()),
+    );
+
+    let mut buffer = Vec::new();
+    to_writer(&mut buffer, &tree, &[tree.root_ref()]).expect("failed to encode model");
+
+    let decoded = DecodedModel::from_reader(buffer.as_slice());
     insta::assert_yaml_snapshot!(decoded);
 }
 

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__empty_properties_serialize.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__serializer__empty_properties_serialize.snap
@@ -1,0 +1,31 @@
+---
+source: rbx_binary/src/tests/serializer.rs
+expression: decoded
+---
+num_types: 1
+num_instances: 1
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: StyleRule
+      object_format: 0
+      referents:
+        - 0
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - StyleRule
+  - Prop:
+      type_id: 0
+      prop_name: PropertiesSerialize
+      prop_type: String
+      values:
+        - "\u0000\u0000\u0000\u0000"
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+  - End

--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* Changed serializer to always write a length for empty `PropertiesSerialize` values, which Roblox requires. ([#639])
+
+[#639]: https://github.com/rojo-rbx/rbx-dom/issues/639
 
 # 3.0.0 (2026-07-01)
 * Upgraded to `rbx_reflection` v3.0.0

--- a/rbx_xml/src/tests/basic.rs
+++ b/rbx_xml/src/tests/basic.rs
@@ -74,6 +74,23 @@ fn write_empty_tags() {
     insta::assert_snapshot!(std::str::from_utf8(&encoded).unwrap());
 }
 
+/// Roblox requires that an empty `PropertiesSerialize` (StyleRule.Properties)
+/// still writes its attribute count. An empty Attributes value normally
+/// serializes to nothing, so the serializer must write a `0` count (base64
+/// `AAAAAA==`) in its place. See https://github.com/rojo-rbx/rbx-dom/issues/639.
+#[test]
+fn write_empty_properties_serialize() {
+    let _ = env_logger::try_init();
+
+    let style_rule =
+        InstanceBuilder::new("StyleRule").with_property("Properties", Attributes::new());
+    let dom = WeakDom::new(style_rule);
+
+    let mut encoded = Vec::new();
+    crate::to_writer_default(&mut encoded, &dom, &[dom.root_ref()]).unwrap();
+    insta::assert_snapshot!(std::str::from_utf8(&encoded).unwrap());
+}
+
 #[test]
 fn write_tags() {
     let _ = env_logger::try_init();

--- a/rbx_xml/src/tests/snapshots/rbx_xml__tests__basic__write_empty_properties_serialize.snap
+++ b/rbx_xml/src/tests/snapshots/rbx_xml__tests__basic__write_empty_properties_serialize.snap
@@ -1,0 +1,12 @@
+---
+source: rbx_xml/src/tests/basic.rs
+expression: "std::str::from_utf8(&encoded).unwrap()"
+---
+<roblox version="4">
+  <Item class="StyleRule" referent="0">
+    <Properties>
+      <string name="Name">StyleRule</string>
+      <BinaryString name="PropertiesSerialize">AAAAAA==</BinaryString>
+    </Properties>
+  </Item>
+</roblox>

--- a/rbx_xml/src/types/attributes.rs
+++ b/rbx_xml/src/types/attributes.rs
@@ -20,6 +20,13 @@ pub fn write_attributes<W: Write>(
         return Err(writer.error(write_error));
     }
 
+    // Roblox requires PropertiesSerialize to write its length even when there
+    // are no attributes. An empty attributes value serializes to nothing, so we
+    // write a 0 count in its place.
+    if buffer.is_empty() && property_name == "PropertiesSerialize" {
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+    }
+
     writer.write(XmlWriteEvent::start_element(XML_TAG_NAME).attr("name", property_name))?;
     writer.write_string(&base64::encode(&buffer))?;
     writer.write(XmlWriteEvent::end_element())?;


### PR DESCRIPTION
This PR closes #639 by special casing on the `PropertiesSerialize` property name in the rbx_binary and rbx_xml serializers, writing a zero length if this property's `Attributes` value is empty. 

This is scoped only to `PropertiesSerialize` to avoid churning existing `Attributes` values. This does turn out somewhat ugly for rbx_binary, but it's the shortest path to getting this fixed. These two property types are so similar, and the only difference seems to be how they serialize when empty. We should consider a refactored solution when we go back to touch attributes again, e.g. #646.  



