### PR TITLE
rbx-util: drop serde_yaml, use yaml_serde

### DIFF
--- a/rbx_util/Cargo.toml
+++ b/rbx_util/Cargo.toml
@@ -27,7 +27,7 @@ name = "rbx-util"
 rbx_binary = { path = "../rbx_binary", features = ["unstable_text_format"] }
 rbx_xml = { path = "../rbx_xml" }
 
-serde_yaml = "0.8.24"
+yaml_serde = "0.10.4"
 clap = { version = "4.6.1", features = ["derive"] }
 
 fs-err = "3.3.0"

--- a/rbx_util/src/view_binary.rs
+++ b/rbx_util/src/view_binary.rs
@@ -30,7 +30,7 @@ impl ViewBinaryCommand {
         log::debug!("Writing to stdout");
         let stdout = io::stdout();
         let output = BufWriter::new(stdout.lock());
-        serde_yaml::to_writer(output, &model)?;
+        yaml_serde::to_writer(output, &model)?;
 
         Ok(())
     }


### PR DESCRIPTION
Drop the deprecated serde_yaml from the dependency tree once and for all. Somewhat of a follow-up to #617.
